### PR TITLE
refactor: decompose ApiServiceProvider into registrar collaborators

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,1 +1,0 @@
-/Users/ben/Projects/sinemacula/Repositories/laravel-api-toolkit/.qlty/sources/https---github-com-sinemacula-coding-standards/v1.1.3/editorconfig/.editorconfig-checker.json

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,38 +2,94 @@
 
 ## From 1.x to 2.x
 
-### Removed: Mutable service configuration methods
+### Composer dependency changes
 
-The following methods have been removed from the `Service` base class:
+The CloudWatch logging dependencies (`aws/aws-sdk-php` and `phpnexus/cwh`) have moved from `require` to
+`suggest`. Applications that use the CloudWatch logging driver must now require them directly:
+
+    composer require aws/aws-sdk-php phpnexus/cwh
+
+Applications that do not use CloudWatch logging require no action.
+
+The toolkit now depends on `sinemacula/http-primitives-php`, which is installed automatically and replaces
+the internal `HttpStatus` enum (see the next section).
+
+### Removed: HttpStatus enum
+
+The internal `SineMacula\ApiToolkit\Enums\HttpStatus` enum has been removed in favour of the shared
+`SineMacula\Http\Enums\HttpStatus` enum provided by `sinemacula/http-primitives-php`.
+
+**Before (1.x):**
+
+    use SineMacula\ApiToolkit\Enums\HttpStatus;
+
+    $code = HttpStatus::NOT_FOUND->getCode();
+
+**After (2.x):**
+
+    use SineMacula\Http\Enums\HttpStatus;
+
+    $code = HttpStatus::NOT_FOUND->getCode();
+
+Custom exceptions extending `ApiException` must type their `HTTP_STATUS` constant with the new enum:
+
+    use SineMacula\Http\Enums\HttpStatus;
+
+    class TeapotException extends ApiException
+    {
+        public const HttpStatus HTTP_STATUS = HttpStatus::IM_A_TEAPOT;
+    }
+
+The shared enum only defines standard HTTP status codes. The non-standard `419` code has no case, so
+`HttpStatus::TOKEN_MISMATCH` no longer exists -- `TokenMismatchException` now overrides `getStatusCode()`
+to return `419` directly. Custom exceptions that need a non-standard status code should override
+`getStatusCode()` in the same way.
+
+### Services: composable concern pipeline replaces transaction and lock configuration
+
+The following have been removed from the `Service` base class:
 
 - `useTransaction()`
 - `dontUseTransaction()`
 - `useLock()`
 - `dontUseLock()`
+- the `$useTransaction` and `$useLock` properties
+
+Transactions and locking are now cross-cutting concerns declared per service via the `concerns()` method.
+Each concern wraps the core lifecycle (`prepare()`, `handle()`, `success()`/`failed()`); the first concern
+in the array is the outermost wrapper.
 
 **Before (1.x):**
 
-Callers configured service behavior at runtime using fluent methods:
+Callers configured service behavior at runtime using fluent methods or property overrides:
 
     $service = new MyService($payload);
     $service->dontUseTransaction();
     $service->useLock();
     $service->run();
 
+    class MyService extends Service
+    {
+        protected bool $useTransaction = false;
+
+        protected bool $useLock = true;
+    }
+
 **After (2.x):**
 
-Configuration is declared at the class level via method overrides:
+Configuration is declared at the class level via the `concerns()` method:
+
+    use SineMacula\ApiToolkit\Services\Concerns\LockConcern;
+    use SineMacula\ApiToolkit\Services\Concerns\TransactionConcern;
 
     class MyService extends Service
     {
-        protected function shouldUseTransaction(): bool
+        protected function concerns(): array
         {
-            return false;
-        }
-
-        protected function shouldUseLock(): bool
-        {
-            return true;
+            return [
+                LockConcern::class,
+                TransactionConcern::class,
+            ];
         }
 
         protected function handle(): bool
@@ -52,118 +108,27 @@ The caller no longer needs to configure the service externally:
     $service = new MyService($payload);
     $service->run();
 
-### Immutable configuration properties
+**The default behavior has changed.** In 1.x every service ran inside a database transaction by default
+(`$useTransaction = true`). In 2.x the base `concerns()` returns an empty array, so a service with no
+override runs with no transaction and no locking. Services that relied on the implicit transaction must now
+declare `TransactionConcern::class` explicitly.
 
-The `$useTransaction` and `$useLock` properties on the `Service`
-base class are now `protected readonly bool`. They are initialized
-during construction via the `shouldUseTransaction()` and
-`shouldUseLock()` methods. This prevents any post-construction
-mutation of service configuration.
+Custom concerns implement the `ServiceConcern` contract and are resolved from the container, so they may
+declare their own constructor dependencies:
 
-Subclasses that previously redeclared these properties with
-different default values must now override the corresponding
-method instead. Code that attempts to reassign these properties
-after construction will produce a PHP error.
+    use SineMacula\ApiToolkit\Services\Contracts\ServiceConcern;
+    use SineMacula\ApiToolkit\Services\Service;
 
-**Before (property override -- this no longer works):**
-
-    class MyService extends Service
+    class RetryConcern implements ServiceConcern
     {
-        protected bool $useTransaction = false;
-
-        protected function handle(): bool
+        public function execute(Service $service, \Closure $next): bool
         {
-            // ...
+            return retry(3, $next);
         }
     }
 
-**After (method override):**
-
-    class MyService extends Service
-    {
-        protected function shouldUseTransaction(): bool
-        {
-            return false;
-        }
-
-        protected function handle(): bool
-        {
-            // ...
-        }
-    }
-
-### Lock key generation via LockKeyProvider contract
-
-The `Lockable` trait no longer declares
-`abstract generateLockKey()`. The `Service` class now implements
-`LockKeyProvider` with a `getLockKey()` method that contains the
-same logic.
-
-**Impact on Service subclasses:** Subclasses that previously
-overrode `generateLockKey()` must now override `getLockKey()`
-instead. The method visibility changes from `protected` to
-`public`.
-
-**Before:**
-
-    class MyService extends Service
-    {
-        protected function generateLockKey(): string
-        {
-            return sha1('custom-key');
-        }
-    }
-
-**After:**
-
-    class MyService extends Service
-    {
-        public function getLockKey(): string
-        {
-            return sha1('custom-key');
-        }
-    }
-
-**Impact on standalone Lockable consumers:** Classes using
-`Lockable` without extending `Service` should implement
-`LockKeyProvider` and provide a `getLockKey()` method instead of
-overriding `generateLockKey()`.
-
-**Before:**
-
-    class MyJob
-    {
-        use Lockable;
-
-        protected function generateLockKey(): string
-        {
-            return sha1('job-lock');
-        }
-    }
-
-**After:**
-
-    use SineMacula\ApiToolkit\Contracts\LockKeyProvider;
-
-    class MyJob implements LockKeyProvider
-    {
-        use Lockable;
-
-        public function getLockKey(): string
-        {
-            return sha1('job-lock');
-        }
-    }
-
-### Removed: ServiceLockException
-
-The `ServiceLockException` class has been removed. It was never
-thrown by the framework -- lock acquisition failures use
-`TooManyRequestsException`.
-
-Any code that catches `ServiceLockException` should be updated
-to catch `TooManyRequestsException` instead (or removed if the
-catch block was unreachable).
+`LockConcern` only takes effect on services whose class uses the `Lockable` trait; the base `Service`
+already uses it, so declaring the concern is sufficient.
 
 ### Changed: Service::run() returns a ServiceResult value object
 
@@ -206,9 +171,259 @@ rethrow explicitly if desired:
         throw $result->exception;
     }
 
-### Default behavior
+### Removed: Implicit trait lifecycle hooks on services
 
-A service subclass with no method overrides behaves identically to the previous default:
+In 1.x, traits used by a service participated in the lifecycle through naming conventions: a static
+`initialize{TraitName}()` method was invoked during service initialization, and a `{traitName}Success()`
+method was invoked after a successful run. This implicit discovery has been removed.
 
-- **Transactions:** enabled (`shouldUseTransaction()` returns `true`)
-- **Locking:** disabled (`shouldUseLock()` returns `false`)
+Move initialization logic into the constructor or `prepare()`, move post-success side effects into
+`success()`, or express the behavior as a `ServiceConcern` (see above).
+
+### Lock key generation via LockKeyProvider contract
+
+The `Lockable` trait no longer declares
+`abstract generateLockKey()`. The `Service` class now implements
+`LockKeyProvider` with a `getLockKey()` method that contains the
+same logic.
+
+**Impact on Service subclasses:** Subclasses that previously
+overrode `generateLockKey()` must now override `getLockKey()`
+instead. The method visibility changes from `protected` to
+`public`.
+
+**Before:**
+
+    class MyService extends Service
+    {
+        protected function generateLockKey(): string
+        {
+            return sha1('custom-key');
+        }
+    }
+
+**After:**
+
+    class MyService extends Service
+    {
+        public function getLockKey(): string
+        {
+            return sha1('custom-key');
+        }
+    }
+
+**Impact on standalone Lockable consumers:** Classes using
+`Lockable` without extending `Service` should implement
+`LockKeyProvider` and provide a `getLockKey()` method instead of
+overriding `generateLockKey()`. Alternatively, the `$lockKey`
+property may be set directly. The trait's `lock()` and `unlock()`
+methods are now `public` (previously `protected`).
+
+**Before:**
+
+    class MyJob
+    {
+        use Lockable;
+
+        protected function generateLockKey(): string
+        {
+            return sha1('job-lock');
+        }
+    }
+
+**After:**
+
+    use SineMacula\ApiToolkit\Contracts\LockKeyProvider;
+
+    class MyJob implements LockKeyProvider
+    {
+        use Lockable;
+
+        public function getLockKey(): string
+        {
+            return sha1('job-lock');
+        }
+    }
+
+### Removed: ServiceLockException
+
+The `ServiceLockException` class has been removed. It was never
+thrown by the framework -- lock acquisition failures use
+`TooManyRequestsException`.
+
+Any code that catches `ServiceLockException` should be updated
+to catch `TooManyRequestsException` instead (or removed if the
+catch block was unreachable).
+
+### Removed: RepositoryResolver and HasRepositories
+
+The static `RepositoryResolver`, the `HasRepositories` trait, and the `repositories.repository_map` config
+key have been removed. Repositories are now resolved through standard Laravel dependency injection.
+
+**Before (1.x):**
+
+    use SineMacula\ApiToolkit\Repositories\Traits\HasRepositories;
+
+    class UserController extends Controller
+    {
+        use HasRepositories;
+
+        public function index()
+        {
+            return $this->users()->all();
+        }
+    }
+
+**After (2.x):**
+
+    class UserController extends Controller
+    {
+        public function __construct(
+
+            private readonly UserRepository $users,
+
+        ) {}
+
+        public function index()
+        {
+            return $this->users->all();
+        }
+    }
+
+Direct calls to `RepositoryResolver::get('alias')` should be replaced with `app(UserRepository::class)` or,
+preferably, constructor injection. Remove any `repository_map` entries from a published
+`config/api-toolkit.php`; the key is no longer read.
+
+### Renamed: ApiRepository::setAttributes() to persist()
+
+The `setAttributes()` method on `ApiRepository` has been renamed to `persist()`. The signature and behavior
+are unchanged.
+
+**Before:**
+
+    $repository->setAttributes($model, $attributes);
+
+**After:**
+
+    $repository->persist($model, $attributes);
+
+### Changed: Relation detection requires return type declarations
+
+Relation detection -- used by filtering, attribute persistence, resource value resolution, and schema
+validation -- no longer
+invokes model methods to discover whether they return a `Relation`. The `SchemaIntrospector` now inspects
+declared return types via reflection. A model method is treated as a relation only when its return type (or
+one member of a union type) is a subclass of `Illuminate\Database\Eloquent\Relations\Relation`.
+
+**Before (1.x -- detected without a return type):**
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+
+**After (2.x -- return type required):**
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+
+Relation methods without a `Relation` return type are silently no longer detected -- filters and eager loads
+referencing them stop working -- so audit your models before upgrading. Enabling the new opt-in boot-time
+schema validation (`api-toolkit.resources.validate_schemas`, or the `api:validate-schemas` command) surfaces
+schema relations that no longer resolve.
+
+Dynamic relations registered with `Model::resolveRelationUsing()` are now detected and resolved; 1.x did not
+support them.
+
+### Removed: BaseResource; ApiResource internals decomposed
+
+`SineMacula\ApiToolkit\Http\Resources\BaseResource` has been removed. `ApiResource` now extends
+`Illuminate\Http\Resources\Json\JsonResource` directly, and `withFields()`, `withoutFields()`, and
+`withAll()` live on `ApiResource` itself. Update any type hints or subclasses referencing `BaseResource` to
+use `ApiResource` (or `ApiResourceInterface`).
+
+The protected resolution hooks have been removed from `ApiResource` and moved into internal collaborator
+classes:
+
+- `getFields()`
+- `resolveFieldValue()`
+- `resolveSimpleProperty()`
+- `resolveComputedValue()`
+- `resolveAccessorValue()`
+- `resolveRelationValue()`
+- `passesGuards()`
+- `resolveCountsPayload()`
+
+Subclasses that overrode these methods must express the behavior through the resource schema definition
+(fields, computed values, accessors, guards) instead.
+
+`ApiResourceInterface` now declares the full field-resolution surface (`schema()`, `getAllFields()`,
+`resolveFields()`, `eagerLoadMapFor()`, `eagerLoadCountsFor()`, `resolve()`, `withFields()`,
+`withoutFields()`, and `withAll()`). Classes implementing the interface directly -- rather than extending
+`ApiResource` -- must implement the new methods.
+
+Parameter names have also been normalized to camelCase (`$load_missing` is now `$loadMissing` on the
+constructor, `$requested_aliases` is now `$requestedAliases` on `eagerLoadCountsFor()`); update any
+named-argument call sites.
+
+### Changed: ApiCriteria decomposed; filter operators are extensible
+
+The protected `applyFilters()`, `applyEagerLoading()`, `applyLimit()`, and `applyOrder()` hooks have been
+removed from `ApiCriteria`; the logic now lives in dedicated internal concern classes. Subclasses that
+overrode these hooks to add custom filter behavior should instead register a custom operator.
+
+Filter operators are now first-class: implement the `SineMacula\ApiToolkit\Contracts\FilterOperator`
+contract and register it on the `OperatorRegistry` singleton (for example, in a service provider):
+
+    use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+
+    app(OperatorRegistry::class)->register('$regex', new RegexOperator);
+
+The registry also exposes `override()` and `remove()` for adjusting the built-in operator set.
+
+### Deprecated: Request macros in favour of RequestCapabilities
+
+The request macros registered by the toolkit -- `includeTrashed()`, `onlyTrashed()`, `expectsExport()`,
+`expectsCsv()`, `expectsXml()`, `expectsPdf()`, and `expectsStream()` -- are deprecated. They continue to
+work in 2.x but emit deprecation notices and will be removed in a future release. Use the typed
+`RequestCapabilities` value object instead.
+
+**Before:**
+
+    if ($request->expectsCsv()) {
+        // ...
+    }
+
+**After:**
+
+    use SineMacula\ApiToolkit\Http\RequestCapabilities;
+
+    $capabilities = RequestCapabilities::fromRequest($request);
+
+    if ($capabilities->expectsCsv()) {
+        // ...
+    }
+
+The new `DetectsCapabilities` middleware (registered globally by default, configurable via the
+`api-toolkit.middleware` config section) precomputes the capabilities once per request; `fromRequest()`
+falls back to resolving them lazily when the middleware has not run.
+
+### Exception handling changes
+
+These changes are largely additive but include behavioral fixes worth noting:
+
+- New exception classes are available: `ConflictException` (409), `GoneException` (410),
+  `PayloadTooLargeException` (413), `LockedException` (423), `ServiceUnavailableException` (503), and a
+  generic `HttpException` carrying an arbitrary `HttpStatus`.
+- Unmapped HTTP-layer exceptions (any Symfony `HttpExceptionInterface`) now preserve their original status
+  code via the generic `HttpException` instead of rendering as a `500` unhandled error.
+- Session token mismatches converted by Laravel to a generic `419` HTTP exception are now mapped back to
+  `TokenMismatchException` and render as `419`; in 1.x they rendered as a `500` unhandled error.
+- `PolymorphicResource` now throws `ResourceMappingException` (a `\LogicException` subclass) instead of a
+  bare `\LogicException`; existing catch blocks for `\LogicException` continue to work.
+- The new `api-toolkit.exceptions` config section controls rendering (`render_strategy`) and debug metadata
+  (`include_debug_info`). The defaults preserve the 1.x behavior.
+- `ApiException` exposes a new instance-level `getStatusCode()` method, which the handler now uses when
+  rendering; the static `getHttpStatusCode()` remains available.

--- a/src/ApiQueryParser.php
+++ b/src/ApiQueryParser.php
@@ -3,13 +3,15 @@
 namespace SineMacula\ApiToolkit;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\ValidationException;
+use SineMacula\ApiToolkit\Concerns\QueryParameterExtractor;
+use SineMacula\ApiToolkit\Concerns\QueryParameterValidator;
 
 /**
  * API query parser.
  *
- * Extract API parameters supplied within the query string of a request.
+ * Thin orchestrator that validates and extracts API parameters supplied
+ * within the query string of a request, delegating to single-responsibility
+ * concern classes and exposing typed access to the parsed parameters.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -18,6 +20,23 @@ class ApiQueryParser
 {
     /** @var array<string, mixed> */
     protected array $parameters = [];
+
+    /** @var \SineMacula\ApiToolkit\Concerns\QueryParameterValidator */
+    private readonly QueryParameterValidator $validator;
+
+    /** @var \SineMacula\ApiToolkit\Concerns\QueryParameterExtractor */
+    private readonly QueryParameterExtractor $extractor;
+
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->validator = new QueryParameterValidator;
+        $this->extractor = new QueryParameterExtractor;
+    }
 
     /**
      * Returns a list of fields set with the URL modifiers.
@@ -164,40 +183,9 @@ class ApiQueryParser
      */
     public function parse(Request $request): void
     {
-        $this->validate($request->all());
+        $this->validator->validate($request->all());
 
-        $this->parameters = $this->extractParameters($request);
-    }
-
-    /**
-     * Extract and parse all parameters from the request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return array<string, mixed>
-     */
-    private function extractParameters(Request $request): array
-    {
-        $parameters = [];
-
-        $parsers = [
-            'page'     => fn ($value) => trim($value),
-            'limit'    => fn ($value) => trim($value),
-            'cursor'   => fn ($value) => $value,
-            'fields'   => fn ($value) => $this->parseFields($value),
-            'counts'   => fn ($value) => $this->parseCounts($value),
-            'sums'     => fn ($value) => $this->parseSums($value),
-            'averages' => fn ($value) => $this->parseAverages($value),
-            'filters'  => fn ($value) => $this->parseFilters($value),
-            'order'    => fn ($value) => $this->parseOrder($value),
-        ];
-
-        foreach ($parsers as $key => $parser) {
-            if ($request->has($key)) {
-                $parameters[$key] = $parser($request->input($key));
-            }
-        }
-
-        return $parameters;
+        $this->parameters = $this->extractor->extract($request);
     }
 
     /**
@@ -214,243 +202,5 @@ class ApiQueryParser
         }
 
         return $this->parameters[$option] ?? null;
-    }
-
-    /**
-     * Validate the incoming request.
-     *
-     * @param  array<string, mixed>  $parameters
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    private function validate(array $parameters): void
-    {
-        $validator = Validator::make($parameters, $this->buildValidationRulesFromParameters($parameters));
-
-        if ($validator->fails()) {
-            throw new ValidationException($validator);
-        }
-    }
-
-    /**
-     * Extract the field parameters from the query string.
-     *
-     * @param  array<string, string>|string  $query
-     * @return array<int, string>|array<string, array<int, string>>
-     */
-    private function parseFields(array|string $query): array
-    {
-        return $this->parseCommaSeparatedValues($query);
-    }
-
-    /**
-     * Extract the count parameters from the query string.
-     *
-     * @param  array<string, string>|string  $query
-     * @return array<int, string>|array<string, array<int, string>>
-     */
-    private function parseCounts(array|string $query): array
-    {
-        return $this->parseCommaSeparatedValues($query);
-    }
-
-    /**
-     * Parse comma-separated values from query parameters.
-     *
-     * @param  array<string, string>|string  $query
-     * @return array<int, string>|array<string, array<int, string>>
-     */
-    private function parseCommaSeparatedValues(array|string $query): array
-    {
-        if (!is_array($query)) {
-            return $this->splitAndTrim($query);
-        }
-
-        return array_map(fn ($value) => $this->splitAndTrim($value), $query);
-    }
-
-    /**
-     * Split a string by comma and trim each value.
-     *
-     * @param  string  $value
-     * @return array<int, string>
-     */
-    private function splitAndTrim(string $value): array
-    {
-        return array_map('trim', explode(',', $value));
-    }
-
-    /**
-     * Extract the sum parameters from the query string.
-     *
-     * @param  array<string, mixed>  $query
-     * @return array<string, mixed>
-     */
-    private function parseSums(array $query): array
-    {
-        return $this->parseAggregations($query);
-    }
-
-    /**
-     * Extract the average parameters from the query string.
-     *
-     * @param  array<string, mixed>  $query
-     * @return array<string, mixed>
-     */
-    private function parseAverages(array $query): array
-    {
-        return $this->parseAggregations($query);
-    }
-
-    /**
-     * Parse aggregation parameters (sums, averages) from the query string.
-     *
-     * @param  array<string, mixed>  $query
-     * @return array<string, mixed>
-     */
-    private function parseAggregations(array $query): array
-    {
-        $aggregations = [];
-
-        foreach ($query as $resource => $relations) {
-            if (!is_array($relations)) {
-                continue;
-            }
-
-            $aggregations[$resource] = $this->parseRelationFields($relations);
-        }
-
-        return $aggregations;
-    }
-
-    /**
-     * Parse relation fields for aggregations.
-     *
-     * @param  array<mixed>  $relations
-     * @return array<array<mixed>>
-     */
-    private function parseRelationFields(array $relations): array
-    {
-        return array_map(fn ($fields) => $this->normalizeFields($fields), $relations);
-    }
-
-    /**
-     * Normalize field values into an array format.
-     *
-     * @param  mixed  $fields
-     * @return array<mixed>
-     */
-    private function normalizeFields(mixed $fields): array
-    {
-        if (is_string($fields)) {
-            return $this->splitAndTrim($fields);
-        }
-
-        if (is_array($fields)) {
-            return $fields;
-        }
-
-        return [$fields];
-    }
-
-    /**
-     * Extract the filter parameters from the query string.
-     *
-     * @param  string  $query
-     * @return array<string, mixed>
-     */
-    private function parseFilters(string $query): array
-    {
-        /** @var array<string, mixed>|null $filters */
-        $filters = json_decode($query, true);
-
-        return $filters ?? [];
-    }
-
-    /**
-     * Extract the order parameters from the query string.
-     *
-     * @param  string  $query
-     * @return array<string, string>
-     */
-    private function parseOrder(string $query): array
-    {
-        $order  = [];
-        $fields = explode(',', $query);
-
-        if (!empty(array_filter($fields, static fn (string $value): bool => (bool) $value))) {
-            foreach ($fields as $field) {
-                $order_parts    = explode(':', $field, 2);
-                $column         = $order_parts[0];
-                $direction      = $order_parts[1] ?? 'asc';
-                $order[$column] = $direction;
-            }
-        }
-
-        return $order;
-    }
-
-    /**
-     * Build the validation rules from the given parameters.
-     *
-     * @param  array<string, mixed>  $parameters
-     * @return array<string, string>
-     */
-    private function buildValidationRulesFromParameters(array $parameters): array
-    {
-        $rules = $this->getBaseValidationRules();
-
-        $this->applyArrayValidationRules($rules, $parameters, 'fields', ['fields.*' => 'string']);
-        $this->applyArrayValidationRules($rules, $parameters, 'counts', ['counts.*' => 'string']);
-        $this->applyArrayValidationRules($rules, $parameters, 'sums', [
-            'sums.*'   => 'array',
-            'sums.*.*' => 'string',
-        ]);
-        $this->applyArrayValidationRules($rules, $parameters, 'averages', [
-            'averages.*'   => 'array',
-            'averages.*.*' => 'string',
-        ]);
-
-        return $rules;
-    }
-
-    /**
-     * Get the base validation rules for all parameters.
-     *
-     * @return array<string, string>
-     */
-    private function getBaseValidationRules(): array
-    {
-        return [
-            'fields'  => 'string',
-            'filters' => 'json',
-            'order'   => 'string',
-            'page'    => 'integer|min:1',
-            'limit'   => 'integer|min:1',
-            'cursor'  => 'string',
-        ];
-    }
-
-    /**
-     * Apply validation rules for array parameters.
-     *
-     * @param  array<string, string>  $rules
-     * @param  array<string, mixed>  $parameters
-     * @param  string  $key
-     * @param  array<string, string>  $array_rules
-     * @return void
-     */
-    private function applyArrayValidationRules(array &$rules, array $parameters, string $key, array $array_rules): void
-    {
-        if (!isset($parameters[$key]) || !is_array($parameters[$key])) {
-            return;
-        }
-
-        $rules[$key] = 'array';
-
-        foreach ($array_rules as $rule_key => $rule_value) {
-            $rules[$rule_key] = $rule_value;
-        }
     }
 }

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -89,6 +89,7 @@ class ApiServiceProvider extends ServiceProvider
      *
      * @return void
      */
+    #[\Override]
     public function register(): void
     {
         $this->mergeConfigFrom(

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -2,60 +2,24 @@
 
 namespace SineMacula\ApiToolkit;
 
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Foundation\Http\Kernel as HttpKernel;
-use Illuminate\Log\LogManager;
-use Illuminate\Notifications\Events\NotificationSending;
-use Illuminate\Notifications\Events\NotificationSent;
-use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Request;
 use Illuminate\Support\ServiceProvider;
-use SineMacula\ApiToolkit\Cache\CacheManager;
 use SineMacula\ApiToolkit\Console\ValidateSchemasCommand;
-use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
-use SineMacula\ApiToolkit\Enums\FlushStrategy;
-use SineMacula\ApiToolkit\Http\Middleware\DetectsCapabilities;
-use SineMacula\ApiToolkit\Http\Middleware\JsonPrettyPrint;
-use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
-use SineMacula\ApiToolkit\Http\Middleware\PreventRequestsDuringMaintenance;
-use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequests;
-use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequestsWithRedis;
-use SineMacula\ApiToolkit\Http\RequestCapabilities;
-use SineMacula\ApiToolkit\Listeners\NotificationListener;
-use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
-use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
-use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
-use SineMacula\ApiToolkit\Logging\CloudWatchLogger;
-use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
-use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\BetweenOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\ContainsOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\EqualOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\GreaterThanOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\GreaterThanOrEqualOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\InOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LessThanOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LessThanOrEqualOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LikeOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
-use SineMacula\ApiToolkit\Services\SchemaIntrospector;
+use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\LoggingRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\RequestMacroRegistrar;
 use SineMacula\ApiToolkit\Services\SchemaValidator;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateAccessors;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateComputedFields;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateConstraints;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateGuards;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateRelationClasses;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateRelationInterfaces;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateRelationMethods;
-use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateTransformers;
 
 /**
  * API service provider.
+ *
+ * Thin coordinator that merges the package configuration, handles publishing
+ * and schema validation, and delegates registration of macros, middleware,
+ * logging, lifecycle listeners, and container bindings to single-
+ * responsibility registrars.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -73,15 +37,11 @@ class ApiServiceProvider extends ServiceProvider
         $this->offerPublishing();
         $this->registerMorphMap();
         $this->validateSchemas();
-        $this->registerTrashedMacros();
-        $this->registerExportMacros();
-        $this->registerStreamMacros();
-        $this->registerMiddleware();
-        $this->registerCloudwatchLogger();
-        $this->registerNotificationLogging();
-        $this->registerWritePoolFlushSubscriber();
-        $this->registerOctaneFlushListener();
-        $this->registerQueueFlushSubscriber();
+
+        (new RequestMacroRegistrar)->register();
+        (new MiddlewareRegistrar($this->app))->register();
+        (new LoggingRegistrar($this->app))->register();
+        (new LifecycleRegistrar)->register();
     }
 
     /**
@@ -102,13 +62,7 @@ class ApiServiceProvider extends ServiceProvider
             'logging',
         );
 
-        $this->registerQueryParser();
-        $this->registerResourceMetadataProvider();
-        $this->registerSchemaIntrospector();
-        $this->registerOperatorRegistry();
-        $this->registerSchemaValidator();
-        $this->registerWritePool();
-        $this->registerCacheManager();
+        (new ContainerBindingRegistrar($this->app))->register();
 
         $this->commands([
             ValidateSchemasCommand::class,
@@ -184,346 +138,6 @@ class ApiServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the deprecated trashed macros to the Request facade.
-     *
-     * @return void
-     */
-    private function registerTrashedMacros(): void
-    {
-        Request::macro('includeTrashed', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::includeTrashed() is deprecated, use RequestCapabilities::fromRequest($request)->includeTrashed() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->includeTrashed();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-
-        Request::macro('onlyTrashed', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::onlyTrashed() is deprecated, use RequestCapabilities::fromRequest($request)->onlyTrashed() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->onlyTrashed();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-    }
-
-    /**
-     * Register the deprecated export macros to the Request facade.
-     *
-     * @return void
-     */
-    private function registerExportMacros(): void
-    {
-        Request::macro('expectsExport', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::expectsExport() is deprecated, use RequestCapabilities::fromRequest($request)->expectsExport() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->expectsExport();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-
-        Request::macro('expectsCsv', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::expectsCsv() is deprecated, use RequestCapabilities::fromRequest($request)->expectsCsv() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->expectsCsv();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-
-        Request::macro('expectsXml', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::expectsXml() is deprecated, use RequestCapabilities::fromRequest($request)->expectsXml() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->expectsXml();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-
-        Request::macro('expectsPdf', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::expectsPdf() is deprecated, use RequestCapabilities::fromRequest($request)->expectsPdf() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->expectsPdf();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-    }
-
-    /**
-     * Register the deprecated stream macros to the Request facade.
-     *
-     * @return void
-     */
-    private function registerStreamMacros(): void
-    {
-        Request::macro('expectsStream', \Closure::bind(function (): bool {
-
-            @trigger_error(
-                'Request::expectsStream() is deprecated, use RequestCapabilities::fromRequest($request)->expectsStream() instead.',
-                E_USER_DEPRECATED,
-            );
-
-            return RequestCapabilities::fromRequest($this)->expectsStream();
-        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
-    }
-
-    /**
-     * Register any relevant middleware.
-     *
-     * @return void
-     */
-    private function registerMiddleware(): void
-    {
-        $router = $this->app->make(Router::class);
-
-        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
-        $kernel = $this->app->make(Kernel::class);
-
-        if (Config::get('api-toolkit.parser.register_middleware', true)) {
-            $kernel->pushMiddleware(ParseApiQuery::class);
-        }
-
-        $this->registerMaintenanceModeMiddleware($kernel);
-        $this->registerDetectsCapabilitiesMiddleware($kernel);
-        $this->registerJsonPrettyPrintMiddleware($kernel);
-        $this->registerThrottleMiddleware($router);
-    }
-
-    /**
-     * Register the maintenance mode middleware swap.
-     *
-     * When enabled, the toolkit's PreventRequestsDuringMaintenance middleware
-     * is prepended to the global middleware stack. Since it extends Laravel's
-     * built-in middleware, it takes precedence without requiring removal of
-     * the original.
-     *
-     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
-     * @return void
-     */
-    private function registerMaintenanceModeMiddleware(HttpKernel $kernel): void
-    {
-        if (!Config::get('api-toolkit.middleware.maintenance_mode_swap.enabled', true)) {
-            return;
-        }
-
-        $kernel->prependMiddleware(PreventRequestsDuringMaintenance::class);
-    }
-
-    /**
-     * Register the DetectsCapabilities middleware.
-     *
-     * When scope is 'global', the middleware is pushed to the global stack.
-     * When scope is 'api', it is appended to the 'api' middleware group.
-     * Capabilities still resolve lazily on first access when the middleware
-     * is not registered; registration simply precomputes them per request.
-     *
-     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
-     * @return void
-     */
-    private function registerDetectsCapabilitiesMiddleware(HttpKernel $kernel): void
-    {
-        if (!Config::get('api-toolkit.middleware.detect_capabilities.enabled', true)) {
-            return;
-        }
-
-        $scope = Config::get('api-toolkit.middleware.detect_capabilities.scope', 'global');
-
-        if ($scope === 'api') {
-            $kernel->appendMiddlewareToGroup('api', DetectsCapabilities::class);
-
-            return;
-        }
-
-        $kernel->pushMiddleware(DetectsCapabilities::class);
-    }
-
-    /**
-     * Register the JsonPrettyPrint middleware.
-     *
-     * When scope is 'global', the middleware is pushed to the global stack.
-     * When scope is 'api', it is appended to the 'api' middleware group.
-     *
-     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
-     * @return void
-     */
-    private function registerJsonPrettyPrintMiddleware(HttpKernel $kernel): void
-    {
-        if (!Config::get('api-toolkit.middleware.json_pretty_print.enabled', true)) {
-            return;
-        }
-
-        $scope = Config::get('api-toolkit.middleware.json_pretty_print.scope', 'global');
-
-        if ($scope === 'api') {
-            $kernel->appendMiddlewareToGroup('api', JsonPrettyPrint::class);
-
-            return;
-        }
-
-        $kernel->pushMiddleware(JsonPrettyPrint::class);
-    }
-
-    /**
-     * Register the throttle middleware alias.
-     *
-     * When a custom class is provided via config, that class is used.
-     * Otherwise, the toolkit auto-detects between standard and Redis
-     * variants based on the configured cache driver.
-     *
-     * @param  \Illuminate\Routing\Router  $router
-     * @return void
-     */
-    private function registerThrottleMiddleware(Router $router): void
-    {
-        if (!Config::get('api-toolkit.middleware.throttle.enabled', true)) {
-            return;
-        }
-
-        $router->aliasMiddleware('throttle', $this->getThrottleMiddleware());
-    }
-
-    /**
-     * Return the throttle middleware that should be used.
-     *
-     * @return class-string
-     */
-    private function getThrottleMiddleware(): string
-    {
-        /** @var class-string|null $custom_class */
-        $custom_class = Config::get('api-toolkit.middleware.throttle.class');
-
-        if ($custom_class !== null) {
-            return $custom_class;
-        }
-
-        return Config::get('cache.default') !== 'redis'
-            ? ThrottleRequests::class
-            : ThrottleRequestsWithRedis::class;
-    }
-
-    /**
-     * Register the Cloudwatch logger driver.
-     *
-     * @return void
-     */
-    private function registerCloudwatchLogger(): void
-    {
-        if (!class_exists(\Aws\CloudWatchLogs\CloudWatchLogsClient::class)) {
-            return;
-        }
-
-        $this->app->make(LogManager::class)->extend('cloudwatch', fn ($app, array $config) => (new CloudWatchLogger)->__invoke($config));
-    }
-
-    /**
-     * Register the notification logging functionality.
-     *
-     * @return void
-     */
-    private function registerNotificationLogging(): void
-    {
-        if (!Config::get('api-toolkit.notifications.enable_logging', true)) {
-            return;
-        }
-
-        Event::listen(NotificationSending::class, [NotificationListener::class, 'sending']);
-        Event::listen(NotificationSent::class, [NotificationListener::class, 'sent']);
-    }
-
-    /**
-     * Bind the API query parser to the service container.
-     *
-     * @return void
-     */
-    private function registerQueryParser(): void
-    {
-        $this->app->scoped(Config::get('api-toolkit.parser.alias'), fn ($app) => new ApiQueryParser);
-    }
-
-    /**
-     * Bind the ResourceMetadataProvider to the service container.
-     *
-     * @return void
-     */
-    private function registerResourceMetadataProvider(): void
-    {
-        $this->app->singleton(
-            \SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider::class,
-            \SineMacula\ApiToolkit\Http\Resources\ResourceMetadataService::class,
-        );
-    }
-
-    /**
-     * Bind the SchemaIntrospectionProvider to the service container.
-     *
-     * @return void
-     */
-    private function registerSchemaIntrospector(): void
-    {
-        $this->app->singleton(
-            SchemaIntrospectionProvider::class,
-            SchemaIntrospector::class,
-        );
-    }
-
-    /**
-     * Bind the OperatorRegistry to the service container.
-     *
-     * @return void
-     */
-    private function registerOperatorRegistry(): void
-    {
-        $this->app->singleton(OperatorRegistry::class, function (): OperatorRegistry {
-
-            $registry = new OperatorRegistry;
-
-            $registry->register('$eq', new EqualOperator);
-            $registry->register('$neq', new NotEqualOperator);
-            $registry->register('$gt', new GreaterThanOperator);
-            $registry->register('$lt', new LessThanOperator);
-            $registry->register('$ge', new GreaterThanOrEqualOperator);
-            $registry->register('$le', new LessThanOrEqualOperator);
-            $registry->register('$like', new LikeOperator);
-            $registry->register('$in', new InOperator);
-            $registry->register('$between', new BetweenOperator);
-            $registry->register('$contains', new ContainsOperator);
-            $registry->register('$null', new NullOperator);
-            $registry->register('$notNull', new NotNullOperator);
-
-            return $registry;
-        });
-    }
-
-    /**
-     * Bind the SchemaValidator to the service container.
-     *
-     * @return void
-     */
-    private function registerSchemaValidator(): void
-    {
-        $this->app->singleton(SchemaValidator::class, fn (): SchemaValidator => new SchemaValidator(
-            new ValidateGuards,
-            new ValidateTransformers,
-            new ValidateRelationClasses,
-            new ValidateRelationInterfaces,
-            new ValidateRelationMethods,
-            new ValidateComputedFields,
-            new ValidateConstraints,
-            new ValidateAccessors,
-        ));
-    }
-
-    /**
      * Validate all registered resource schemas.
      *
      * @return void
@@ -541,79 +155,5 @@ class ApiServiceProvider extends ServiceProvider
         }
 
         $this->app->make(SchemaValidator::class)->validate($resourceMap);
-    }
-
-    /**
-     * Bind the WritePool to the service container as a scoped singleton.
-     *
-     * @return void
-     */
-    private function registerWritePool(): void
-    {
-        $this->app->scoped(WritePool::class, function (): WritePool {
-
-            $chunk_size = Config::get('api-toolkit.deferred_writes.chunk_size', 500);
-            $pool_limit = Config::get('api-toolkit.deferred_writes.pool_limit', 10000);
-            $on_failure = Config::get('api-toolkit.deferred_writes.on_failure', 'log');
-
-            return new WritePool(
-                is_numeric($chunk_size) ? (int) $chunk_size : 500,
-                is_numeric($pool_limit) ? (int) $pool_limit : 10000,
-                FlushStrategy::from(is_string($on_failure) ? $on_failure : 'log'),
-            );
-        });
-    }
-
-    /**
-     * Bind the CacheManager to the service container.
-     *
-     * @return void
-     */
-    private function registerCacheManager(): void
-    {
-        $this->app->singleton(CacheManager::class);
-    }
-
-    /**
-     * Subscribe the write pool flush subscriber to lifecycle events.
-     *
-     * @return void
-     */
-    private function registerWritePoolFlushSubscriber(): void
-    {
-        Event::subscribe(WritePoolFlushSubscriber::class);
-    }
-
-    /**
-     * Register the Octane flush listener if configured and Octane is
-     * installed.
-     *
-     * @return void
-     */
-    private function registerOctaneFlushListener(): void
-    {
-        if (!(bool) Config::get('api-toolkit.lifecycle.octane')) {
-            return;
-        }
-
-        if (!class_exists(\Laravel\Octane\Events\OperationTerminated::class)) {
-            return;
-        }
-
-        Event::listen(\Laravel\Octane\Events\OperationTerminated::class, OctaneFlushListener::class);
-    }
-
-    /**
-     * Register the queue flush subscriber if configured.
-     *
-     * @return void
-     */
-    private function registerQueueFlushSubscriber(): void
-    {
-        if (!(bool) Config::get('api-toolkit.lifecycle.queue')) {
-            return;
-        }
-
-        Event::subscribe(QueueFlushSubscriber::class);
     }
 }

--- a/src/Concerns/QueryParameterExtractor.php
+++ b/src/Concerns/QueryParameterExtractor.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Concerns;
+
+use Illuminate\Http\Request;
+
+/**
+ * Extracts and parses API query parameters from a request.
+ *
+ * Walks the supported query keys (page, limit, cursor, fields, counts, sums,
+ * averages, filters, order) and normalises each raw value into its parsed
+ * representation.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class QueryParameterExtractor
+{
+    /**
+     * Extract and parse all parameters from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function extract(Request $request): array
+    {
+        $parameters = [];
+
+        $parsers = [
+            'page'     => fn ($value) => trim($value),
+            'limit'    => fn ($value) => trim($value),
+            'cursor'   => fn ($value) => $value,
+            'fields'   => fn ($value) => $this->parseFields($value),
+            'counts'   => fn ($value) => $this->parseCounts($value),
+            'sums'     => fn ($value) => $this->parseSums($value),
+            'averages' => fn ($value) => $this->parseAverages($value),
+            'filters'  => fn ($value) => $this->parseFilters($value),
+            'order'    => fn ($value) => $this->parseOrder($value),
+        ];
+
+        foreach ($parsers as $key => $parser) {
+            if ($request->has($key)) {
+                $parameters[$key] = $parser($request->input($key));
+            }
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Extract the field parameters from the query string.
+     *
+     * @param  array<string, string>|string  $query
+     * @return array<int, string>|array<string, array<int, string>>
+     */
+    private function parseFields(array|string $query): array
+    {
+        return $this->parseCommaSeparatedValues($query);
+    }
+
+    /**
+     * Extract the count parameters from the query string.
+     *
+     * @param  array<string, string>|string  $query
+     * @return array<int, string>|array<string, array<int, string>>
+     */
+    private function parseCounts(array|string $query): array
+    {
+        return $this->parseCommaSeparatedValues($query);
+    }
+
+    /**
+     * Parse comma-separated values from query parameters.
+     *
+     * @param  array<string, string>|string  $query
+     * @return array<int, string>|array<string, array<int, string>>
+     */
+    private function parseCommaSeparatedValues(array|string $query): array
+    {
+        if (!is_array($query)) {
+            return $this->splitAndTrim($query);
+        }
+
+        return array_map(fn ($value) => $this->splitAndTrim($value), $query);
+    }
+
+    /**
+     * Split a string by comma and trim each value.
+     *
+     * @param  string  $value
+     * @return array<int, string>
+     */
+    private function splitAndTrim(string $value): array
+    {
+        return array_map('trim', explode(',', $value));
+    }
+
+    /**
+     * Extract the sum parameters from the query string.
+     *
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    private function parseSums(array $query): array
+    {
+        return $this->parseAggregations($query);
+    }
+
+    /**
+     * Extract the average parameters from the query string.
+     *
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    private function parseAverages(array $query): array
+    {
+        return $this->parseAggregations($query);
+    }
+
+    /**
+     * Parse aggregation parameters (sums, averages) from the query string.
+     *
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    private function parseAggregations(array $query): array
+    {
+        $aggregations = [];
+
+        foreach ($query as $resource => $relations) {
+            if (!is_array($relations)) {
+                continue;
+            }
+
+            $aggregations[$resource] = $this->parseRelationFields($relations);
+        }
+
+        return $aggregations;
+    }
+
+    /**
+     * Parse relation fields for aggregations.
+     *
+     * @param  array<mixed>  $relations
+     * @return array<array<mixed>>
+     */
+    private function parseRelationFields(array $relations): array
+    {
+        return array_map(fn ($fields) => $this->normalizeFields($fields), $relations);
+    }
+
+    /**
+     * Normalize field values into an array format.
+     *
+     * @param  mixed  $fields
+     * @return array<mixed>
+     */
+    private function normalizeFields(mixed $fields): array
+    {
+        if (is_string($fields)) {
+            return $this->splitAndTrim($fields);
+        }
+
+        if (is_array($fields)) {
+            return $fields;
+        }
+
+        return [$fields];
+    }
+
+    /**
+     * Extract the filter parameters from the query string.
+     *
+     * @param  string  $query
+     * @return array<string, mixed>
+     */
+    private function parseFilters(string $query): array
+    {
+        /** @var array<string, mixed>|null $filters */
+        $filters = json_decode($query, true);
+
+        return $filters ?? [];
+    }
+
+    /**
+     * Extract the order parameters from the query string.
+     *
+     * @param  string  $query
+     * @return array<string, string>
+     */
+    private function parseOrder(string $query): array
+    {
+        $order  = [];
+        $fields = explode(',', $query);
+
+        if (!empty(array_filter($fields, static fn (string $value): bool => (bool) $value))) {
+            foreach ($fields as $field) {
+                $order_parts    = explode(':', $field, 2);
+                $column         = $order_parts[0];
+                $direction      = $order_parts[1] ?? 'asc';
+                $order[$column] = $direction;
+            }
+        }
+
+        return $order;
+    }
+}

--- a/src/Concerns/QueryParameterValidator.php
+++ b/src/Concerns/QueryParameterValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Concerns;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Validates incoming API query parameters.
+ *
+ * Builds the validation rule set from the supplied parameters and rejects
+ * requests whose query modifiers do not match the expected shapes.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class QueryParameterValidator
+{
+    /**
+     * Validate the incoming request parameters.
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validate(array $parameters): void
+    {
+        $validator = Validator::make($parameters, $this->buildValidationRulesFromParameters($parameters));
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * Build the validation rules from the given parameters.
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return array<string, string>
+     */
+    private function buildValidationRulesFromParameters(array $parameters): array
+    {
+        $rules = $this->getBaseValidationRules();
+
+        $this->applyArrayValidationRules($rules, $parameters, 'fields', ['fields.*' => 'string']);
+        $this->applyArrayValidationRules($rules, $parameters, 'counts', ['counts.*' => 'string']);
+        $this->applyArrayValidationRules($rules, $parameters, 'sums', [
+            'sums.*'   => 'array',
+            'sums.*.*' => 'string',
+        ]);
+        $this->applyArrayValidationRules($rules, $parameters, 'averages', [
+            'averages.*'   => 'array',
+            'averages.*.*' => 'string',
+        ]);
+
+        return $rules;
+    }
+
+    /**
+     * Get the base validation rules for all parameters.
+     *
+     * @return array<string, string>
+     */
+    private function getBaseValidationRules(): array
+    {
+        return [
+            'fields'  => 'string',
+            'filters' => 'json',
+            'order'   => 'string',
+            'page'    => 'integer|min:1',
+            'limit'   => 'integer|min:1',
+            'cursor'  => 'string',
+        ];
+    }
+
+    /**
+     * Apply validation rules for array parameters.
+     *
+     * @param  array<string, string>  $rules
+     * @param  array<string, mixed>  $parameters
+     * @param  string  $key
+     * @param  array<string, string>  $array_rules
+     * @return void
+     */
+    private function applyArrayValidationRules(array &$rules, array $parameters, string $key, array $array_rules): void
+    {
+        if (!isset($parameters[$key]) || !is_array($parameters[$key])) {
+            return;
+        }
+
+        $rules[$key] = 'array';
+
+        foreach ($array_rules as $rule_key => $rule_value) {
+            $rules[$rule_key] = $rule_value;
+        }
+    }
+}

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -155,10 +155,8 @@ abstract class ApiException extends \Exception
             throw new \LogicException('The CODE constant must be defined on the exception');
         }
 
-        /** @var \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface $code */
-        $code = constant(static::class . '::CODE');
-
-        return $code;
+        /** @var \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface */
+        return constant(static::class . '::CODE');
     }
 
     /**
@@ -172,10 +170,8 @@ abstract class ApiException extends \Exception
             throw new \LogicException('The HTTP_STATUS constant must be defined on the exception');
         }
 
-        /** @var \SineMacula\Http\Enums\HttpStatus $status */
-        $status = constant(static::class . '::HTTP_STATUS');
-
-        return $status;
+        /** @var \SineMacula\Http\Enums\HttpStatus */
+        return constant(static::class . '::HTTP_STATUS');
     }
 
     /**

--- a/src/Exceptions/DuplicateSchemaKeyException.php
+++ b/src/Exceptions/DuplicateSchemaKeyException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Exceptions;
+
+/**
+ * Exception thrown when duplicate schema keys are detected.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class DuplicateSchemaKeyException extends \RuntimeException {}

--- a/src/Exceptions/LockOperationException.php
+++ b/src/Exceptions/LockOperationException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Exceptions;
+
+/**
+ * Exception thrown when a lock operation cannot be performed.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LockOperationException extends \RuntimeException {}

--- a/src/Exceptions/TokenMismatchException.php
+++ b/src/Exceptions/TokenMismatchException.php
@@ -24,6 +24,7 @@ class TokenMismatchException extends ApiException
      *
      * @return int
      */
+    #[\Override]
     public static function getHttpStatusCode(): int
     {
         return 419;

--- a/src/Facades/ApiQuery.php
+++ b/src/Facades/ApiQuery.php
@@ -31,6 +31,7 @@ class ApiQuery extends Facade
      *
      * @return string
      */
+    #[\Override]
     protected static function getFacadeAccessor(): string
     {
         $alias = Config::get('api-toolkit.parser.alias');

--- a/src/Http/Concerns/RespondsWithStream.php
+++ b/src/Http/Concerns/RespondsWithStream.php
@@ -37,13 +37,14 @@ trait RespondsWithStream
         $transformer = $this->makeTransformer($repository);
 
         // Strip any user-defined ordering before chunking.
-        $repository->addScope(fn ($query) => $query->reorder());
+        $repository->addScope(fn ($query) => $query->getQuery()->reorder());
 
         $stream = function () use ($repository, $transformer, $chunk_size, $limit): void {
 
             $is_first_chunk = true;
             $processed      = 0;
 
+            // @phpstan-ignore staticMethod.dynamicCall (chunkById() is forwarded to the builder via Repository::__call())
             $repository->chunkById($chunk_size, function ($chunk) use ($transformer, &$is_first_chunk, &$processed, $limit): bool {
 
                 if ($limit && $processed >= $limit) {
@@ -75,7 +76,7 @@ trait RespondsWithStream
      * Create a transformer closure for the given repository.
      *
      * @param  \SineMacula\ApiToolkit\Repositories\ApiRepository<\Illuminate\Database\Eloquent\Model>  $repository
-     * @return \Closure
+     * @return \Closure(array<int, \Illuminate\Database\Eloquent\Model>): array<int, array<string, mixed>>
      *
      * @throws \InvalidArgumentException
      */
@@ -85,7 +86,8 @@ trait RespondsWithStream
             throw new \InvalidArgumentException('Unable to resolve resource class from repository.');
         }
 
-        return fn ($items) => $resource_class::collection($items)->resolve();
+        /** @var class-string<\Illuminate\Http\Resources\Json\JsonResource> $resource_class */
+        return fn (array $items): array => $resource_class::collection($items)->resolve();
     }
 
     /**
@@ -105,6 +107,7 @@ trait RespondsWithStream
             ->withoutFields(config('api-toolkit.exports.ignored_fields', []));
 
         if (!$is_first_chunk) {
+            // @phpstan-ignore method.notFound (withoutHeaders() exists on the CSV exporter but is not part of the Exporter contract)
             $exporter->withoutHeaders();
         }
 
@@ -116,7 +119,7 @@ trait RespondsWithStream
     /**
      * Create a streamed response.
      *
-     * @param  callable  $callback
+     * @param  callable(): void  $callback
      * @param  string  $content_type
      * @param  string  $filename
      * @return \Symfony\Component\HttpFoundation\StreamedResponse

--- a/src/Http/FormRequest.php
+++ b/src/Http/FormRequest.php
@@ -22,6 +22,7 @@ abstract class FormRequest extends LaravelFormRequest
      *
      * @throws \SineMacula\ApiToolkit\Exceptions\ApiException
      */
+    #[\Override]
     protected function failedValidation(Validator $validator): void
     {
         throw new InvalidInputException($validator->getMessageBag()->toArray());

--- a/src/Http/Middleware/Traits/ThrottleRequestsTrait.php
+++ b/src/Http/Middleware/Traits/ThrottleRequestsTrait.php
@@ -2,6 +2,8 @@
 
 namespace SineMacula\ApiToolkit\Http\Middleware\Traits;
 
+use SineMacula\ApiToolkit\Exceptions\RequestSignatureException;
+
 /**
  * Throttle requests trait.
  *
@@ -18,7 +20,7 @@ trait ThrottleRequestsTrait
      * @param  \Illuminate\Http\Request  $request
      * @return string
      *
-     * @throws \RuntimeException
+     * @throws \SineMacula\ApiToolkit\Exceptions\RequestSignatureException
      */
     protected function resolveRequestSignature(#[\SensitiveParameter] $request): string
     {
@@ -28,7 +30,7 @@ trait ThrottleRequestsTrait
         $route = ($request->getRouteResolver())();
 
         if ($route === null) {
-            throw new \RuntimeException('Unable to generate the request signature. Route unavailable.');
+            throw new RequestSignatureException('Unable to generate the request signature. Route unavailable.');
         }
 
         $server_name = $request->server('SERVER_NAME');

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -80,6 +80,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  mixed  $request
      * @return array<string, mixed>
      */
+    #[\Override]
     public function resolve(#[\SensitiveParameter] mixed $request = null): array
     {
         $schema = SchemaCompiler::compile(static::class);
@@ -125,6 +126,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  array<int, string>  $fields
      * @return array<int|string, mixed>
      */
+    #[\Override]
     public static function eagerLoadMapFor(array $fields): array
     {
         return EagerLoadPlanner::buildEagerLoadMap(static::class, $fields);
@@ -136,6 +138,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  array<int, string>|null  $requestedAliases
      * @return array<int|string, mixed>
      */
+    #[\Override]
     public static function eagerLoadCountsFor(?array $requestedAliases = null): array
     {
         return EagerLoadPlanner::buildCountMap(static::class, $requestedAliases);
@@ -146,6 +149,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      *
      * @return string
      */
+    #[\Override]
     public static function getResourceType(): string
     {
         if (!defined(static::class . '::RESOURCE_TYPE')) {
@@ -160,6 +164,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      *
      * @return array<int, string>
      */
+    #[\Override]
     public static function getDefaultFields(): array
     {
         return static::$default;
@@ -170,6 +175,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      *
      * @return array<int, string>
      */
+    #[\Override]
     public static function getAllFields(): array
     {
         $schema = SchemaCompiler::compile(static::class);
@@ -182,6 +188,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      *
      * @return array<string, array<string, mixed>>
      */
+    #[\Override]
     abstract public static function schema(): array;
 
     /**
@@ -190,6 +197,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  \Illuminate\Http\Request  $request
      * @return array<string, mixed>
      */
+    #[\Override]
     public function toArray(Request $request): array
     {
         return $this->resolve($request);
@@ -200,6 +208,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      *
      * @return array<int, string>
      */
+    #[\Override]
     public static function resolveFields(): array
     {
         return ApiQuery::getFields(static::getResourceType()) ?? static::getDefaultFields();
@@ -211,6 +220,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  array<int, string>|null  $fields
      * @return static
      */
+    #[\Override]
     public function withFields(?array $fields = null): static
     {
         $this->fieldResolver->withFields($fields);
@@ -224,6 +234,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  array<int, string>|null  $fields
      * @return static
      */
+    #[\Override]
     public function withoutFields(?array $fields = null): static
     {
         $this->fieldResolver->withoutFields($fields);
@@ -236,6 +247,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      *
      * @return static
      */
+    #[\Override]
     public function withAll(): static
     {
         $this->fieldResolver->withAll();
@@ -249,6 +261,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
      * @param  mixed  $resource
      * @return \SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection
      */
+    #[\Override]
     protected static function newCollection(#[\SensitiveParameter] mixed $resource): ApiResourceCollection
     {
         return new ApiResourceCollection($resource, static::class);

--- a/src/Http/Resources/ApiResourceCollection.php
+++ b/src/Http/Resources/ApiResourceCollection.php
@@ -32,6 +32,7 @@ class ApiResourceCollection extends AnonymousResourceCollection
      * @param  \Illuminate\Http\Request  $request
      * @return array<int|string, array<string, mixed>>
      */
+    #[\Override]
     public function toArray(Request $request): array
     {
         /** @var class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource> $resource_class */
@@ -90,6 +91,7 @@ class ApiResourceCollection extends AnonymousResourceCollection
      * @param  \Illuminate\Http\JsonResponse  $response
      * @return void
      */
+    #[\Override]
     public function withResponse(Request $request, JsonResponse $response): void
     {
         if ($this->resource instanceof LengthAwarePaginator) {

--- a/src/Http/Resources/ResourceMetadataService.php
+++ b/src/Http/Resources/ResourceMetadataService.php
@@ -22,6 +22,7 @@ class ResourceMetadataService implements ResourceMetadataProvider
      * @param  string  $resourceClass
      * @return string
      */
+    #[\Override]
     public function getResourceType(string $resourceClass): string
     {
         return $resourceClass::getResourceType();
@@ -33,6 +34,7 @@ class ResourceMetadataService implements ResourceMetadataProvider
      * @param  string  $resourceClass
      * @return array<int, string>
      */
+    #[\Override]
     public function resolveFields(string $resourceClass): array
     {
         return $resourceClass::resolveFields();
@@ -44,6 +46,7 @@ class ResourceMetadataService implements ResourceMetadataProvider
      * @param  string  $resourceClass
      * @return array<int, string>
      */
+    #[\Override]
     public function getAllFields(string $resourceClass): array
     {
         return $resourceClass::getAllFields();
@@ -56,6 +59,7 @@ class ResourceMetadataService implements ResourceMetadataProvider
      * @param  array<int, string>  $fields
      * @return array<int|string, mixed>
      */
+    #[\Override]
     public function eagerLoadMapFor(string $resourceClass, array $fields): array
     {
         return $resourceClass::eagerLoadMapFor($fields);
@@ -69,6 +73,7 @@ class ResourceMetadataService implements ResourceMetadataProvider
      * @param  array<int, string>|null  $requestedAliases
      * @return array<int|string, mixed>
      */
+    #[\Override]
     public function eagerLoadCountsFor(string $resourceClass, ?array $requestedAliases = null): array
     {
         return $resourceClass::eagerLoadCountsFor($requestedAliases);

--- a/src/Http/Resources/Schema/BaseDefinition.php
+++ b/src/Http/Resources/Schema/BaseDefinition.php
@@ -87,5 +87,6 @@ abstract class BaseDefinition implements Arrayable
      *
      * @return array<string, array<string, mixed>>
      */
+    #[\Override]
     abstract public function toArray(): array;
 }

--- a/src/Http/Resources/Schema/Count.php
+++ b/src/Http/Resources/Schema/Count.php
@@ -92,6 +92,7 @@ final class Count extends BaseDefinition implements Arrayable
      *
      * @return array<string, array<string, mixed>>
      */
+    #[\Override]
     public function toArray(): array
     {
         $present = $this->alias ?? $this->name;

--- a/src/Http/Resources/Schema/Field.php
+++ b/src/Http/Resources/Schema/Field.php
@@ -4,6 +4,7 @@ namespace SineMacula\ApiToolkit\Http\Resources\Schema;
 
 use Carbon\CarbonInterface;
 use Illuminate\Contracts\Support\Arrayable;
+use SineMacula\ApiToolkit\Exceptions\DuplicateSchemaKeyException;
 
 /**
  * Field schema helpers for scalar and accessor fields.
@@ -132,6 +133,7 @@ final class Field extends BaseDefinition
      *
      * @return array<string, array<string, mixed>>
      */
+    #[\Override]
     public function toArray(): array
     {
         $key = $this->alias ?? $this->name;
@@ -153,7 +155,7 @@ final class Field extends BaseDefinition
      * @param  array<string, array<string, mixed>>|\Illuminate\Contracts\Support\Arrayable<string, array<string, mixed>>  ...$definitions
      * @return array<string, array<string, mixed>>
      *
-     * @throws \RuntimeException
+     * @throws \SineMacula\ApiToolkit\Exceptions\DuplicateSchemaKeyException
      */
     public static function set(array|Arrayable ...$definitions): array
     {
@@ -166,7 +168,7 @@ final class Field extends BaseDefinition
             foreach ($definition as $key => $value) {
 
                 if (array_key_exists($key, $compiled)) {
-                    throw new \RuntimeException(sprintf('Duplicate schema key "%s" detected in Field::set()', $key));
+                    throw new DuplicateSchemaKeyException(sprintf('Duplicate schema key "%s" detected in Field::set()', $key));
                 }
 
                 $compiled[$key] = $value;

--- a/src/Http/Resources/Schema/Relation.php
+++ b/src/Http/Resources/Schema/Relation.php
@@ -119,6 +119,7 @@ final class Relation extends BaseDefinition implements Arrayable
      *
      * @return array<string, array<string, mixed>>
      */
+    #[\Override]
     public function toArray(): array
     {
         $key = $this->alias ?? $this->name;

--- a/src/Listeners/OctaneFlushListener.php
+++ b/src/Listeners/OctaneFlushListener.php
@@ -31,6 +31,11 @@ final class OctaneFlushListener
     /**
      * Handle the event.
      *
+     * The event parameter is unused but required by Laravel's event
+     * listener signature.
+     *
+     * @SuppressWarnings("php:S1172")
+     *
      * @param  object  $event
      * @return void
      */

--- a/src/Listeners/Traits/ProvidesExclusiveLock.php
+++ b/src/Listeners/Traits/ProvidesExclusiveLock.php
@@ -16,13 +16,13 @@ trait ProvidesExclusiveLock
      * Executes the given callback under an exclusive lock.
      *
      * @param  string  $id
-     * @param  callable  $callback
+     * @param  callable(): void  $callback
      * @param  string  $prefix
      * @return void
      */
     protected function handleWithLock(string $id, callable $callback, string $prefix = 'LISTENER_LOCK'): void
     {
-        $lock = Cache::lock(implode(':', array_filter([$prefix, $id])), 10);
+        $lock = Cache::lock(implode(':', array_filter([$prefix, $id], static fn (string $value): bool => (bool) $value)), 10);
 
         try {
             if ($lock->get()) {

--- a/src/Logging/DatabaseHandler.php
+++ b/src/Logging/DatabaseHandler.php
@@ -27,6 +27,7 @@ class DatabaseHandler extends AbstractProcessingHandler
      * @param  \Monolog\LogRecord  $record
      * @return void
      */
+    #[\Override]
     protected function write(LogRecord $record): void
     {
         if (!$this->shouldLog($record)) {

--- a/src/Logging/DatabaseLogger.php
+++ b/src/Logging/DatabaseLogger.php
@@ -18,6 +18,11 @@ class DatabaseLogger
     /**
      * Invoke the custom logger instance.
      *
+     * The config parameter is unused but required by Laravel's custom
+     * logger factory contract.
+     *
+     * @SuppressWarnings("php:S1172")
+     *
      * @param  array<string, mixed>  $config
      * @return \Monolog\Logger
      */

--- a/src/Models/LogMessage.php
+++ b/src/Models/LogMessage.php
@@ -47,6 +47,7 @@ class LogMessage extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/src/Providers/Registrars/ContainerBindingRegistrar.php
+++ b/src/Providers/Registrars/ContainerBindingRegistrar.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Providers\Registrars;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Config;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\Enums\FlushStrategy;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\BetweenOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\ContainsOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\EqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\GreaterThanOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\GreaterThanOrEqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\InOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LessThanOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LessThanOrEqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LikeOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
+use SineMacula\ApiToolkit\Services\SchemaIntrospector;
+use SineMacula\ApiToolkit\Services\SchemaValidator;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateAccessors;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateComputedFields;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateConstraints;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateGuards;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateRelationClasses;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateRelationInterfaces;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateRelationMethods;
+use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateTransformers;
+
+/**
+ * Registers the toolkit container bindings.
+ *
+ * Binds the query parser, resource metadata provider, schema introspector,
+ * operator registry, schema validator, write pool, and cache manager to the
+ * service container.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ContainerBindingRegistrar
+{
+    /**
+     * Create a new container binding registrar instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function __construct(
+
+        /** The service container to register the bindings on. */
+        private readonly Container $container,
+
+    ) {}
+
+    /**
+     * Register the toolkit container bindings.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->registerQueryParser();
+        $this->registerResourceMetadataProvider();
+        $this->registerSchemaIntrospector();
+        $this->registerOperatorRegistry();
+        $this->registerSchemaValidator();
+        $this->registerWritePool();
+        $this->registerCacheManager();
+    }
+
+    /**
+     * Bind the API query parser to the service container.
+     *
+     * @return void
+     */
+    private function registerQueryParser(): void
+    {
+        $this->container->scoped(Config::get('api-toolkit.parser.alias'), fn ($app) => new ApiQueryParser);
+    }
+
+    /**
+     * Bind the ResourceMetadataProvider to the service container.
+     *
+     * @return void
+     */
+    private function registerResourceMetadataProvider(): void
+    {
+        $this->container->singleton(
+            \SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider::class,
+            \SineMacula\ApiToolkit\Http\Resources\ResourceMetadataService::class,
+        );
+    }
+
+    /**
+     * Bind the SchemaIntrospectionProvider to the service container.
+     *
+     * @return void
+     */
+    private function registerSchemaIntrospector(): void
+    {
+        $this->container->singleton(
+            SchemaIntrospectionProvider::class,
+            SchemaIntrospector::class,
+        );
+    }
+
+    /**
+     * Bind the OperatorRegistry to the service container.
+     *
+     * @return void
+     */
+    private function registerOperatorRegistry(): void
+    {
+        $this->container->singleton(OperatorRegistry::class, function (): OperatorRegistry {
+
+            $registry = new OperatorRegistry;
+
+            $registry->register('$eq', new EqualOperator);
+            $registry->register('$neq', new NotEqualOperator);
+            $registry->register('$gt', new GreaterThanOperator);
+            $registry->register('$lt', new LessThanOperator);
+            $registry->register('$ge', new GreaterThanOrEqualOperator);
+            $registry->register('$le', new LessThanOrEqualOperator);
+            $registry->register('$like', new LikeOperator);
+            $registry->register('$in', new InOperator);
+            $registry->register('$between', new BetweenOperator);
+            $registry->register('$contains', new ContainsOperator);
+            $registry->register('$null', new NullOperator);
+            $registry->register('$notNull', new NotNullOperator);
+
+            return $registry;
+        });
+    }
+
+    /**
+     * Bind the SchemaValidator to the service container.
+     *
+     * @return void
+     */
+    private function registerSchemaValidator(): void
+    {
+        $this->container->singleton(SchemaValidator::class, fn (): SchemaValidator => new SchemaValidator(
+            new ValidateGuards,
+            new ValidateTransformers,
+            new ValidateRelationClasses,
+            new ValidateRelationInterfaces,
+            new ValidateRelationMethods,
+            new ValidateComputedFields,
+            new ValidateConstraints,
+            new ValidateAccessors,
+        ));
+    }
+
+    /**
+     * Bind the WritePool to the service container as a scoped singleton.
+     *
+     * @return void
+     */
+    private function registerWritePool(): void
+    {
+        $this->container->scoped(WritePool::class, function (): WritePool {
+
+            $chunk_size = Config::get('api-toolkit.deferred_writes.chunk_size', 500);
+            $pool_limit = Config::get('api-toolkit.deferred_writes.pool_limit', 10000);
+            $on_failure = Config::get('api-toolkit.deferred_writes.on_failure', 'log');
+
+            return new WritePool(
+                is_numeric($chunk_size) ? (int) $chunk_size : 500,
+                is_numeric($pool_limit) ? (int) $pool_limit : 10000,
+                FlushStrategy::from(is_string($on_failure) ? $on_failure : 'log'),
+            );
+        });
+    }
+
+    /**
+     * Bind the CacheManager to the service container.
+     *
+     * @return void
+     */
+    private function registerCacheManager(): void
+    {
+        $this->container->singleton(CacheManager::class);
+    }
+}

--- a/src/Providers/Registrars/LifecycleRegistrar.php
+++ b/src/Providers/Registrars/LifecycleRegistrar.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Providers\Registrars;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
+use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+
+/**
+ * Registers the toolkit lifecycle listeners.
+ *
+ * Subscribes the write pool flush subscriber, the Octane flush listener, and
+ * the queue flush subscriber to their lifecycle events, honouring the
+ * configured gates.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LifecycleRegistrar
+{
+    /**
+     * Register the toolkit lifecycle listeners.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->registerWritePoolFlushSubscriber();
+        $this->registerOctaneFlushListener();
+        $this->registerQueueFlushSubscriber();
+    }
+
+    /**
+     * Subscribe the write pool flush subscriber to lifecycle events.
+     *
+     * @return void
+     */
+    private function registerWritePoolFlushSubscriber(): void
+    {
+        Event::subscribe(WritePoolFlushSubscriber::class);
+    }
+
+    /**
+     * Register the Octane flush listener if configured and Octane is
+     * installed.
+     *
+     * @return void
+     */
+    private function registerOctaneFlushListener(): void
+    {
+        if (!(bool) Config::get('api-toolkit.lifecycle.octane')) {
+            return;
+        }
+
+        if (!class_exists(\Laravel\Octane\Events\OperationTerminated::class)) {
+            return;
+        }
+
+        Event::listen(\Laravel\Octane\Events\OperationTerminated::class, OctaneFlushListener::class);
+    }
+
+    /**
+     * Register the queue flush subscriber if configured.
+     *
+     * @return void
+     */
+    private function registerQueueFlushSubscriber(): void
+    {
+        if (!(bool) Config::get('api-toolkit.lifecycle.queue')) {
+            return;
+        }
+
+        Event::subscribe(QueueFlushSubscriber::class);
+    }
+}

--- a/src/Providers/Registrars/LoggingRegistrar.php
+++ b/src/Providers/Registrars/LoggingRegistrar.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Providers\Registrars;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Log\LogManager;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use SineMacula\ApiToolkit\Listeners\NotificationListener;
+use SineMacula\ApiToolkit\Logging\CloudWatchLogger;
+
+/**
+ * Registers the toolkit logging functionality.
+ *
+ * Extends the log manager with the CloudWatch driver when the AWS SDK is
+ * available, and wires the notification logging listeners when enabled.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LoggingRegistrar
+{
+    /**
+     * Create a new logging registrar instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function __construct(
+
+        /** The service container for resolving the log manager. */
+        private readonly Container $container,
+
+    ) {}
+
+    /**
+     * Register the toolkit logging functionality.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->registerCloudwatchLogger();
+        $this->registerNotificationLogging();
+    }
+
+    /**
+     * Register the Cloudwatch logger driver.
+     *
+     * @return void
+     */
+    private function registerCloudwatchLogger(): void
+    {
+        if (!class_exists(\Aws\CloudWatchLogs\CloudWatchLogsClient::class)) {
+            return;
+        }
+
+        $this->container->make(LogManager::class)->extend('cloudwatch', fn ($app, array $config) => (new CloudWatchLogger)->__invoke($config));
+    }
+
+    /**
+     * Register the notification logging functionality.
+     *
+     * @return void
+     */
+    private function registerNotificationLogging(): void
+    {
+        if (!Config::get('api-toolkit.notifications.enable_logging', true)) {
+            return;
+        }
+
+        Event::listen(NotificationSending::class, [NotificationListener::class, 'sending']);
+        Event::listen(NotificationSent::class, [NotificationListener::class, 'sent']);
+    }
+}

--- a/src/Providers/Registrars/MiddlewareRegistrar.php
+++ b/src/Providers/Registrars/MiddlewareRegistrar.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Providers\Registrars;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Config;
+use SineMacula\ApiToolkit\Http\Middleware\DetectsCapabilities;
+use SineMacula\ApiToolkit\Http\Middleware\JsonPrettyPrint;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Middleware\PreventRequestsDuringMaintenance;
+use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequests;
+use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequestsWithRedis;
+
+/**
+ * Registers the toolkit middleware.
+ *
+ * Pushes the query parser, maintenance mode, capability detection, and JSON
+ * pretty print middleware onto the HTTP kernel, and aliases the throttle
+ * middleware on the router, honouring the configured gates and scopes.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class MiddlewareRegistrar
+{
+    /**
+     * Create a new middleware registrar instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function __construct(
+
+        /** The service container for resolving the router and kernel. */
+        private readonly Container $container,
+
+    ) {}
+
+    /**
+     * Register any relevant middleware.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $router = $this->container->make(Router::class);
+
+        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
+        $kernel = $this->container->make(Kernel::class);
+
+        if (Config::get('api-toolkit.parser.register_middleware', true)) {
+            $kernel->pushMiddleware(ParseApiQuery::class);
+        }
+
+        $this->registerMaintenanceModeMiddleware($kernel);
+        $this->registerDetectsCapabilitiesMiddleware($kernel);
+        $this->registerJsonPrettyPrintMiddleware($kernel);
+        $this->registerThrottleMiddleware($router);
+    }
+
+    /**
+     * Register the maintenance mode middleware swap.
+     *
+     * When enabled, the toolkit's PreventRequestsDuringMaintenance middleware
+     * is prepended to the global middleware stack. Since it extends Laravel's
+     * built-in middleware, it takes precedence without requiring removal of
+     * the original.
+     *
+     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
+     * @return void
+     */
+    private function registerMaintenanceModeMiddleware(HttpKernel $kernel): void
+    {
+        if (!Config::get('api-toolkit.middleware.maintenance_mode_swap.enabled', true)) {
+            return;
+        }
+
+        $kernel->prependMiddleware(PreventRequestsDuringMaintenance::class);
+    }
+
+    /**
+     * Register the DetectsCapabilities middleware.
+     *
+     * When scope is 'global', the middleware is pushed to the global stack.
+     * When scope is 'api', it is appended to the 'api' middleware group.
+     * Capabilities still resolve lazily on first access when the middleware
+     * is not registered; registration simply precomputes them per request.
+     *
+     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
+     * @return void
+     */
+    private function registerDetectsCapabilitiesMiddleware(HttpKernel $kernel): void
+    {
+        if (!Config::get('api-toolkit.middleware.detect_capabilities.enabled', true)) {
+            return;
+        }
+
+        $scope = Config::get('api-toolkit.middleware.detect_capabilities.scope', 'global');
+
+        if ($scope === 'api') {
+            $kernel->appendMiddlewareToGroup('api', DetectsCapabilities::class);
+
+            return;
+        }
+
+        $kernel->pushMiddleware(DetectsCapabilities::class);
+    }
+
+    /**
+     * Register the JsonPrettyPrint middleware.
+     *
+     * When scope is 'global', the middleware is pushed to the global stack.
+     * When scope is 'api', it is appended to the 'api' middleware group.
+     *
+     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
+     * @return void
+     */
+    private function registerJsonPrettyPrintMiddleware(HttpKernel $kernel): void
+    {
+        if (!Config::get('api-toolkit.middleware.json_pretty_print.enabled', true)) {
+            return;
+        }
+
+        $scope = Config::get('api-toolkit.middleware.json_pretty_print.scope', 'global');
+
+        if ($scope === 'api') {
+            $kernel->appendMiddlewareToGroup('api', JsonPrettyPrint::class);
+
+            return;
+        }
+
+        $kernel->pushMiddleware(JsonPrettyPrint::class);
+    }
+
+    /**
+     * Register the throttle middleware alias.
+     *
+     * When a custom class is provided via config, that class is used.
+     * Otherwise, the toolkit auto-detects between standard and Redis
+     * variants based on the configured cache driver.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return void
+     */
+    private function registerThrottleMiddleware(Router $router): void
+    {
+        if (!Config::get('api-toolkit.middleware.throttle.enabled', true)) {
+            return;
+        }
+
+        $router->aliasMiddleware('throttle', $this->getThrottleMiddleware());
+    }
+
+    /**
+     * Return the throttle middleware that should be used.
+     *
+     * @return class-string
+     */
+    private function getThrottleMiddleware(): string
+    {
+        /** @var class-string|null $custom_class */
+        $custom_class = Config::get('api-toolkit.middleware.throttle.class');
+
+        if ($custom_class !== null) {
+            return $custom_class;
+        }
+
+        return Config::get('cache.default') !== 'redis'
+            ? ThrottleRequests::class
+            : ThrottleRequestsWithRedis::class;
+    }
+}

--- a/src/Providers/Registrars/RequestMacroRegistrar.php
+++ b/src/Providers/Registrars/RequestMacroRegistrar.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Providers\Registrars;
+
+use Illuminate\Support\Facades\Request;
+use SineMacula\ApiToolkit\Http\RequestCapabilities;
+
+/**
+ * Registers the deprecated request macros.
+ *
+ * Binds the trashed, export, and stream macros to the Request facade. Each
+ * macro emits a deprecation notice and delegates to the RequestCapabilities
+ * value object that replaces it.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RequestMacroRegistrar
+{
+    /**
+     * Register the deprecated request macros.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->registerTrashedMacros();
+        $this->registerExportMacros();
+        $this->registerStreamMacros();
+    }
+
+    /**
+     * Register the deprecated trashed macros to the Request facade.
+     *
+     * @return void
+     */
+    private function registerTrashedMacros(): void
+    {
+        Request::macro('includeTrashed', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::includeTrashed() is deprecated, use RequestCapabilities::fromRequest($request)->includeTrashed() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->includeTrashed();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+
+        Request::macro('onlyTrashed', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::onlyTrashed() is deprecated, use RequestCapabilities::fromRequest($request)->onlyTrashed() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->onlyTrashed();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+    }
+
+    /**
+     * Register the deprecated export macros to the Request facade.
+     *
+     * @return void
+     */
+    private function registerExportMacros(): void
+    {
+        Request::macro('expectsExport', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::expectsExport() is deprecated, use RequestCapabilities::fromRequest($request)->expectsExport() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->expectsExport();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+
+        Request::macro('expectsCsv', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::expectsCsv() is deprecated, use RequestCapabilities::fromRequest($request)->expectsCsv() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->expectsCsv();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+
+        Request::macro('expectsXml', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::expectsXml() is deprecated, use RequestCapabilities::fromRequest($request)->expectsXml() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->expectsXml();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+
+        Request::macro('expectsPdf', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::expectsPdf() is deprecated, use RequestCapabilities::fromRequest($request)->expectsPdf() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->expectsPdf();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+    }
+
+    /**
+     * Register the deprecated stream macros to the Request facade.
+     *
+     * @return void
+     */
+    private function registerStreamMacros(): void
+    {
+        Request::macro('expectsStream', \Closure::bind(function (): bool {
+
+            @trigger_error(
+                'Request::expectsStream() is deprecated, use RequestCapabilities::fromRequest($request)->expectsStream() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return RequestCapabilities::fromRequest($this)->expectsStream();
+        }, new \Illuminate\Http\Request, \Illuminate\Http\Request::class));
+    }
+}

--- a/src/Services/Concerns/LockConcern.php
+++ b/src/Services/Concerns/LockConcern.php
@@ -26,6 +26,7 @@ class LockConcern implements ServiceConcern
      * @param  \Closure(): bool  $next
      * @return bool
      */
+    #[\Override]
     public function execute(Service $service, \Closure $next): bool
     {
         if (!in_array(Lockable::class, class_uses_recursive($service), true)) {

--- a/src/Services/Concerns/TransactionConcern.php
+++ b/src/Services/Concerns/TransactionConcern.php
@@ -28,6 +28,7 @@ class TransactionConcern implements ServiceConcern
      * @param  \Closure(): bool  $next
      * @return bool
      */
+    #[\Override]
     public function execute(Service $service, \Closure $next): bool
     {
         return (bool) DB::transaction(fn () => $next(), self::DEFAULT_RETRIES);

--- a/src/Services/SchemaIntrospector.php
+++ b/src/Services/SchemaIntrospector.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use ReflectionMethod;
-use ReflectionNamedType;
-use ReflectionUnionType;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 
@@ -131,7 +128,7 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
             $key,
         ]), function () use ($key, $model) {
             if (method_exists($model, $key)) {
-                return $this->hasRelationReturnType(new ReflectionMethod($model, $key));
+                return $this->hasRelationReturnType(new \ReflectionMethod($model, $key));
             }
 
             return $model->relationResolver($model::class, $key) !== null;
@@ -185,17 +182,17 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
      * @param  \ReflectionMethod  $method
      * @return bool
      */
-    private function hasRelationReturnType(ReflectionMethod $method): bool
+    private function hasRelationReturnType(\ReflectionMethod $method): bool
     {
         $returnType = $method->getReturnType();
 
-        if ($returnType instanceof ReflectionNamedType) {
+        if ($returnType instanceof \ReflectionNamedType) {
             return is_subclass_of($returnType->getName(), Relation::class);
         }
 
-        if ($returnType instanceof ReflectionUnionType) {
+        if ($returnType instanceof \ReflectionUnionType) {
             foreach ($returnType->getTypes() as $member) {
-                if ($member instanceof ReflectionNamedType && is_subclass_of($member->getName(), Relation::class)) {
+                if ($member instanceof \ReflectionNamedType && is_subclass_of($member->getName(), Relation::class)) {
                     return true;
                 }
             }

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -88,6 +88,7 @@ abstract class Service implements LockKeyProvider, ServiceInterface
      *
      * @return \SineMacula\ApiToolkit\Services\ServiceResult
      */
+    #[\Override]
     public function run(): ServiceResult
     {
         $pipeline = $this->buildPipeline();

--- a/src/Services/Validation/Rules/ValidateRelationMethods.php
+++ b/src/Services/Validation/Rules/ValidateRelationMethods.php
@@ -3,10 +3,6 @@
 namespace SineMacula\ApiToolkit\Services\Validation\Rules;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
-use ReflectionMethod;
-use ReflectionNamedType;
-use ReflectionType;
-use ReflectionUnionType;
 use SineMacula\ApiToolkit\Contracts\SchemaValidationRule;
 use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema;
 use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
@@ -83,7 +79,7 @@ final class ValidateRelationMethods implements SchemaValidationRule
             );
         }
 
-        $returnType = (new ReflectionMethod($modelClass, $relationMethod))->getReturnType();
+        $returnType = (new \ReflectionMethod($modelClass, $relationMethod))->getReturnType();
 
         if ($this->isRelationReturnType($returnType)) {
             return null;
@@ -102,15 +98,15 @@ final class ValidateRelationMethods implements SchemaValidationRule
      * @param  \ReflectionType|null  $returnType
      * @return bool
      */
-    private function isRelationReturnType(?ReflectionType $returnType): bool
+    private function isRelationReturnType(?\ReflectionType $returnType): bool
     {
-        if ($returnType instanceof ReflectionNamedType) {
+        if ($returnType instanceof \ReflectionNamedType) {
             return is_subclass_of($returnType->getName(), Relation::class);
         }
 
-        if ($returnType instanceof ReflectionUnionType) {
+        if ($returnType instanceof \ReflectionUnionType) {
             foreach ($returnType->getTypes() as $member) {
-                if ($member instanceof ReflectionNamedType && is_subclass_of($member->getName(), Relation::class)) {
+                if ($member instanceof \ReflectionNamedType && is_subclass_of($member->getName(), Relation::class)) {
                     return true;
                 }
             }
@@ -127,13 +123,13 @@ final class ValidateRelationMethods implements SchemaValidationRule
      * @param  string  $modelClass
      * @return string
      */
-    private function describeReturnTypeDefect(?ReflectionType $returnType, string $relationMethod, string $modelClass): string
+    private function describeReturnTypeDefect(?\ReflectionType $returnType, string $relationMethod, string $modelClass): string
     {
         if ($returnType === null) {
             return sprintf('Relation method "%s" on model "%s" has no return type hint', $relationMethod, $modelClass);
         }
 
-        if ($returnType instanceof ReflectionUnionType) {
+        if ($returnType instanceof \ReflectionUnionType) {
             return sprintf(
                 'Relation method "%s" on model "%s" has a union return type with no Relation subclass member',
                 $relationMethod,

--- a/src/Services/Validation/SchemaValidationError.php
+++ b/src/Services/Validation/SchemaValidationError.php
@@ -35,6 +35,7 @@ final readonly class SchemaValidationError
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         return sprintf('[%s] Field "%s": %s', $this->resourceClass, $this->fieldKey, $this->defect);

--- a/src/Traits/Lockable.php
+++ b/src/Traits/Lockable.php
@@ -5,6 +5,7 @@ namespace SineMacula\ApiToolkit\Traits;
 use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Support\Facades\Cache;
 use SineMacula\ApiToolkit\Contracts\LockKeyProvider;
+use SineMacula\ApiToolkit\Exceptions\LockOperationException;
 use SineMacula\ApiToolkit\Exceptions\TooManyRequestsException;
 
 /**
@@ -76,12 +77,12 @@ trait Lockable
      *
      * @return string
      *
-     * @throws \RuntimeException
+     * @throws \SineMacula\ApiToolkit\Exceptions\LockOperationException
      */
     private function resolveLockKey(): string
     {
         return $this->lockKey ??= ($this instanceof LockKeyProvider
             ? $this->getLockKey()
-            : throw new \RuntimeException('The lock key must be provided via the LockKeyProvider contract or by setting the $lockKey property'));
+            : throw new LockOperationException('The lock key must be provided via the LockKeyProvider contract or by setting the $lockKey property'));
     }
 }

--- a/tests/Integration/ApiServiceProviderTest.php
+++ b/tests/Integration/ApiServiceProviderTest.php
@@ -32,6 +32,11 @@ use SineMacula\ApiToolkit\Http\Resources\ResourceMetadataService;
 use SineMacula\ApiToolkit\Listeners\NotificationListener;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\LoggingRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
+use SineMacula\ApiToolkit\Providers\Registrars\RequestMacroRegistrar;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
 use SineMacula\ApiToolkit\Services\SchemaIntrospector;
@@ -47,6 +52,11 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ApiServiceProvider::class)]
+#[CoversClass(ContainerBindingRegistrar::class)]
+#[CoversClass(LifecycleRegistrar::class)]
+#[CoversClass(LoggingRegistrar::class)]
+#[CoversClass(MiddlewareRegistrar::class)]
+#[CoversClass(RequestMacroRegistrar::class)]
 class ApiServiceProviderTest extends TestCase
 {
     /**

--- a/tests/Integration/MiddlewareConfigApiScopeTest.php
+++ b/tests/Integration/MiddlewareConfigApiScopeTest.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\ApiServiceProvider;
 use SineMacula\ApiToolkit\Http\Middleware\JsonPrettyPrint;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
 use Tests\TestCase;
 
 /**
@@ -23,6 +24,7 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ApiServiceProvider::class)]
+#[CoversClass(MiddlewareRegistrar::class)]
 class MiddlewareConfigApiScopeTest extends TestCase
 {
     /**

--- a/tests/Integration/MiddlewareConfigCustomThrottleTest.php
+++ b/tests/Integration/MiddlewareConfigCustomThrottleTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\ApiServiceProvider;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
 use Tests\TestCase;
 
 /**
@@ -21,6 +22,7 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ApiServiceProvider::class)]
+#[CoversClass(MiddlewareRegistrar::class)]
 class MiddlewareConfigCustomThrottleTest extends TestCase
 {
     /** @var string */

--- a/tests/Integration/MiddlewareConfigDisabledTest.php
+++ b/tests/Integration/MiddlewareConfigDisabledTest.php
@@ -11,6 +11,7 @@ use SineMacula\ApiToolkit\Http\Middleware\JsonPrettyPrint;
 use SineMacula\ApiToolkit\Http\Middleware\PreventRequestsDuringMaintenance;
 use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequests;
 use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequestsWithRedis;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
 use Tests\TestCase;
 
 /**
@@ -26,6 +27,7 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ApiServiceProvider::class)]
+#[CoversClass(MiddlewareRegistrar::class)]
 class MiddlewareConfigDisabledTest extends TestCase
 {
     /**

--- a/tests/Integration/MiddlewareConfigRedisThrottleTest.php
+++ b/tests/Integration/MiddlewareConfigRedisThrottleTest.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\ApiServiceProvider;
 use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequestsWithRedis;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
 use Tests\TestCase;
 
 /**
@@ -21,6 +22,7 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ApiServiceProvider::class)]
+#[CoversClass(MiddlewareRegistrar::class)]
 class MiddlewareConfigRedisThrottleTest extends TestCase
 {
     /**

--- a/tests/Integration/Providers/Registrars/ContainerBindingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/ContainerBindingRegistrarTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Integration\Providers\Registrars;
+
+use Illuminate\Foundation\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider;
+use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+use SineMacula\ApiToolkit\Services\SchemaValidator;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the ContainerBindingRegistrar.
+ *
+ * The binding behaviour is pinned by the ApiServiceProvider integration
+ * suite; this test proves the registrar binds its surface when invoked
+ * directly.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ContainerBindingRegistrar::class)]
+class ContainerBindingRegistrarTest extends TestCase
+{
+    /**
+     * Test that all toolkit container bindings resolve after the registrar
+     * is invoked.
+     *
+     * @return void
+     */
+    public function testRegisterBindsAllContainerServices(): void
+    {
+        $app = $this->getApplication();
+
+        (new ContainerBindingRegistrar($app))->register();
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app->make('config');
+
+        /** @var string $alias */
+        $alias = $config->get('api-toolkit.parser.alias');
+
+        static::assertInstanceOf(ApiQueryParser::class, $app->make($alias));
+        static::assertInstanceOf(ResourceMetadataProvider::class, $app->make(ResourceMetadataProvider::class));
+        static::assertInstanceOf(SchemaIntrospectionProvider::class, $app->make(SchemaIntrospectionProvider::class));
+        static::assertInstanceOf(OperatorRegistry::class, $app->make(OperatorRegistry::class));
+        static::assertInstanceOf(SchemaValidator::class, $app->make(SchemaValidator::class));
+        static::assertInstanceOf(WritePool::class, $app->make(WritePool::class));
+        static::assertInstanceOf(CacheManager::class, $app->make(CacheManager::class));
+    }
+
+    /**
+     * Get the application instance.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    private function getApplication(): Application
+    {
+        assert($this->app !== null);
+
+        return $this->app;
+    }
+}

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Integration\Providers\Registrars;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Events\RequestHandled;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the LifecycleRegistrar.
+ *
+ * The lifecycle configuration permutations are pinned by the
+ * ApiServiceProvider integration suite; this test proves the registrar
+ * registers its surface when invoked directly.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(LifecycleRegistrar::class)]
+class LifecycleRegistrarTest extends TestCase
+{
+    /**
+     * Test that the lifecycle subscribers are registered when the registrar
+     * is invoked with the queue lifecycle enabled.
+     *
+     * @return void
+     */
+    public function testRegisterBindsLifecycleSubscribers(): void
+    {
+        $app = $this->getApplication();
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app->make('config');
+
+        $config->set('api-toolkit.lifecycle.queue', true);
+
+        (new LifecycleRegistrar)->register();
+
+        static::assertTrue($this->eventHasSubscriberListener(RequestHandled::class, WritePoolFlushSubscriber::class));
+        static::assertTrue($this->eventHasSubscriberListener(\Illuminate\Queue\Events\JobProcessed::class, QueueFlushSubscriber::class));
+    }
+
+    /**
+     * Get the application instance.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    private function getApplication(): Application
+    {
+        assert($this->app !== null);
+
+        return $this->app;
+    }
+
+    /**
+     * Determine whether the given event has a listener belonging to the
+     * given subscriber class.
+     *
+     * @param  class-string  $event
+     * @param  class-string  $subscriber
+     * @return bool
+     */
+    private function eventHasSubscriberListener(string $event, string $subscriber): bool
+    {
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $this->getApplication()->make('events');
+
+        $listeners = $events->getRawListeners()[$event] ?? [];
+
+        if (!is_iterable($listeners)) {
+            return false;
+        }
+
+        foreach ($listeners as $listener) {
+            if (is_array($listener) && ($listener[0] ?? null) instanceof $subscriber) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Integration\Providers\Registrars;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Notifications\Events\NotificationSent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Listeners\NotificationListener;
+use SineMacula\ApiToolkit\Providers\Registrars\LoggingRegistrar;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the LoggingRegistrar.
+ *
+ * The logging configuration permutations are pinned by the
+ * ApiServiceProvider integration suite; this test proves the registrar
+ * registers its surface when invoked directly.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(LoggingRegistrar::class)]
+class LoggingRegistrarTest extends TestCase
+{
+    /**
+     * Test that the notification logging listeners are registered when the
+     * registrar is invoked with logging enabled.
+     *
+     * @return void
+     */
+    public function testRegisterBindsNotificationLoggingListeners(): void
+    {
+        $app = $this->getApplication();
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app->make('config');
+
+        $config->set('api-toolkit.notifications.enable_logging', true);
+
+        (new LoggingRegistrar($app))->register();
+
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $app->make('events');
+
+        $raw = $events->getRawListeners();
+
+        static::assertContains([NotificationListener::class, 'sending'], $raw[NotificationSending::class] ?? []);
+        static::assertContains([NotificationListener::class, 'sent'], $raw[NotificationSent::class] ?? []);
+    }
+
+    /**
+     * Get the application instance.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    private function getApplication(): Application
+    {
+        assert($this->app !== null);
+
+        return $this->app;
+    }
+}

--- a/tests/Integration/Providers/Registrars/MiddlewareRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/MiddlewareRegistrarTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Integration\Providers\Registrars;
+
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\DetectsCapabilities;
+use SineMacula\ApiToolkit\Http\Middleware\JsonPrettyPrint;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Middleware\PreventRequestsDuringMaintenance;
+use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the MiddlewareRegistrar.
+ *
+ * The middleware configuration permutations are pinned by the
+ * ApiServiceProvider integration suite; this test proves the registrar
+ * registers its surface when invoked directly.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(MiddlewareRegistrar::class)]
+class MiddlewareRegistrarTest extends TestCase
+{
+    /**
+     * Test that the registrar pushes the kernel middleware and aliases the
+     * throttle middleware when invoked.
+     *
+     * @return void
+     */
+    public function testRegisterBindsMiddlewareSurface(): void
+    {
+        $app = $this->getApplication();
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app->make('config');
+
+        $config->set('api-toolkit.parser.register_middleware', true);
+
+        $app->forgetInstance(HttpKernel::class);
+        $app->forgetInstance(Router::class);
+        $app->forgetInstance('router');
+
+        (new MiddlewareRegistrar($app))->register();
+
+        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
+        $kernel     = $app->make(HttpKernel::class);
+        $middleware = $kernel->getGlobalMiddleware();
+
+        static::assertContains(ParseApiQuery::class, $middleware);
+        static::assertContains(PreventRequestsDuringMaintenance::class, $middleware);
+        static::assertContains(DetectsCapabilities::class, $middleware);
+        static::assertContains(JsonPrettyPrint::class, $middleware);
+
+        /** @var \Illuminate\Routing\Router $router */
+        $router = $app->make(Router::class);
+
+        static::assertArrayHasKey('throttle', $router->getMiddleware());
+    }
+
+    /**
+     * Get the application instance.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    private function getApplication(): Application
+    {
+        assert($this->app !== null);
+
+        return $this->app;
+    }
+}

--- a/tests/Integration/Providers/Registrars/RequestMacroRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/RequestMacroRegistrarTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Integration\Providers\Registrars;
+
+use Illuminate\Support\Facades\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Providers\Registrars\RequestMacroRegistrar;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the RequestMacroRegistrar.
+ *
+ * The deprecated macro behaviour is pinned by the ApiServiceProvider
+ * integration suite; this test proves the registrar binds its surface when
+ * invoked directly.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RequestMacroRegistrar::class)]
+class RequestMacroRegistrarTest extends TestCase
+{
+    /**
+     * Test that all deprecated request macros are registered when the
+     * registrar is invoked.
+     *
+     * @return void
+     */
+    public function testRegisterBindsAllDeprecatedRequestMacros(): void
+    {
+        (new RequestMacroRegistrar)->register();
+
+        static::assertTrue(Request::hasMacro('includeTrashed'));
+        static::assertTrue(Request::hasMacro('onlyTrashed'));
+        static::assertTrue(Request::hasMacro('expectsExport'));
+        static::assertTrue(Request::hasMacro('expectsCsv'));
+        static::assertTrue(Request::hasMacro('expectsXml'));
+        static::assertTrue(Request::hasMacro('expectsPdf'));
+        static::assertTrue(Request::hasMacro('expectsStream'));
+    }
+}

--- a/tests/Unit/ApiQueryParserTest.php
+++ b/tests/Unit/ApiQueryParserTest.php
@@ -7,6 +7,7 @@ use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Concerns\QueryParameterExtractor;
 use SineMacula\Http\Enums\HttpMethod;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\TestCase;
@@ -433,7 +434,7 @@ class ApiQueryParserTest extends TestCase
      */
     public function testNormalizeFieldsPreservesArrayInput(): void
     {
-        $result = $this->invokeMethod($this->parser, 'normalizeFields', ['amount', 'fee']);
+        $result = $this->invokeMethod(new QueryParameterExtractor, 'normalizeFields', ['amount', 'fee']);
 
         static::assertSame(['amount', 'fee'], $result);
     }
@@ -445,7 +446,7 @@ class ApiQueryParserTest extends TestCase
      */
     public function testNormalizeFieldsWrapsOtherInputInArray(): void
     {
-        $result = $this->invokeMethod($this->parser, 'normalizeFields', 42);
+        $result = $this->invokeMethod(new QueryParameterExtractor, 'normalizeFields', 42);
 
         static::assertSame([42], $result);
     }
@@ -457,7 +458,7 @@ class ApiQueryParserTest extends TestCase
      */
     public function testParseAggregationsSkipsNonArrayRelations(): void
     {
-        $result = $this->invokeMethod($this->parser, 'parseAggregations', [
+        $result = $this->invokeMethod(new QueryParameterExtractor, 'parseAggregations', [
             'valid'   => ['fields' => 'amount'],
             'invalid' => 'not_an_array',
         ]);
@@ -474,7 +475,7 @@ class ApiQueryParserTest extends TestCase
      */
     public function testParseAggregationsContinuesPastNonArrayRelations(): void
     {
-        $result = $this->invokeMethod($this->parser, 'parseAggregations', [
+        $result = $this->invokeMethod(new QueryParameterExtractor, 'parseAggregations', [
             'invalid' => 'not_an_array',
             'valid'   => ['fields' => 'amount'],
         ]);

--- a/tests/Unit/Concerns/QueryParameterExtractorTest.php
+++ b/tests/Unit/Concerns/QueryParameterExtractorTest.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Tests\Unit\Concerns;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SineMacula\ApiToolkit\Concerns\QueryParameterExtractor;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\TestCase;
+
+/**
+ * Tests for the QueryParameterExtractor concern class.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QueryParameterExtractor::class)]
+class QueryParameterExtractorTest extends TestCase
+{
+    /** @var string */
+    private const string TEST_URL = '/test';
+
+    /** @var \SineMacula\ApiToolkit\Concerns\QueryParameterExtractor */
+    private QueryParameterExtractor $extractor;
+
+    /**
+     * Set up the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extractor = new QueryParameterExtractor;
+    }
+
+    /**
+     * Test that extract returns an empty array when no parameters are
+     * supplied.
+     *
+     * @return void
+     */
+    public function testExtractReturnsEmptyArrayWhenNoParametersSupplied(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb());
+
+        static::assertSame([], $this->extractor->extract($request));
+    }
+
+    /**
+     * Test that extract only includes the keys present on the request.
+     *
+     * @return void
+     */
+    public function testExtractOnlyIncludesPresentKeys(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['fields' => 'name']);
+
+        static::assertSame(['fields' => ['name']], $this->extractor->extract($request));
+    }
+
+    /**
+     * Test that extract trims the page and limit parameters.
+     *
+     * @return void
+     */
+    public function testExtractTrimsPageAndLimitParameters(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['page' => ' 2 ', 'limit' => ' 10 ']);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame('2', $parameters['page']);
+        static::assertSame('10', $parameters['limit']);
+    }
+
+    /**
+     * Test that extract passes the cursor through unchanged.
+     *
+     * @return void
+     */
+    public function testExtractPassesCursorThroughUnchanged(): void
+    {
+        $cursor  = 'eyJpZCI6MTAwfQ==';
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['cursor' => $cursor]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame($cursor, $parameters['cursor']);
+    }
+
+    /**
+     * Test that extract splits and trims a comma-separated fields string.
+     *
+     * @return void
+     */
+    public function testExtractSplitsAndTrimsFieldsString(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['fields' => ' first_name , last_name ']);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['first_name', 'last_name'], $parameters['fields']);
+    }
+
+    /**
+     * Test that extract parses a fields array per resource.
+     *
+     * @return void
+     */
+    public function testExtractParsesFieldsArrayPerResource(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields' => [
+                'user' => 'name,email',
+                'post' => 'title,body',
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame([
+            'user' => ['name', 'email'],
+            'post' => ['title', 'body'],
+        ], $parameters['fields']);
+    }
+
+    /**
+     * Test that extract splits and trims a comma-separated counts string.
+     *
+     * @return void
+     */
+    public function testExtractSplitsAndTrimsCountsString(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['counts' => ' posts , comments ']);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['posts', 'comments'], $parameters['counts']);
+    }
+
+    /**
+     * Test that extract parses a counts array per resource.
+     *
+     * @return void
+     */
+    public function testExtractParsesCountsArrayPerResource(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'counts' => ['user' => 'posts,comments'],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['user' => ['posts', 'comments']], $parameters['counts']);
+    }
+
+    /**
+     * Test that extract splits and trims sum aggregation field strings.
+     *
+     * @return void
+     */
+    public function testExtractSplitsAndTrimsSumAggregationFields(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'sums' => [
+                'account' => [
+                    'transaction' => ' amount , fee ',
+                ],
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['account' => ['transaction' => ['amount', 'fee']]], $parameters['sums']);
+    }
+
+    /**
+     * Test that extract parses average aggregation fields.
+     *
+     * @return void
+     */
+    public function testExtractParsesAverageAggregationFields(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'averages' => [
+                'account' => [
+                    'transaction' => 'amount',
+                ],
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['account' => ['transaction' => ['amount']]], $parameters['averages']);
+    }
+
+    /**
+     * Test that extract skips non-array aggregation relations and continues
+     * parsing subsequent valid entries.
+     *
+     * @return void
+     */
+    public function testExtractSkipsNonArrayAggregationRelations(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'sums' => [
+                'invalid' => 'not_an_array',
+                'account' => ['transaction' => 'amount'],
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['account' => ['transaction' => ['amount']]], $parameters['sums']);
+    }
+
+    /**
+     * Test that extract preserves aggregation field values that are already
+     * arrays.
+     *
+     * @return void
+     */
+    public function testExtractPreservesArrayAggregationFields(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'sums' => [
+                'account' => [
+                    'transaction' => ['amount', 'fee'],
+                ],
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['account' => ['transaction' => ['amount', 'fee']]], $parameters['sums']);
+    }
+
+    /**
+     * Test that extract wraps scalar non-string aggregation field values in
+     * an array.
+     *
+     * @return void
+     */
+    public function testExtractWrapsScalarAggregationFieldsInArray(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'sums' => [
+                'account' => [
+                    'transaction' => 42,
+                ],
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['account' => ['transaction' => [42]]], $parameters['sums']);
+    }
+
+    /**
+     * Test that extract decodes a JSON filter string.
+     *
+     * @return void
+     */
+    public function testExtractDecodesJsonFilters(): void
+    {
+        $filters = json_encode(['status' => 'active', 'role' => 'admin']);
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['filters' => $filters]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['status' => 'active', 'role' => 'admin'], $parameters['filters']);
+    }
+
+    /**
+     * Test that extract returns an empty array for undecodable filters.
+     *
+     * @return void
+     */
+    public function testExtractReturnsEmptyArrayForUndecodableFilters(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['filters' => 'not-valid-json{']);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame([], $parameters['filters']);
+    }
+
+    /**
+     * Provide order string parsing scenarios.
+     *
+     * @return iterable<string, array{string, array<string, string>}>
+     */
+    public static function orderProvider(): iterable
+    {
+        yield 'single field ascending' => ['name:asc', ['name' => 'asc']];
+        yield 'single field descending' => ['name:desc', ['name' => 'desc']];
+        yield 'default ascending direction' => ['name', ['name' => 'asc']];
+        yield 'multiple fields' => ['name:asc,created_at:desc', ['name' => 'asc', 'created_at' => 'desc']];
+        yield 'mixed directions' => ['first_name,last_name:desc', ['first_name' => 'asc', 'last_name' => 'desc']];
+        yield 'direction containing colons' => ['name:desc:extra', ['name' => 'desc:extra']];
+        yield 'empty order string' => ['', []];
+        yield 'order string of empty values' => [',,', []];
+    }
+
+    /**
+     * Test that extract parses order strings into column and direction pairs.
+     *
+     * @param  string  $orderString
+     * @param  array<string, string>  $expected
+     * @return void
+     */
+    #[DataProvider('orderProvider')]
+    public function testExtractParsesOrderStrings(string $orderString, array $expected): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['order' => $orderString]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame($expected, $parameters['order']);
+    }
+
+    /**
+     * Test that extract parses multiple parameters simultaneously.
+     *
+     * @return void
+     */
+    public function testExtractParsesMultipleParametersSimultaneously(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields'  => 'name,email',
+            'order'   => 'name:asc',
+            'page'    => '2',
+            'limit'   => '10',
+            'filters' => json_encode(['active' => true]),
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        static::assertSame(['name', 'email'], $parameters['fields']);
+        static::assertSame(['name' => 'asc'], $parameters['order']);
+        static::assertSame('2', $parameters['page']);
+        static::assertSame('10', $parameters['limit']);
+        static::assertSame(['active' => true], $parameters['filters']);
+    }
+}

--- a/tests/Unit/Concerns/QueryParameterValidatorTest.php
+++ b/tests/Unit/Concerns/QueryParameterValidatorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\Concerns;
+
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SineMacula\ApiToolkit\Concerns\QueryParameterValidator;
+use Tests\TestCase;
+
+/**
+ * Tests for the QueryParameterValidator concern class.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QueryParameterValidator::class)]
+class QueryParameterValidatorTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\Concerns\QueryParameterValidator */
+    private QueryParameterValidator $validator;
+
+    /**
+     * Set up the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = new QueryParameterValidator;
+    }
+
+    /**
+     * Provide parameter sets that pass validation.
+     *
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function validParameterProvider(): iterable
+    {
+        yield 'no parameters' => [[]];
+        yield 'fields string' => [['fields' => 'name,email']];
+        yield 'fields array of strings' => [['fields' => ['user' => 'name,email']]];
+        yield 'counts array of strings' => [['counts' => ['user' => 'posts,comments']]];
+        yield 'sums nested arrays of strings' => [['sums' => ['account' => ['transaction' => 'amount']]]];
+        yield 'averages nested arrays of strings' => [['averages' => ['account' => ['transaction' => 'amount']]]];
+        yield 'valid json filters' => [['filters' => '{"status":"active"}']];
+        yield 'order string' => [['order' => 'name:asc']];
+        yield 'page of one' => [['page' => '1']];
+        yield 'limit of one' => [['limit' => '1']];
+        yield 'cursor string' => [['cursor' => 'eyJpZCI6MTAwfQ==']];
+    }
+
+    /**
+     * Test that valid parameters pass validation without an exception.
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return void
+     */
+    #[DataProvider('validParameterProvider')]
+    public function testValidParametersPassValidation(array $parameters): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->validator->validate($parameters);
+    }
+
+    /**
+     * Provide parameter sets that fail validation.
+     *
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function invalidParameterProvider(): iterable
+    {
+        yield 'non-numeric page' => [['page' => 'not-a-number']];
+        yield 'page below one' => [['page' => '0']];
+        yield 'non-numeric limit' => [['limit' => 'abc']];
+        yield 'limit below one' => [['limit' => '0']];
+        yield 'invalid json filters' => [['filters' => 'not-valid-json{']];
+        yield 'integer fields' => [['fields' => 123]];
+        yield 'array order' => [['order' => ['name' => 'asc']]];
+        yield 'array cursor' => [['cursor' => ['id' => 100]]];
+        yield 'array fields resource value' => [['fields' => ['user' => ['name', 'email']]]];
+        yield 'array counts resource value' => [['counts' => ['user' => ['posts', 'comments']]]];
+        yield 'string sums resource value' => [['sums' => ['account' => 'amount']]];
+        yield 'string averages resource value' => [['averages' => ['account' => 'amount']]];
+        yield 'integer sums field value' => [['sums' => ['account' => ['transaction' => 42]]]];
+        yield 'integer averages field value' => [['averages' => ['account' => ['transaction' => 42]]]];
+    }
+
+    /**
+     * Test that invalid parameters fail validation with an exception.
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return void
+     */
+    #[DataProvider('invalidParameterProvider')]
+    public function testInvalidParametersFailValidation(array $parameters): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validator->validate($parameters);
+    }
+}

--- a/tests/Unit/Exceptions/DuplicateSchemaKeyExceptionTest.php
+++ b/tests/Unit/Exceptions/DuplicateSchemaKeyExceptionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Exceptions;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Exceptions\DuplicateSchemaKeyException;
+
+/**
+ * Tests for the DuplicateSchemaKeyException.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(DuplicateSchemaKeyException::class)]
+class DuplicateSchemaKeyExceptionTest extends TestCase
+{
+    /**
+     * Test that the exception extends RuntimeException.
+     *
+     * @return void
+     */
+    public function testExtendsRuntimeException(): void
+    {
+        $exception = new DuplicateSchemaKeyException;
+
+        static::assertInstanceOf(\RuntimeException::class, $exception);
+    }
+
+    /**
+     * Test that the exception can be instantiated with a message.
+     *
+     * @return void
+     */
+    public function testCanBeInstantiatedWithMessage(): void
+    {
+        $message   = 'Duplicate schema key "name" detected';
+        $exception = new DuplicateSchemaKeyException($message);
+
+        static::assertSame($message, $exception->getMessage());
+    }
+
+    /**
+     * Test that the exception can be instantiated with a code.
+     *
+     * @return void
+     */
+    public function testCanBeInstantiatedWithCode(): void
+    {
+        $exception = new DuplicateSchemaKeyException(\Error::class, 42);
+
+        static::assertSame(42, $exception->getCode());
+    }
+
+    /**
+     * Test that the exception can be instantiated with a previous exception.
+     *
+     * @return void
+     */
+    public function testCanBeInstantiatedWithPreviousException(): void
+    {
+        $previous  = new \RuntimeException('Previous error');
+        $exception = new DuplicateSchemaKeyException(\Error::class, 0, $previous);
+
+        static::assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * Test that the exception has default empty message.
+     *
+     * @return void
+     */
+    public function testDefaultMessageIsEmpty(): void
+    {
+        $exception = new DuplicateSchemaKeyException;
+
+        static::assertSame('', $exception->getMessage());
+    }
+
+    /**
+     * Test that the exception has default zero code.
+     *
+     * @return void
+     */
+    public function testDefaultCodeIsZero(): void
+    {
+        $exception = new DuplicateSchemaKeyException;
+
+        static::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Exceptions/LockOperationExceptionTest.php
+++ b/tests/Unit/Exceptions/LockOperationExceptionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Exceptions;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Exceptions\LockOperationException;
+
+/**
+ * Tests for the LockOperationException.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(LockOperationException::class)]
+class LockOperationExceptionTest extends TestCase
+{
+    /**
+     * Test that the exception extends RuntimeException.
+     *
+     * @return void
+     */
+    public function testExtendsRuntimeException(): void
+    {
+        $exception = new LockOperationException;
+
+        static::assertInstanceOf(\RuntimeException::class, $exception);
+    }
+
+    /**
+     * Test that the exception can be instantiated with a message.
+     *
+     * @return void
+     */
+    public function testCanBeInstantiatedWithMessage(): void
+    {
+        $message   = 'The lock key must be provided';
+        $exception = new LockOperationException($message);
+
+        static::assertSame($message, $exception->getMessage());
+    }
+
+    /**
+     * Test that the exception can be instantiated with a code.
+     *
+     * @return void
+     */
+    public function testCanBeInstantiatedWithCode(): void
+    {
+        $exception = new LockOperationException(\Error::class, 42);
+
+        static::assertSame(42, $exception->getCode());
+    }
+
+    /**
+     * Test that the exception can be instantiated with a previous exception.
+     *
+     * @return void
+     */
+    public function testCanBeInstantiatedWithPreviousException(): void
+    {
+        $previous  = new \RuntimeException('Previous error');
+        $exception = new LockOperationException(\Error::class, 0, $previous);
+
+        static::assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * Test that the exception has default empty message.
+     *
+     * @return void
+     */
+    public function testDefaultMessageIsEmpty(): void
+    {
+        $exception = new LockOperationException;
+
+        static::assertSame('', $exception->getMessage());
+    }
+
+    /**
+     * Test that the exception has default zero code.
+     *
+     * @return void
+     */
+    public function testDefaultCodeIsZero(): void
+    {
+        $exception = new LockOperationException;
+
+        static::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Http/Concerns/RespondsWithStreamTest.php
+++ b/tests/Unit/Http/Concerns/RespondsWithStreamTest.php
@@ -437,6 +437,7 @@ class RespondsWithStreamTest extends TestCase
 
                 /** @var \Mockery\MockInterface $query */
                 $query = \Mockery::mock();
+                $query->shouldReceive('getQuery')->once()->andReturnSelf();
                 $query->shouldReceive('reorder')->once()->andReturnSelf();
 
                 $scope($query);
@@ -583,7 +584,7 @@ class RespondsWithStreamTest extends TestCase
         $controller = new class extends TestingExportController {
             /**
              * @param  \SineMacula\ApiToolkit\Repositories\ApiRepository<\Illuminate\Database\Eloquent\Model>  $repository
-             * @return \Closure(mixed): array<int, mixed>
+             * @return \Closure(array<int, \Illuminate\Database\Eloquent\Model>): array<int, array<string, mixed>>
              */
             public function callMakeTransformer(ApiRepository $repository): \Closure
             {

--- a/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
+++ b/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Exceptions\RequestSignatureException;
 use SineMacula\ApiToolkit\Http\Middleware\Traits\ThrottleRequestsTrait;
 use SineMacula\Http\Enums\HttpMethod;
 
@@ -23,13 +24,13 @@ class ThrottleRequestsTraitTest extends TestCase
     private const string API_DATA_URI = '/api/data';
 
     /**
-     * Test that resolveRequestSignature throws RuntimeException when route is null.
+     * Test that resolveRequestSignature throws RequestSignatureException when route is null.
      *
      * @return void
      */
-    public function testThrowsRuntimeExceptionWhenRouteIsNull(): void
+    public function testThrowsRequestSignatureExceptionWhenRouteIsNull(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RequestSignatureException::class);
         $this->expectExceptionMessage('Unable to generate the request signature. Route unavailable.');
 
         $trait   = $this->createTraitInstance();

--- a/tests/Unit/Http/Resources/Schema/FieldTest.php
+++ b/tests/Unit/Http/Resources/Schema/FieldTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Http\Resources\Schema;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Exceptions\DuplicateSchemaKeyException;
 use SineMacula\ApiToolkit\Http\Resources\Schema\Field;
 
 /**
@@ -264,7 +265,7 @@ class FieldTest extends TestCase
      */
     public function testSetThrowsOnDuplicateKeyFromSeparateDefinitions(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(DuplicateSchemaKeyException::class);
 
         Field::set(
             Field::scalar('name'),
@@ -279,7 +280,7 @@ class FieldTest extends TestCase
      */
     public function testSetThrowsOnDuplicateKeyFromArrayableAndScalar(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(DuplicateSchemaKeyException::class);
 
         Field::set(
             Field::scalar('email'),
@@ -312,7 +313,7 @@ class FieldTest extends TestCase
      */
     public function testSetExceptionMessageContainsDuplicateKeyName(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(DuplicateSchemaKeyException::class);
         $this->expectExceptionMessage('Duplicate schema key "title" detected in Field::set()');
 
         Field::set(

--- a/tests/Unit/Services/SchemaIntrospectorTest.php
+++ b/tests/Unit/Services/SchemaIntrospectorTest.php
@@ -360,15 +360,15 @@ class SchemaIntrospectorTest extends TestCase
             /** @var string|null */
             protected $table = 'users';
 
+            // phpcs:disable Squiz.Commenting.FunctionComment.MissingReturn
             /**
              * A method with no return type declaration.
-             *
-             * @return null
              */
-            public function tags()
+            public function tags() // @phpstan-ignore missingType.return
             {
-                return null;
+                return $this;
             }
+            // phpcs:enable Squiz.Commenting.FunctionComment.MissingReturn
         };
 
         $introspector = new SchemaIntrospector;
@@ -388,16 +388,17 @@ class SchemaIntrospectorTest extends TestCase
             /** @var string|null */
             protected $table = 'users';
 
+            // phpcs:disable Generic.Files.LineLength.TooLong
             /**
              * A method with a union return type containing relation types.
              *
-             * @return \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\MorphMany
+             * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Tests\Fixtures\Models\Post, $this>|\Illuminate\Database\Eloquent\Relations\MorphMany<\Illuminate\Database\Eloquent\Model, $this>
              */
-            // @phpstan-ignore-next-line return.unusedType, missingType.generics (the union return type is the reflection subject under test)
-            public function tags(): HasMany|MorphMany
+            public function tags(): HasMany|MorphMany // @phpstan-ignore return.unusedType
             {
                 return $this->hasMany(Post::class);
             }
+            // phpcs:enable Generic.Files.LineLength.TooLong
         };
 
         $introspector = new SchemaIntrospector;
@@ -420,10 +421,9 @@ class SchemaIntrospectorTest extends TestCase
             /**
              * A method with a union return type containing no relation types.
              *
-             * @return string|int
+             * @return int|string
              */
-            // @phpstan-ignore-next-line return.unusedType (the non-relation union return type is the reflection subject under test)
-            public function tags(): string|int
+            public function tags(): int|string // @phpstan-ignore return.unusedType (the non-relation union return type is the reflection subject under test)
             {
                 return '';
             }
@@ -640,6 +640,7 @@ class SchemaIntrospectorTest extends TestCase
             /** @var string|null */
             protected $table = 'users';
 
+            // phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn
             /**
              * A relation method that throws a LogicException.
              *
@@ -649,6 +650,7 @@ class SchemaIntrospectorTest extends TestCase
             {
                 throw new \LogicException('Test logic failure');
             }
+            // phpcs:enable Squiz.Commenting.FunctionComment.InvalidNoReturn
         };
 
         Log::shouldReceive('warning')
@@ -672,6 +674,7 @@ class SchemaIntrospectorTest extends TestCase
             /** @var string|null */
             protected $table = 'users';
 
+            // phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn
             /**
              * A relation method that throws a ReflectionException.
              *
@@ -681,6 +684,7 @@ class SchemaIntrospectorTest extends TestCase
             {
                 throw new \ReflectionException('Test reflection failure');
             }
+            // phpcs:enable Squiz.Commenting.FunctionComment.InvalidNoReturn
         };
 
         Log::shouldReceive('warning')
@@ -704,6 +708,7 @@ class SchemaIntrospectorTest extends TestCase
             /** @var string|null */
             protected $table = 'users';
 
+            // phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn
             /**
              * A relation method that throws a RuntimeException.
              *
@@ -713,6 +718,7 @@ class SchemaIntrospectorTest extends TestCase
             {
                 throw new \RuntimeException('Unexpected failure');
             }
+            // phpcs:enable Squiz.Commenting.FunctionComment.InvalidNoReturn
         };
 
         $this->expectException(\RuntimeException::class);

--- a/tests/Unit/Services/Validation/Rules/ValidateRelationMethodsTest.php
+++ b/tests/Unit/Services/Validation/Rules/ValidateRelationMethodsTest.php
@@ -278,14 +278,18 @@ class ValidateRelationMethodsTest extends TestCase
     public function testReportsFieldRelationMethodWithoutReturnTypeHint(): void
     {
         $model = new class extends Model {
-            /** @return mixed */
-            public function items()
+            // phpcs:disable Squiz.Commenting.FunctionComment.MissingReturn
+            /**
+             * A relation method with no return type declaration.
+             */
+            public function items() // @phpstan-ignore missingType.return
             {
-                return null;
+                return $this;
             }
+            // phpcs:enable Squiz.Commenting.FunctionComment.MissingReturn
         };
 
-        $modelClass = get_class($model);
+        $modelClass = $model::class;
 
         $schema = new CompiledSchema(
             fields: [
@@ -327,7 +331,7 @@ class ValidateRelationMethodsTest extends TestCase
                 return '';
             }
         };
-        $modelClass = get_class($model);
+        $modelClass = $model::class;
 
         $schema = new CompiledSchema(
             fields: [
@@ -362,16 +366,17 @@ class ValidateRelationMethodsTest extends TestCase
     public function testPassesFieldRelationMethodWithUnionTypeContainingRelation(): void
     {
         $model = new class extends Model {
+            // phpcs:disable Generic.Files.LineLength.TooLong
             /**
-             * @return \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\MorphMany
+             * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Tests\Fixtures\Models\User, $this>|\Illuminate\Database\Eloquent\Relations\MorphMany<\Illuminate\Database\Eloquent\Model, $this>
              */
-            // @phpstan-ignore-next-line return.unusedType, missingType.generics (the union return type is the validation subject under test)
-            public function items(): HasMany|MorphMany
+            public function items(): HasMany|MorphMany // @phpstan-ignore return.unusedType
             {
-                return $this->hasMany(self::class);
+                return $this->hasMany(User::class);
             }
+            // phpcs:enable Generic.Files.LineLength.TooLong
         };
-        $modelClass = get_class($model);
+        $modelClass = $model::class;
 
         $schema = new CompiledSchema(
             fields: [
@@ -406,15 +411,14 @@ class ValidateRelationMethodsTest extends TestCase
     {
         $model = new class extends Model {
             /**
-             * @return string|int
+             * @return int|string
              */
-            // @phpstan-ignore-next-line return.unusedType (the non-relation union return type is the validation subject under test)
-            public function items(): string|int
+            public function items(): int|string // @phpstan-ignore return.unusedType (the non-relation union return type is the validation subject under test)
             {
                 return '';
             }
         };
-        $modelClass = get_class($model);
+        $modelClass = $model::class;
 
         $schema = new CompiledSchema(
             fields: [
@@ -448,14 +452,18 @@ class ValidateRelationMethodsTest extends TestCase
     public function testReportsCountDefinitionRelationMethodWithoutReturnTypeHint(): void
     {
         $model = new class extends Model {
-            /** @return mixed */
-            public function items()
+            // phpcs:disable Squiz.Commenting.FunctionComment.MissingReturn
+            /**
+             * A relation method with no return type declaration.
+             */
+            public function items() // @phpstan-ignore missingType.return
             {
-                return null;
+                return $this;
             }
+            // phpcs:enable Squiz.Commenting.FunctionComment.MissingReturn
         };
 
-        $modelClass = get_class($model);
+        $modelClass = $model::class;
 
         $schema = new CompiledSchema(
             fields: [],
@@ -496,7 +504,7 @@ class ValidateRelationMethodsTest extends TestCase
             }
         };
 
-        $modelClass = get_class($model);
+        $modelClass = $model::class;
 
         $schema = new CompiledSchema(
             fields: [],

--- a/tests/Unit/Traits/LockableTest.php
+++ b/tests/Unit/Traits/LockableTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Traits;
 use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Exceptions\LockOperationException;
 use SineMacula\ApiToolkit\Exceptions\TooManyRequestsException;
 use SineMacula\ApiToolkit\Traits\Lockable;
 use Tests\Fixtures\Traits\StandaloneLockableFixture;
@@ -148,18 +149,18 @@ class LockableTest extends TestCase
     }
 
     /**
-     * Test that lock throws RuntimeException when no LockKeyProvider is
+     * Test that lock throws LockOperationException when no LockKeyProvider is
      * implemented.
      *
      * @return void
      */
-    public function testLockThrowsRuntimeExceptionWhenNoLockKeyProviderImplemented(): void
+    public function testLockThrowsLockOperationExceptionWhenNoLockKeyProviderImplemented(): void
     {
         $consumer = new class {
             use Lockable;
         };
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LockOperationException::class);
         $this->expectExceptionMessage('LockKeyProvider');
 
         $consumer->lock();


### PR DESCRIPTION
## Summary

Clears the last S1448 architecture finding (stacked on #245). `ApiServiceProvider` goes from 27 methods to 6, with the registration blocks extracted into dedicated `final` registrars under `Providers\Registrars`:

- **`RequestMacroRegistrar`** — the deprecated trashed/export/stream macros
- **`MiddlewareRegistrar`** — parser, maintenance swap, detect-capabilities, json-pretty-print, throttle alias
- **`LoggingRegistrar`** — CloudWatch driver + notification logging listeners
- **`LifecycleRegistrar`** — write-pool flush, Octane, and queue subscribers
- **`ContainerBindingRegistrar`** — the seven singleton/scoped bindings

`loadTranslationFiles`/`offerPublishing` (ServiceProvider-API-bound) and `registerMorphMap`/`validateSchemas` (small boot-time concerns) deliberately stay on the provider.

## Compatibility

Zero behaviour change: registration order, config keys, and container-resolution timing preserved exactly; no new public API. The extensive `ApiServiceProviderTest` behavioural suite passes untouched apart from `#[CoversClass]` retargets (required so coverage attribution follows the moved code); each registrar gained a thin direct-invocation test.

## Verification

- 1514 tests / 3042 assertions green, including random-order
- phpstan: zero errors (src + tests, trait contexts included)
- Mutation gate: exit 0 — 2065 mutants, MSI 96%, escaped count identical to the pre-refactor baseline
- **`qlty check src/`: No issues — zero radarlint findings remain anywhere in src**