### PR TITLE
refactor: deduplicate operators, registrar, and validation rules

### DIFF
--- a/src/Providers/Registrars/MiddlewareRegistrar.php
+++ b/src/Providers/Registrars/MiddlewareRegistrar.php
@@ -56,8 +56,8 @@ final class MiddlewareRegistrar
         }
 
         $this->registerMaintenanceModeMiddleware($kernel);
-        $this->registerDetectsCapabilitiesMiddleware($kernel);
-        $this->registerJsonPrettyPrintMiddleware($kernel);
+        $this->registerScopedMiddleware($kernel, 'api-toolkit.middleware.detect_capabilities', DetectsCapabilities::class);
+        $this->registerScopedMiddleware($kernel, 'api-toolkit.middleware.json_pretty_print', JsonPrettyPrint::class);
         $this->registerThrottleMiddleware($router);
     }
 
@@ -82,57 +82,31 @@ final class MiddlewareRegistrar
     }
 
     /**
-     * Register the DetectsCapabilities middleware.
-     *
-     * When scope is 'global', the middleware is pushed to the global stack.
-     * When scope is 'api', it is appended to the 'api' middleware group.
-     * Capabilities still resolve lazily on first access when the middleware
-     * is not registered; registration simply precomputes them per request.
-     *
-     * @param  \Illuminate\Foundation\Http\Kernel  $kernel
-     * @return void
-     */
-    private function registerDetectsCapabilitiesMiddleware(HttpKernel $kernel): void
-    {
-        if (!Config::get('api-toolkit.middleware.detect_capabilities.enabled', true)) {
-            return;
-        }
-
-        $scope = Config::get('api-toolkit.middleware.detect_capabilities.scope', 'global');
-
-        if ($scope === 'api') {
-            $kernel->appendMiddlewareToGroup('api', DetectsCapabilities::class);
-
-            return;
-        }
-
-        $kernel->pushMiddleware(DetectsCapabilities::class);
-    }
-
-    /**
-     * Register the JsonPrettyPrint middleware.
+     * Register a middleware honouring its enabled gate and configured scope.
      *
      * When scope is 'global', the middleware is pushed to the global stack.
      * When scope is 'api', it is appended to the 'api' middleware group.
      *
      * @param  \Illuminate\Foundation\Http\Kernel  $kernel
+     * @param  string  $config
+     * @param  class-string  $middleware
      * @return void
      */
-    private function registerJsonPrettyPrintMiddleware(HttpKernel $kernel): void
+    private function registerScopedMiddleware(HttpKernel $kernel, string $config, string $middleware): void
     {
-        if (!Config::get('api-toolkit.middleware.json_pretty_print.enabled', true)) {
+        if (!Config::get($config . '.enabled', true)) {
             return;
         }
 
-        $scope = Config::get('api-toolkit.middleware.json_pretty_print.scope', 'global');
+        $scope = Config::get($config . '.scope', 'global');
 
         if ($scope === 'api') {
-            $kernel->appendMiddlewareToGroup('api', JsonPrettyPrint::class);
+            $kernel->appendMiddlewareToGroup('api', $middleware);
 
             return;
         }
 
-        $kernel->pushMiddleware(JsonPrettyPrint::class);
+        $kernel->pushMiddleware($middleware);
     }
 
     /**

--- a/src/Repositories/Criteria/Operators/ComparisonOperator.php
+++ b/src/Repositories/Criteria/Operators/ComparisonOperator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
+
+use Illuminate\Database\Eloquent\Builder;
+use SineMacula\ApiToolkit\Contracts\FilterOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
+
+/**
+ * Base handler for binary comparison filter operators.
+ *
+ * Applies a single comparison constraint to the query builder using the SQL
+ * operator symbol declared by the concrete subclass, honouring the logical
+ * operator of the current filter context.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+abstract class ComparisonOperator implements FilterOperator
+{
+    /**
+     * Apply the comparison constraint to the query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
+     * @return void
+     */
+    #[\Override]
+    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    {
+        $boolean = $context->getLogicalOperator() === '$or' ? 'or' : 'and';
+
+        $query->getQuery()->where($column, $this->operator(), $value, $boolean);
+    }
+
+    /**
+     * Return the SQL comparison operator symbol.
+     *
+     * @return string
+     */
+    abstract protected function operator(): string;
+}

--- a/src/Repositories/Criteria/Operators/EqualOperator.php
+++ b/src/Repositories/Criteria/Operators/EqualOperator.php
@@ -2,32 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Handler for the $eq filter operator.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class EqualOperator implements FilterOperator
+final class EqualOperator extends ComparisonOperator
 {
     /**
-     * Apply the equality constraint to the query builder.
+     * Return the SQL comparison operator symbol.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return string
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function operator(): string
     {
-        $method = $context->getLogicalOperator() === '$or' ? 'orWhere' : 'where';
-
-        $query->{$method}($column, '=', $value); // @phpstan-ignore method.dynamicName
+        return '=';
     }
 }

--- a/src/Repositories/Criteria/Operators/GreaterThanOperator.php
+++ b/src/Repositories/Criteria/Operators/GreaterThanOperator.php
@@ -2,32 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Handler for the $gt filter operator.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class GreaterThanOperator implements FilterOperator
+final class GreaterThanOperator extends ComparisonOperator
 {
     /**
-     * Apply the greater-than constraint to the query builder.
+     * Return the SQL comparison operator symbol.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return string
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function operator(): string
     {
-        $method = $context->getLogicalOperator() === '$or' ? 'orWhere' : 'where';
-
-        $query->{$method}($column, '>', $value); // @phpstan-ignore method.dynamicName
+        return '>';
     }
 }

--- a/src/Repositories/Criteria/Operators/GreaterThanOrEqualOperator.php
+++ b/src/Repositories/Criteria/Operators/GreaterThanOrEqualOperator.php
@@ -2,34 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Filter operator handler for the $ge (greater than or equal) token.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class GreaterThanOrEqualOperator implements FilterOperator
+final class GreaterThanOrEqualOperator extends ComparisonOperator
 {
     /**
-     * Apply the greater than or equal constraint to the query builder.
+     * Return the SQL comparison operator symbol.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return string
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function operator(): string
     {
-        if ($context->getLogicalOperator() === '$or') {
-            $query->orWhere($column, '>=', $value);
-        } else {
-            $query->where($column, '>=', $value);
-        }
+        return '>=';
     }
 }

--- a/src/Repositories/Criteria/Operators/LessThanOperator.php
+++ b/src/Repositories/Criteria/Operators/LessThanOperator.php
@@ -2,34 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Filter operator handler for the $lt (less than) token.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class LessThanOperator implements FilterOperator
+final class LessThanOperator extends ComparisonOperator
 {
     /**
-     * Apply the less than constraint to the query builder.
+     * Return the SQL comparison operator symbol.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return string
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function operator(): string
     {
-        if ($context->getLogicalOperator() === '$or') {
-            $query->orWhere($column, '<', $value);
-        } else {
-            $query->where($column, '<', $value);
-        }
+        return '<';
     }
 }

--- a/src/Repositories/Criteria/Operators/LessThanOrEqualOperator.php
+++ b/src/Repositories/Criteria/Operators/LessThanOrEqualOperator.php
@@ -2,34 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Filter operator handler for the $le (less than or equal) token.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class LessThanOrEqualOperator implements FilterOperator
+final class LessThanOrEqualOperator extends ComparisonOperator
 {
     /**
-     * Apply the less than or equal constraint to the query builder.
+     * Return the SQL comparison operator symbol.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return string
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function operator(): string
     {
-        if ($context->getLogicalOperator() === '$or') {
-            $query->orWhere($column, '<=', $value);
-        } else {
-            $query->where($column, '<=', $value);
-        }
+        return '<=';
     }
 }

--- a/src/Repositories/Criteria/Operators/NotEqualOperator.php
+++ b/src/Repositories/Criteria/Operators/NotEqualOperator.php
@@ -2,32 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Handler for the $neq filter operator.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class NotEqualOperator implements FilterOperator
+final class NotEqualOperator extends ComparisonOperator
 {
     /**
-     * Apply the not-equal constraint to the query builder.
+     * Return the SQL comparison operator symbol.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return string
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function operator(): string
     {
-        $method = $context->getLogicalOperator() === '$or' ? 'orWhere' : 'where';
-
-        $query->{$method}($column, '<>', $value); // @phpstan-ignore method.dynamicName
+        return '<>';
     }
 }

--- a/src/Repositories/Criteria/Operators/NotNullOperator.php
+++ b/src/Repositories/Criteria/Operators/NotNullOperator.php
@@ -2,34 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Filter operator handler for the $notNull token.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class NotNullOperator implements FilterOperator
+final class NotNullOperator extends NullityOperator
 {
     /**
-     * Apply the not null constraint to the query builder.
+     * Return whether the constraint asserts the column is not null.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return bool
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function negated(): bool
     {
-        if ($context->getLogicalOperator() === '$or') {
-            $query->getQuery()->orWhereNotNull($column);
-        } else {
-            $query->getQuery()->whereNotNull($column);
-        }
+        return true;
     }
 }

--- a/src/Repositories/Criteria/Operators/NullOperator.php
+++ b/src/Repositories/Criteria/Operators/NullOperator.php
@@ -2,34 +2,22 @@
 
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
-use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\FilterOperator;
-use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
-
 /**
  * Filter operator handler for the $null token.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class NullOperator implements FilterOperator
+final class NullOperator extends NullityOperator
 {
     /**
-     * Apply the null constraint to the query builder.
+     * Return whether the constraint asserts the column is not null.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
-     * @param  string  $column
-     * @param  mixed  $value
-     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
-     * @return void
+     * @return bool
      */
     #[\Override]
-    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    protected function negated(): bool
     {
-        if ($context->getLogicalOperator() === '$or') {
-            $query->getQuery()->orWhereNull($column);
-        } else {
-            $query->getQuery()->whereNull($column);
-        }
+        return false;
     }
 }

--- a/src/Repositories/Criteria/Operators/NullityOperator.php
+++ b/src/Repositories/Criteria/Operators/NullityOperator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
+
+use Illuminate\Database\Eloquent\Builder;
+use SineMacula\ApiToolkit\Contracts\FilterOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
+
+/**
+ * Base handler for nullity filter operators.
+ *
+ * Applies a null or not-null constraint to the query builder depending on the
+ * negation declared by the concrete subclass, honouring the logical operator
+ * of the current filter context.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+abstract class NullityOperator implements FilterOperator
+{
+    /**
+     * Apply the nullity constraint to the query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
+     * @return void
+     */
+    #[\Override]
+    public function apply(Builder $query, string $column, mixed $value, FilterContext $context): void
+    {
+        $boolean = $context->getLogicalOperator() === '$or' ? 'or' : 'and';
+
+        $query->getQuery()->whereNull($column, $boolean, $this->negated());
+    }
+
+    /**
+     * Return whether the constraint asserts the column is not null.
+     *
+     * @return bool
+     */
+    abstract protected function negated(): bool;
+}

--- a/src/Services/Validation/Rules/ValidateGuards.php
+++ b/src/Services/Validation/Rules/ValidateGuards.php
@@ -2,9 +2,8 @@
 
 namespace SineMacula\ApiToolkit\Services\Validation\Rules;
 
-use SineMacula\ApiToolkit\Contracts\SchemaValidationRule;
+use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema;
-use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
 
 /**
  * Validate that all guard entries in the compiled schema are callable.
@@ -12,7 +11,7 @@ use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class ValidateGuards implements SchemaValidationRule
+final class ValidateGuards extends ValidatesCallableLists
 {
     /**
      * Validate the compiled schema for the given resource class.
@@ -25,42 +24,35 @@ final class ValidateGuards implements SchemaValidationRule
     #[\Override]
     public function validate(string $resourceClass, ?string $modelClass, CompiledSchema $schema): array
     {
-        $errors = [];
-
-        foreach ($schema->getFieldKeys() as $key) {
-
-            $field = $schema->getField($key);
-
-            if ($field === null) {
-                continue;
-            }
-
-            foreach ($field->guards as $i => $guard) {
-
-                if (!is_callable($guard)) { // @phpstan-ignore function.alreadyNarrowedType
-                    $errors[] = new SchemaValidationError(
-                        resourceClass: $resourceClass,
-                        fieldKey: $key,
-                        defect: sprintf('Guard at index %d is not callable', $i),
-                    );
-                }
-            }
-        }
+        $errors = parent::validate($resourceClass, $modelClass, $schema);
 
         foreach ($schema->getCountDefinitions() as $count) {
-
-            foreach ($count->guards as $i => $guard) {
-
-                if (!is_callable($guard)) { // @phpstan-ignore function.alreadyNarrowedType
-                    $errors[] = new SchemaValidationError(
-                        resourceClass: $resourceClass,
-                        fieldKey: $count->presentKey,
-                        defect: sprintf('Guard at index %d is not callable', $i),
-                    );
-                }
-            }
+            $errors = array_merge($errors, $this->collectCallableErrors($resourceClass, $count->presentKey, $count->guards));
         }
 
         return $errors;
+    }
+
+    /**
+     * Return the callable list to validate for the given field definition.
+     *
+     * @param  \SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition  $field
+     * @return array<int, callable(mixed, mixed): bool>
+     */
+    #[\Override]
+    protected function getCallables(CompiledFieldDefinition $field): array
+    {
+        return $field->guards;
+    }
+
+    /**
+     * Return the human-readable label used in defect messages.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected function getLabel(): string
+    {
+        return 'Guard';
     }
 }

--- a/src/Services/Validation/Rules/ValidateTransformers.php
+++ b/src/Services/Validation/Rules/ValidateTransformers.php
@@ -2,9 +2,7 @@
 
 namespace SineMacula\ApiToolkit\Services\Validation\Rules;
 
-use SineMacula\ApiToolkit\Contracts\SchemaValidationRule;
-use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema;
-use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
+use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition;
 
 /**
  * Validate that all transformer entries in the compiled schema are callable.
@@ -12,41 +10,28 @@ use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class ValidateTransformers implements SchemaValidationRule
+final class ValidateTransformers extends ValidatesCallableLists
 {
     /**
-     * Validate the compiled schema for the given resource class.
+     * Return the callable list to validate for the given field definition.
      *
-     * @param  string  $resourceClass
-     * @param  string|null  $modelClass
-     * @param  \SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema  $schema
-     * @return array<int, \SineMacula\ApiToolkit\Services\Validation\SchemaValidationError>
+     * @param  \SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition  $field
+     * @return array<int, callable(mixed, mixed): mixed>
      */
     #[\Override]
-    public function validate(string $resourceClass, ?string $modelClass, CompiledSchema $schema): array
+    protected function getCallables(CompiledFieldDefinition $field): array
     {
-        $errors = [];
+        return $field->transformers;
+    }
 
-        foreach ($schema->getFieldKeys() as $key) {
-
-            $field = $schema->getField($key);
-
-            if ($field === null) {
-                continue;
-            }
-
-            foreach ($field->transformers as $i => $transformer) {
-
-                if (!is_callable($transformer)) { // @phpstan-ignore function.alreadyNarrowedType
-                    $errors[] = new SchemaValidationError(
-                        resourceClass: $resourceClass,
-                        fieldKey: $key,
-                        defect: sprintf('Transformer at index %d is not callable', $i),
-                    );
-                }
-            }
-        }
-
-        return $errors;
+    /**
+     * Return the human-readable label used in defect messages.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected function getLabel(): string
+    {
+        return 'Transformer';
     }
 }

--- a/src/Services/Validation/Rules/ValidatesCallableLists.php
+++ b/src/Services/Validation/Rules/ValidatesCallableLists.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Services\Validation\Rules;
+
+use SineMacula\ApiToolkit\Contracts\SchemaValidationRule;
+use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition;
+use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema;
+use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
+
+/**
+ * Base rule for validating callable lists on compiled field definitions.
+ *
+ * Iterates the compiled fields and reports a validation error for every list
+ * entry that is not callable, using the callable list and label declared by
+ * the concrete subclass.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+abstract class ValidatesCallableLists implements SchemaValidationRule
+{
+    /**
+     * Validate the compiled schema for the given resource class.
+     *
+     * @param  string  $resourceClass
+     * @param  string|null  $modelClass
+     * @param  \SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema  $schema
+     * @return array<int, \SineMacula\ApiToolkit\Services\Validation\SchemaValidationError>
+     */
+    #[\Override]
+    public function validate(string $resourceClass, ?string $modelClass, CompiledSchema $schema): array
+    {
+        $errors = [];
+
+        foreach ($schema->getFieldKeys() as $key) {
+
+            $field = $schema->getField($key);
+
+            if ($field === null) {
+                continue;
+            }
+
+            $errors = array_merge($errors, $this->collectCallableErrors($resourceClass, $key, $this->getCallables($field)));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Return the callable list to validate for the given field definition.
+     *
+     * @param  \SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition  $field
+     * @return array<int, callable(mixed, mixed): mixed>
+     */
+    abstract protected function getCallables(CompiledFieldDefinition $field): array;
+
+    /**
+     * Return the human-readable label used in defect messages.
+     *
+     * @return string
+     */
+    abstract protected function getLabel(): string;
+
+    /**
+     * Collect validation errors for non-callable entries in the given list.
+     *
+     * @param  string  $resourceClass
+     * @param  string  $fieldKey
+     * @param  array<int, callable(mixed, mixed): mixed>  $callables
+     * @return array<int, \SineMacula\ApiToolkit\Services\Validation\SchemaValidationError>
+     */
+    protected function collectCallableErrors(string $resourceClass, string $fieldKey, array $callables): array
+    {
+        $errors = [];
+
+        foreach ($callables as $i => $callable) {
+
+            if (!is_callable($callable)) { // @phpstan-ignore function.alreadyNarrowedType
+                $errors[] = new SchemaValidationError(
+                    resourceClass: $resourceClass,
+                    fieldKey: $fieldKey,
+                    defect: sprintf('%s at index %d is not callable', $this->getLabel(), $i),
+                );
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
+++ b/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
@@ -22,6 +22,9 @@ use Tests\TestCase;
 #[CoversClass(DetectsCapabilities::class)]
 class DetectsCapabilitiesTest extends TestCase
 {
+    /** @var string */
+    private const string TEST_URL = '/test';
+
     /**
      * Test that the middleware stores capabilities on the request.
      *
@@ -30,7 +33,7 @@ class DetectsCapabilitiesTest extends TestCase
     public function testHandleStoresCapabilitiesOnRequest(): void
     {
         $middleware = new DetectsCapabilities;
-        $request    = Request::create('/test', 'GET', ['include_trashed' => 'true']);
+        $request    = Request::create(self::TEST_URL, 'GET', ['include_trashed' => 'true']);
 
         $middleware->handle($request, function (Request $request): Response {
 
@@ -51,7 +54,7 @@ class DetectsCapabilitiesTest extends TestCase
     public function testHandlePassesRequestToNextMiddleware(): void
     {
         $middleware       = new DetectsCapabilities;
-        $request          = Request::create('/test');
+        $request          = Request::create(self::TEST_URL);
         $expectedResponse = new Response('OK');
 
         $response = $middleware->handle($request, fn (): Response => $expectedResponse);
@@ -72,7 +75,7 @@ class DetectsCapabilitiesTest extends TestCase
 
         $middleware = new DetectsCapabilities;
 
-        $request = Request::create('/test', 'GET', ['include_trashed' => 'true']);
+        $request = Request::create(self::TEST_URL, 'GET', ['include_trashed' => 'true']);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_CSV->getMimeType());
 
         $middleware->handle($request, function (Request $request): Response {

--- a/tests/Unit/Http/RequestCapabilitiesTest.php
+++ b/tests/Unit/Http/RequestCapabilitiesTest.php
@@ -20,6 +20,9 @@ use Tests\TestCase;
 #[CoversClass(RequestCapabilities::class)]
 class RequestCapabilitiesTest extends TestCase
 {
+    /** @var string */
+    private const string TEST_URL = '/test';
+
     /**
      * Test that fromRequest returns the stored instance.
      *
@@ -27,7 +30,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testFromRequestReturnsStoredInstance(): void
     {
-        $request      = Request::create('/test');
+        $request      = Request::create(self::TEST_URL);
         $capabilities = $this->createCapabilities(include_trashed: true);
 
         RequestCapabilities::storeOnRequest($request, $capabilities);
@@ -45,7 +48,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testFromRequestResolvesLazilyWhenAttributeNotSet(): void
     {
-        $request      = Request::create('/test');
+        $request      = Request::create(self::TEST_URL);
         $capabilities = RequestCapabilities::fromRequest($request);
 
         static::assertFalse($capabilities->includeTrashed());
@@ -65,7 +68,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testFromRequestResolvesFromRequestStateAndCaches(): void
     {
-        $request = Request::create('/test', 'GET', ['include_trashed' => 'true']);
+        $request = Request::create(self::TEST_URL, 'GET', ['include_trashed' => 'true']);
 
         $capabilities = RequestCapabilities::fromRequest($request);
 
@@ -80,7 +83,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testResolveDetectsIncludeTrashed(): void
     {
-        $request      = Request::create('/test', 'GET', ['include_trashed' => 'true']);
+        $request      = Request::create(self::TEST_URL, 'GET', ['include_trashed' => 'true']);
         $capabilities = RequestCapabilities::resolve($request);
 
         static::assertTrue($capabilities->includeTrashed());
@@ -94,7 +97,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testResolveDetectsOnlyTrashed(): void
     {
-        $request      = Request::create('/test', 'GET', ['only_trashed' => 'true']);
+        $request      = Request::create(self::TEST_URL, 'GET', ['only_trashed' => 'true']);
         $capabilities = RequestCapabilities::resolve($request);
 
         static::assertTrue($capabilities->onlyTrashed());
@@ -112,7 +115,7 @@ class RequestCapabilitiesTest extends TestCase
         config()->set('api-toolkit.exports.enabled', true);
         config()->set('api-toolkit.exports.supported_formats', ['csv', 'xml']);
 
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_CSV->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -132,7 +135,7 @@ class RequestCapabilitiesTest extends TestCase
         config()->set('api-toolkit.exports.enabled', true);
         config()->set('api-toolkit.exports.supported_formats', ['csv', 'xml']);
 
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::APPLICATION_XML->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -152,7 +155,7 @@ class RequestCapabilitiesTest extends TestCase
         config()->set('api-toolkit.exports.enabled', true);
         config()->set('api-toolkit.exports.supported_formats', ['csv']);
 
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_CSV->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -167,7 +170,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testResolveDetectsExpectsPdf(): void
     {
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::APPLICATION_PDF->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -182,7 +185,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testResolveDetectsExpectsStream(): void
     {
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_EVENT_STREAM->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -201,7 +204,7 @@ class RequestCapabilitiesTest extends TestCase
         config()->set('api-toolkit.exports.enabled', true);
         config()->set('api-toolkit.exports.supported_formats', ['csv']);
 
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), 'TEXT/CSV');
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -217,7 +220,7 @@ class RequestCapabilitiesTest extends TestCase
      */
     public function testStoreOnRequestSetsAttribute(): void
     {
-        $request      = Request::create('/test');
+        $request      = Request::create(self::TEST_URL);
         $capabilities = $this->createCapabilities(expects_pdf: true);
 
         RequestCapabilities::storeOnRequest($request, $capabilities);
@@ -239,7 +242,7 @@ class RequestCapabilitiesTest extends TestCase
         config()->set('api-toolkit.exports.enabled', true);
         config()->set('api-toolkit.exports.supported_formats', ['xml']);
 
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_CSV->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);
@@ -258,7 +261,7 @@ class RequestCapabilitiesTest extends TestCase
         config()->set('api-toolkit.exports.enabled', false);
         config()->set('api-toolkit.exports.supported_formats', ['csv', 'xml']);
 
-        $request = Request::create('/test');
+        $request = Request::create(self::TEST_URL);
         $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_CSV->getMimeType());
 
         $capabilities = RequestCapabilities::resolve($request);


### PR DESCRIPTION
## Summary

Closes out the `composer smells` review across the whole stack (stacked on #246). Every similar-code finding in src is now resolved:

- **`ComparisonOperator` base** — the six comparison operators (`=`, `<>`, `>`, `>=`, `<`, `<=`) declare only their symbol; the base routes through `where($column, $op, $value, $boolean)`, verified byte-identical SQL (`wheres` type/column/operator/value/boolean and bindings) against the vendor delegation chain. Also removes the residual `method.dynamicName` ignores.
- **`NullityOperator` base** — `NullOperator`/`NotNullOperator` declare only negation; `whereNull($column, $boolean, $not)` is the vendor-verified equivalent of all four where/orWhere null variants.
- **`MiddlewareRegistrar`** — the two identical enabled-gate + global/api-scope blocks collapse into one `registerScopedMiddleware()` helper (config keys, defaults, and registration order untouched).
- **`ValidatesCallableLists` base** — shared iteration/validation for `ValidateGuards`/`ValidateTransformers`, error messages byte-identical (asserted by existing tests, which pass unmodified).
- Test literal duplication (`"/test"`) replaced with the established `TEST_URL` constant pattern.

## Accepted findings (documented, not "fixed")

The remaining `function-parameters` findings are all constructor property promotion on value objects (`RequestCapabilities`, `CompiledFieldDefinition`, `ServiceResult`, `FilterContext`, etc.) — the "parameters" are the typed properties themselves; replacing them with arrays/builders would trade away type safety for a metric. The reflection-in-tests S3011 comments are the established `ReflectionProperty` state-assertion pattern used throughout the suite.

## Verification

- 1514 tests / 3042 assertions green, including random-order; operator and FilterApplier suites pass **unmodified**
- phpstan: zero errors; `composer format` stable; `qlty check src/`: No issues
- `composer smells -- --all`: **zero similar-code findings**
- Mutation gate: exit 0, MSI 96%