### PR TITLE
test: harden per-query cache mutation coverage to restore the 95% gate

### DIFF
--- a/tests/Fixtures/Repositories/TunedCacheableTagRepository.php
+++ b/tests/Fixtures/Repositories/TunedCacheableTagRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Fixtures\Repositories;
+
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\ApiToolkit\Repositories\Concerns\Cacheable;
+use Tests\Fixtures\Models\Tag;
+
+/**
+ * Fixture cacheable tag repository that overrides every cache tuning property,
+ * so the property-over-config precedence can be asserted.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @extends \SineMacula\ApiToolkit\Repositories\ApiRepository<\Tests\Fixtures\Models\Tag>
+ */
+class TunedCacheableTagRepository extends ApiRepository
+{
+    use Cacheable;
+
+    /** @var int Per-query cache duration in seconds. */
+    protected int $cacheTtl = 120;
+
+    /** @var int Reference-mode cache duration in seconds. */
+    protected int $cacheReferenceTtl = 240;
+
+    /** @var int The maximum cacheable row count. */
+    protected int $cacheMaxRows = 50;
+
+    /** @var int The maximum cacheable serialized byte size. */
+    protected int $cacheMaxBytes = 2048;
+
+    /** @var bool Whether the non-taggable key registry is enabled. */
+    protected bool $cacheRegistryEnabled = false;
+
+    /**
+     * Return the model class.
+     *
+     * @return class-string<\Tests\Fixtures\Models\Tag>
+     */
+    public function model(): string
+    {
+        return Tag::class;
+    }
+}

--- a/tests/Unit/Repositories/Concerns/CacheSizeGuardTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheSizeGuardTest.php
@@ -76,4 +76,31 @@ class CacheSizeGuardTest extends TestCase
 
         static::assertTrue($guard->allows(str_repeat('x', 100000), 1));
     }
+
+    /**
+     * Test that a result whose row count exactly equals the ceiling is
+     * allowed, pinning the bound as exclusive rather than inclusive.
+     *
+     * @return void
+     */
+    public function testRowCountEqualToCeilingIsAllowed(): void
+    {
+        $guard = new CacheSizeGuard(5, 262144);
+
+        static::assertTrue($guard->allows(collect(['a']), 5));
+    }
+
+    /**
+     * Test that a result whose serialized size exactly equals the byte ceiling
+     * is allowed, pinning the bound as exclusive rather than inclusive.
+     *
+     * @return void
+     */
+    public function testByteSizeEqualToCeilingIsAllowed(): void
+    {
+        $result = collect(['a', 'b']);
+        $guard  = new CacheSizeGuard(1000, strlen(serialize($result)));
+
+        static::assertTrue($guard->allows($result, 2));
+    }
 }

--- a/tests/Unit/Repositories/Concerns/CacheStoreTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheStoreTest.php
@@ -286,4 +286,44 @@ class CacheStoreTest extends TestCase
     {
         static::assertInstanceOf(CacheContract::class, $this->cacheStore->getStore());
     }
+
+    /**
+     * Test that a taggable store flushes through its tag even when the key
+     * registry is disabled, proving the tag path is selected for taggable
+     * stores rather than the registry.
+     *
+     * @return void
+     */
+    public function testTaggableStoreFlushesViaTagsWhenRegistryDisabled(): void
+    {
+        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), false));
+
+        $store->put(self::HASH, collect(['item']), 1);
+
+        static::assertNotNull($store->get(self::HASH));
+
+        $store->flushTable();
+
+        static::assertNull($store->get(self::HASH));
+    }
+
+    /**
+     * Test that the per-table tag isolates entries between tables, so flushing
+     * one table never invalidates another table's cached entries.
+     *
+     * @return void
+     */
+    public function testTagIsolatesEntriesBetweenTables(): void
+    {
+        $tableA = new CacheStore('array', 'table-a', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
+        $tableB = new CacheStore('array', 'table-b', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
+
+        $tableA->put(self::HASH, collect(['a']), 1);
+        $tableB->put(self::HASH, collect(['b']), 1);
+
+        $tableA->flushTable();
+
+        static::assertNull($tableA->get(self::HASH));
+        static::assertNotNull($tableB->get(self::HASH));
+    }
 }

--- a/tests/Unit/Repositories/Concerns/CacheableTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheableTest.php
@@ -8,11 +8,14 @@ use PHPUnit\Framework\Attributes\CoversTrait;
 use SineMacula\ApiToolkit\Repositories\ApiRepository;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
 use SineMacula\ApiToolkit\Repositories\Concerns\Cacheable;
+use SineMacula\ApiToolkit\Repositories\Concerns\CacheSizeGuard;
+use SineMacula\ApiToolkit\Repositories\Concerns\CacheStoreOptions;
 use Tests\Fixtures\Models\Tag;
 use Tests\Fixtures\Repositories\CacheableTagRepository;
 use Tests\Fixtures\Repositories\CustomPrefixCacheableTagRepository;
 use Tests\Fixtures\Repositories\CustomStoreCacheableTagRepository;
 use Tests\Fixtures\Repositories\ShortTtlTagRepository;
+use Tests\Fixtures\Repositories\TunedCacheableTagRepository;
 use Tests\TestCase;
 
 /**
@@ -410,5 +413,66 @@ class CacheableTest extends TestCase
         $found = $this->repository->scopeById($created?->id)->first(); // @phpstan-ignore staticMethod.dynamicCall, property.notFound
 
         static::assertInstanceOf(Tag::class, $found);
+    }
+
+    /**
+     * Test that the row count used by the size guard is the collection size for
+     * a collection, exactly one for a single model, and zero otherwise.
+     *
+     * @return void
+     */
+    public function testRowCountReflectsResultShape(): void
+    {
+        $rowCount = new \ReflectionMethod($this->repository, 'rowCount');
+
+        static::assertSame(2, $rowCount->invoke($this->repository, new Collection(['a', 'b'])));
+        static::assertSame(1, $rowCount->invoke($this->repository, new Tag));
+        static::assertSame(0, $rowCount->invoke($this->repository, 'not-a-model'));
+        static::assertSame(0, $rowCount->invoke($this->repository, null));
+    }
+
+    /**
+     * Test that the reference-mode key argument is taken from the first
+     * argument, defaults to zero, and preserves integer and string keys while
+     * casting any other type to a string.
+     *
+     * @return void
+     */
+    public function testReferenceIdResolvesPrimaryKeyArgument(): void
+    {
+        $referenceId = new \ReflectionMethod($this->repository, 'referenceId');
+
+        static::assertSame(5, $referenceId->invoke($this->repository, [5, 99]));
+        static::assertSame('php', $referenceId->invoke($this->repository, ['php']));
+        static::assertSame(0, $referenceId->invoke($this->repository, []));
+        static::assertSame('1.5', $referenceId->invoke($this->repository, [1.5]));
+    }
+
+    /**
+     * Test that the repository's cache tuning properties take precedence over
+     * the package configuration when resolving the store options.
+     *
+     * @return void
+     */
+    public function testTuningPropertiesTakePrecedenceOverConfig(): void
+    {
+        assert($this->app !== null);
+
+        $repository = $this->app->make(TunedCacheableTagRepository::class);
+
+        $resolveTtl          = new \ReflectionMethod($repository, 'resolveTtl');
+        $resolveReferenceTtl = new \ReflectionMethod($repository, 'resolveReferenceTtl');
+        $resolveStoreOptions = new \ReflectionMethod($repository, 'resolveStoreOptions');
+
+        static::assertSame(120, $resolveTtl->invoke($repository));
+        static::assertSame(240, $resolveReferenceTtl->invoke($repository));
+
+        $options = $resolveStoreOptions->invoke($repository);
+
+        static::assertInstanceOf(CacheStoreOptions::class, $options);
+        static::assertSame(120, $options->ttl);
+        static::assertFalse($options->registryEnabled);
+        static::assertSame(50, (new \ReflectionProperty(CacheSizeGuard::class, 'maxRows'))->getValue($options->sizeGuard));
+        static::assertSame(2048, (new \ReflectionProperty(CacheSizeGuard::class, 'maxBytes'))->getValue($options->sizeGuard));
     }
 }

--- a/tests/Unit/Repositories/Concerns/QueryFingerprintTest.php
+++ b/tests/Unit/Repositories/Concerns/QueryFingerprintTest.php
@@ -60,6 +60,21 @@ class QueryFingerprintTest extends TestCase
     }
 
     /**
+     * Test that two queries with identical bindings but differing SQL yield
+     * distinct fingerprints, proving the compiled SQL is part of the digest
+     * independently of the bindings.
+     *
+     * @return void
+     */
+    public function testSameBindingsDifferentSqlYieldDistinctFingerprint(): void
+    {
+        $equals    = QueryFingerprint::for(Tag::query()->where('name', 'php'));
+        $notEquals = QueryFingerprint::for(Tag::query()->where('name', '!=', 'php'));
+
+        static::assertNotSame($equals, $notEquals);
+    }
+
+    /**
      * Test that a Carbon binding produces a stable fingerprint across
      * equivalent instances.
      *

--- a/tests/Unit/Repositories/Concerns/ReferenceCacheTest.php
+++ b/tests/Unit/Repositories/Concerns/ReferenceCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Repositories\Concerns;
 
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -33,10 +34,25 @@ class ReferenceCacheTest extends TestCase
     {
         parent::setUp();
 
+        Carbon::setTestNow(Carbon::parse('2026-03-09 12:00:00'));
+
         Tag::create(['name' => 'php']);
         Tag::create(['name' => 'laravel']);
 
         $this->referenceCache = new ReferenceCache('array', 'tags', 3600);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
     }
 
     /**
@@ -132,5 +148,54 @@ class ReferenceCacheTest extends TestCase
         $this->referenceCache->all(new Tag);
 
         static::assertTrue($this->referenceCache->getStatus()->isPopulated());
+    }
+
+    /**
+     * Test that the snapshot and metadata cache keys are scoped to the table,
+     * so two reference caches for different tables never collide.
+     *
+     * @return void
+     */
+    public function testCacheKeysAreScopedToTable(): void
+    {
+        $this->referenceCache->all(new Tag);
+
+        static::assertTrue($this->referenceCache->getStore()->has('api-toolkit:repository-cache:tags'));
+        static::assertTrue($this->referenceCache->getStore()->has('api-toolkit:repository-cache-meta:tags'));
+    }
+
+    /**
+     * Test that loading the table records the populated_at timestamp in the
+     * reference metadata.
+     *
+     * @return void
+     */
+    public function testLoadRecordsPopulatedAtMetadata(): void
+    {
+        $this->referenceCache->all(new Tag);
+
+        $meta = $this->referenceCache->getStore()->get('api-toolkit:repository-cache-meta:tags');
+
+        static::assertIsArray($meta);
+        static::assertArrayHasKey('populated_at', $meta);
+        static::assertSame(now()->timestamp, $meta['populated_at']);
+    }
+
+    /**
+     * Test that a flush records the invalidated_at timestamp in the reference
+     * metadata.
+     *
+     * @return void
+     */
+    public function testFlushRecordsInvalidatedAtMetadata(): void
+    {
+        $this->referenceCache->all(new Tag);
+        $this->referenceCache->flush();
+
+        $meta = $this->referenceCache->getStore()->get('api-toolkit:repository-cache-meta:tags');
+
+        static::assertIsArray($meta);
+        static::assertArrayHasKey('invalidated_at', $meta);
+        static::assertSame(now()->timestamp, $meta['invalidated_at']);
     }
 }


### PR DESCRIPTION
## Why

Merging **#249** (per-query repository caching) left `2.x` **below the 95% mutation gate** — `94%` covered MSI with **119 escaped mutants**. The escaped mutants are concentrated in the new cache collaborators: #249's `PerQueryCacheTest` integration test widened coverage over lines that the unit tests never asserted on, turning previously-uncounted mutants into *covered-but-not-killed* ones.

This is why the gate now fails on every branch that has merged #249 (notably #250), even though #249 itself flaky-passed at merge time. This PR closes the gap at the source so `2.x` — and every PR that rebases onto it — sits comfortably above the gate.

## What

Targeted, behaviour-level tests that kill the surviving cache-code mutants:

| Collaborator | Gap closed |
|---|---|
| `CacheSizeGuard` | Exact `==` boundary cases pin the row/byte ceilings as **exclusive** (`>`, not `>=`). |
| `Cacheable` | Reflection tests on `rowCount` and `referenceId`; a tuned fixture proving cache tuning **properties take precedence over config** (`?? Config::get`). |
| `ReferenceCache` | Table-scoped cache keys; `populated_at` / `invalidated_at` metadata written on load and flush. |
| `CacheStore` | Tag path is selected for taggable stores **even with the registry disabled**; the per-table tag **isolates entries between tables**. |
| `QueryFingerprint` | Compiled SQL contributes to the digest **independently of the bindings**. |

No production code changes — tests and one fixture only.

## Result

- Covered MSI **94% → 95.87%** (2088/2178 mutants detected; 90 escaped, down from 119).
- `qlty check` clean (style, PHPStan level 8, naming).
- The remaining escaped mutants are genuine equivalents (e.g. `Config::get(key, DEFAULT)` defaults where the key is always set; visited-map flags only ever read as keys).

## Merge order

Should merge **before #250** — #250 rebases onto this and inherits the restored margin (it will still want a small follow-up for its own writepool coverage).