### PR TITLE
feat: RESTful route convention linter (api-toolkit:lint-routes)

### DIFF
--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -486,8 +486,12 @@ return [
     |
     | `exemptions`: Per-route exemption allowlist — ships EMPTY. Each entry
     | waives one route and MUST carry a non-empty written reason. Entries are
-    | keyed by route name or URI pattern. Example:
-    |   ['match' => 'legacy.export', 'reason' => 'BL-123 frozen contract'].
+    | keyed by route name or URI pattern. The optional `rules` key restricts the
+    | waiver to specific rule IDs (omit or set to [] to waive all rules). Example:
+    |   ['match' => 'legacy.export', 'reason' => 'BL-123 frozen contract',
+    |    'rules' => ['R1', 'R2']].
+    | Routes can also be waived inline at registration via the `ignoreRouteLint`
+    | macro: `->ignoreRouteLint(['R9'], 'reason')` (co-located with the route).
     |
     | `uncountables`: Nouns honoured by the plural-collections rule (R4) and
     | the verb-rule singularisation step. Words in this list are never

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -468,4 +468,79 @@ return [
 
     ],
 
+    /*
+    |---------------------------------------------------------------------------
+    | RESTful Route Linter Configuration
+    |---------------------------------------------------------------------------
+    |
+    | This section configures the opt-in RESTful route convention linter, which
+    | is invoked explicitly via the `api-toolkit:lint-routes` Artisan command
+    | and never runs as part of normal request handling.
+    |
+    | `verb_denylist`: Action verbs that flag a URI path segment. This list is
+    | tunable — add or remove words to control which segments trigger rule R1.
+    | Removing a word is rule tuning (not a per-route exemption).
+    |
+    | `remediation_hints`: Per-verb RESTful rewrite hints surfaced alongside
+    | each verb violation, keyed by the denylisted verb string.
+    |
+    | `exemptions`: Per-route exemption allowlist — ships EMPTY. Each entry
+    | waives one route and MUST carry a non-empty written reason. Entries are
+    | keyed by route name or URI pattern. Example:
+    |   ['match' => 'legacy.export', 'reason' => 'BL-123 frozen contract'].
+    |
+    | `uncountables`: Nouns honoured by the plural-collections rule (R4) and
+    | the verb-rule singularisation step. Words in this list are never
+    | mis-singularised or incorrectly flagged as singular collections.
+    |
+    */
+
+    'route_linting' => [
+
+        'verb_denylist' => [
+            'get', 'create', 'update', 'delete', 'edit', 'store', 'fetch', 'list',
+            'show', 'cancel', 'activate', 'deactivate', 'login', 'logout', 'register',
+            'search', 'add', 'remove', 'check', 'process', 'submit', 'send', 'transfer',
+            'download', 'upload', 'import', 'export', 'validate', 'generate', 'refresh',
+        ],
+
+        'remediation_hints' => [
+            'login'      => 'POST /sessions',
+            'logout'     => 'DELETE /sessions/{session}',
+            'register'   => 'POST /users',
+            'get'        => 'GET /{resources}',
+            'list'       => 'GET /{resources}',
+            'fetch'      => 'GET /{resources}/{resource}',
+            'show'       => 'GET /{resources}/{resource}',
+            'create'     => 'POST /{resources} (create a new resource)',
+            'add'        => 'POST /{resources} (add a resource)',
+            'store'      => 'POST /{resources} (store a resource)',
+            'update'     => 'PUT /{resources}/{resource} or PATCH /{resources}/{resource}',
+            'edit'       => 'PUT /{resources}/{resource} or PATCH /{resources}/{resource}',
+            'delete'     => 'DELETE /{resources}/{resource}',
+            'remove'     => 'DELETE /{resources}/{resource}',
+            'cancel'     => 'POST /{resources}/{resource}/cancellations',
+            'activate'   => 'POST /{resources}/{resource}/activations',
+            'deactivate' => 'POST /{resources}/{resource}/deactivations',
+            'search'     => 'GET /{resources}?q=',
+            'check'      => 'GET /{resources}/{resource}/status',
+            'process'    => 'POST /{resources}/{resource}/processings',
+            'submit'     => 'POST /{resources}/{resource}/submissions',
+            'send'       => 'POST /{resources}/{resource}/deliveries',
+            'transfer'   => 'POST /{resources}/{resource}/transfers',
+            'download'   => 'GET /{resources}/{resource}/download',
+            'upload'     => 'POST /{resources}/{resource}/uploads',
+            'import'     => 'POST /{resources}/imports',
+            'export'     => 'GET /{resources}/exports',
+            'validate'   => 'POST /{resources}/validations',
+            'generate'   => 'POST /{resources}/generations',
+            'refresh'    => 'POST /{resources}/{resource}/refreshes',
+        ],
+
+        'exemptions' => [],
+
+        'uncountables' => ['media', 'data', 'series', 'information', 'news', 'feedback', 'metadata'],
+
+    ],
+
 ];

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -13,6 +13,7 @@ use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
 use SineMacula\ApiToolkit\Providers\Registrars\LoggingRegistrar;
 use SineMacula\ApiToolkit\Providers\Registrars\MiddlewareRegistrar;
 use SineMacula\ApiToolkit\Providers\Registrars\RequestMacroRegistrar;
+use SineMacula\ApiToolkit\RouteLinting\Support\RouteLintMacros;
 use SineMacula\ApiToolkit\Services\SchemaValidator;
 
 /**
@@ -40,6 +41,7 @@ class ApiServiceProvider extends ServiceProvider
         $this->registerMorphMap();
         $this->validateSchemas();
 
+        RouteLintMacros::register();
         (new RequestMacroRegistrar)->register();
         (new MiddlewareRegistrar($this->app))->register();
         (new LoggingRegistrar($this->app))->register();

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use SineMacula\ApiToolkit\Console\ExportOpenApiCommand;
+use SineMacula\ApiToolkit\Console\LintRoutesCommand;
 use SineMacula\ApiToolkit\Console\ValidateSchemasCommand;
 use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
 use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
@@ -68,6 +69,7 @@ class ApiServiceProvider extends ServiceProvider
         $this->commands([
             ValidateSchemasCommand::class,
             ExportOpenApiCommand::class,
+            LintRoutesCommand::class,
         ]);
     }
 

--- a/src/Console/LintRoutesCommand.php
+++ b/src/Console/LintRoutesCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Console;
+
+use Illuminate\Console\Command;
+use SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException;
+use SineMacula\ApiToolkit\RouteLinting\LintRoutes;
+use SineMacula\ApiToolkit\RouteLinting\Output\ConsoleLintReporter;
+
+/**
+ * Artisan command to lint the application route table against RESTful conventions.
+ *
+ * Invokes the LintRoutes use case, renders the report via ConsoleLintReporter,
+ * and exits non-zero when the verdict contains any ERROR-severity violations.
+ * Warning-severity findings and stale waivers are surfaced but do not gate the
+ * exit code. A misconfigured allowlist entry (StaleWaiverException) is treated
+ * as an error-grade configuration failure and exits non-zero immediately.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LintRoutesCommand extends Command
+{
+    /** @var string The console command signature. */
+    protected $signature = 'api-toolkit:lint-routes';
+
+    /** @var string The console command description. */
+    protected $description = 'Lint the application route table against the RESTful URL conventions';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\LintRoutes  $linter
+     * @return int
+     */
+    public function handle(LintRoutes $linter): int
+    {
+        $reporter = new ConsoleLintReporter($this->output);
+
+        try {
+            $report = $linter->lint();
+        } catch (StaleWaiverException $exception) {
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $reporter->report($report);
+
+        return $report->hasErrors() ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/src/Providers/Registrars/ContainerBindingRegistrar.php
+++ b/src/Providers/Registrars/ContainerBindingRegistrar.php
@@ -26,6 +26,24 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LikeOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
+use SineMacula\ApiToolkit\RouteLinting\Configuration\ConfigRuleConfiguration;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\RouteSource;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\RuleConfiguration;
+use SineMacula\ApiToolkit\RouteLinting\Inflection\FrameworkInflector;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintEngine;
+use SineMacula\ApiToolkit\RouteLinting\Rules\ApiResourceAlignmentRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\KebabCaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\LowercaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\NestingDepthRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\PluralCollectionsRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\RouteNameRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\SlashSanityRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\StandardMethodsRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist;
+use SineMacula\ApiToolkit\RouteLinting\Rules\VerbInPathRule;
+use SineMacula\ApiToolkit\RouteLinting\Sources\RouterRouteSource;
 use SineMacula\ApiToolkit\Services\SchemaIntrospector;
 use SineMacula\ApiToolkit\Services\SchemaValidator;
 use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateAccessors;
@@ -77,6 +95,7 @@ final class ContainerBindingRegistrar
         $this->registerWritePool();
         $this->registerCacheManager();
         $this->registerOpenApiExporter();
+        $this->registerRouteLinter();
     }
 
     /**
@@ -208,5 +227,55 @@ final class ContainerBindingRegistrar
     {
         $this->container->singleton(MetadataCatalogue::class, ConfigMetadataCatalogue::class);
         $this->container->singleton(DocumentWriter::class, FilesystemDocumentWriter::class);
+    }
+
+    /**
+     * Bind the route-linter ports to their default adapters.
+     *
+     * Binds the four ports as singletons and assembles the RouteLintEngine with
+     * the rule set in a fixed declared order (R1, R2, R3, R4, R5, R7, R8, R9,
+     * R11). The LintRoutes use case is auto-resolved through constructor
+     * injection from these bindings; no explicit binding for it is required.
+     *
+     * @return void
+     */
+    private function registerRouteLinter(): void
+    {
+        $this->container->singleton(RouteSource::class, fn ($app) => new RouterRouteSource($app['router']));
+
+        $this->container->singleton(RuleConfiguration::class, ConfigRuleConfiguration::class);
+
+        $this->container->singleton(Inflector::class, function (): FrameworkInflector {
+
+            $uncountables = Config::get('api-toolkit.route_linting.uncountables');
+
+            return new FrameworkInflector(is_array($uncountables) ? $uncountables : []);
+        });
+
+        $this->container->singleton(RouteLintEngine::class, function (): RouteLintEngine {
+
+            $inflector = $this->container->make(Inflector::class);
+
+            $denylist = Config::get('api-toolkit.route_linting.verb_denylist');
+            $hints    = Config::get('api-toolkit.route_linting.remediation_hints');
+
+            return new RouteLintEngine(
+                new VerbInPathRule(
+                    new SegmentNormaliser($inflector),
+                    new VerbDenylist(
+                        is_array($denylist) ? $denylist : [],
+                        is_array($hints) ? $hints : [],
+                    ),
+                ),
+                new KebabCaseRule,
+                new LowercaseRule,
+                new PluralCollectionsRule($inflector),
+                new SlashSanityRule,
+                new StandardMethodsRule,
+                new RouteNameRule,
+                new ApiResourceAlignmentRule,
+                new NestingDepthRule,
+            );
+        });
     }
 }

--- a/src/RouteLinting/Configuration/ConfigRuleConfiguration.php
+++ b/src/RouteLinting/Configuration/ConfigRuleConfiguration.php
@@ -73,7 +73,10 @@ final class ConfigRuleConfiguration implements RuleConfiguration
                 throw new StaleWaiverException(sprintf('Allowlist entry "%s" is missing a required reason.', $match));
             }
 
-            $entries[] = new AllowlistEntry($match, $reason);
+            $rawRules = $item['rules'] ?? [];
+            $rules    = is_array($rawRules) ? array_values(array_filter($rawRules, 'is_string')) : [];
+
+            $entries[] = new AllowlistEntry($match, $reason, $rules);
         }
 
         return $entries;

--- a/src/RouteLinting/Configuration/ConfigRuleConfiguration.php
+++ b/src/RouteLinting/Configuration/ConfigRuleConfiguration.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Configuration;
+
+use Illuminate\Support\Facades\Config;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\RuleConfiguration;
+use SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException;
+
+/**
+ * Config-backed adapter for the RuleConfiguration port.
+ *
+ * Reads the `api-toolkit.route_linting.*` config section and assembles the
+ * three strictly-separate surfaces — verb denylist, exemption allowlist, and
+ * inflector uncountables — into a {@see RuleConfig} DTO. Every allowlist entry
+ * must carry a non-empty written reason; entries that violate this invariant
+ * cause a {@see StaleWaiverException} to be thrown immediately so a reasonless
+ * waiver never enters the effective configuration.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ConfigRuleConfiguration implements RuleConfiguration
+{
+    /**
+     * Build the rule-config DTO from the three separate config surfaces.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig
+     *
+     * @throws \SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException
+     */
+    #[\Override]
+    public function load(): RuleConfig
+    {
+        $verbDenylist     = Config::get('api-toolkit.route_linting.verb_denylist');
+        $remediationHints = Config::get('api-toolkit.route_linting.remediation_hints');
+        $rawExemptions    = Config::get('api-toolkit.route_linting.exemptions');
+        $uncountables     = Config::get('api-toolkit.route_linting.uncountables');
+
+        return new RuleConfig(
+            verbDenylist: is_array($verbDenylist) ? $verbDenylist : [],
+            remediationHints: is_array($remediationHints) ? $remediationHints : [],
+            exemptions: $this->buildExemptions(is_array($rawExemptions) ? $rawExemptions : []),
+            uncountables: is_array($uncountables) ? $uncountables : [],
+        );
+    }
+
+    /**
+     * Map raw config exemption entries to AllowlistEntry DTOs.
+     *
+     * Rejects any entry where `match` is absent or `reason` is missing,
+     * not a string, or consists only of whitespace.
+     *
+     * @param  array<int|string, mixed>  $raw
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry>
+     *
+     * @throws \SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException
+     */
+    private function buildExemptions(array $raw): array
+    {
+        $entries = [];
+
+        foreach ($raw as $item) {
+            if (!is_array($item) || !isset($item['match']) || !is_string($item['match'])) {
+                throw new StaleWaiverException('Allowlist entry is missing a required match key.');
+            }
+
+            $match  = $item['match'];
+            $reason = $item['reason'] ?? null;
+
+            if (!is_string($reason) || trim($reason) === '') {
+                throw new StaleWaiverException(sprintf('Allowlist entry "%s" is missing a required reason.', $match));
+            }
+
+            $entries[] = new AllowlistEntry($match, $reason);
+        }
+
+        return $entries;
+    }
+}

--- a/src/RouteLinting/Contracts/Inflector.php
+++ b/src/RouteLinting/Contracts/Inflector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Contracts;
+
+/**
+ * Outbound port for word inflection, honouring configured uncountables.
+ *
+ * Isolates the domain's singularisation and plurality checks from the
+ * framework inflector. The adapter honours the uncountables list supplied
+ * by the rule configuration so domain nouns like "media" or "data" are
+ * never mis-singularised.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+interface Inflector
+{
+    /**
+     * Return the singular form of a segment, honouring configured uncountables.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function singular(string $value): string;
+
+    /**
+     * Determine whether a segment is already plural (uncountables are treated as plural-safe).
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public function isPlural(string $value): bool;
+}

--- a/src/RouteLinting/Contracts/Inflector.php
+++ b/src/RouteLinting/Contracts/Inflector.php
@@ -16,18 +16,18 @@ namespace SineMacula\ApiToolkit\RouteLinting\Contracts;
 interface Inflector
 {
     /**
-     * Return the singular form of a segment, honouring configured uncountables.
+     * Return the singular form of a word, honouring configured uncountables.
      *
-     * @param  string  $value
+     * @param  string  $word
      * @return string
      */
-    public function singular(string $value): string;
+    public function singular(string $word): string;
 
     /**
-     * Determine whether a segment is already plural (uncountables are treated as plural-safe).
+     * Determine whether a word is already plural (uncountables are treated as plural-safe).
      *
-     * @param  string  $value
+     * @param  string  $word
      * @return bool
      */
-    public function isPlural(string $value): bool;
+    public function isPlural(string $word): bool;
 }

--- a/src/RouteLinting/Contracts/LintReporter.php
+++ b/src/RouteLinting/Contracts/LintReporter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Contracts;
+
+use SineMacula\ApiToolkit\RouteLinting\RouteLintReport;
+
+/**
+ * Outbound port for rendering the lint report to the invoking surface.
+ *
+ * Implementers receive the fully-assembled {@see RouteLintReport} verdict
+ * aggregate and render findings (grouped by severity) plus any stale-waiver
+ * entries to their backing output surface (e.g. console, structured log).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+interface LintReporter
+{
+    /**
+     * Render the report (findings grouped by severity, plus stale-waiver findings) to the invoking surface.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintReport  $report
+     * @return void
+     */
+    public function report(RouteLintReport $report): void;
+}

--- a/src/RouteLinting/Contracts/RouteSource.php
+++ b/src/RouteLinting/Contracts/RouteSource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Contracts;
+
+/**
+ * Outbound port for enumerating the application's owned routes.
+ *
+ * Implementers enumerate every app-owned route after a full boot, excluding
+ * vendor routes the application cannot change. The domain never reads the
+ * framework router directly — all route sourcing flows through this port.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+interface RouteSource
+{
+    /**
+     * Enumerate every app-owned route, excluding vendor routes the app cannot change.
+     *
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor>
+     */
+    public function appRoutes(): array;
+}

--- a/src/RouteLinting/Contracts/Rule.php
+++ b/src/RouteLinting/Contracts/Rule.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Contracts;
+
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Domain contract for a single route-linting rule.
+ *
+ * Each rule carries a stable identifier, a fixed severity tier, and an
+ * inspection method that maps one normalised route plus the active rule
+ * configuration to zero or more violation value objects. Rules are pure:
+ * they read their inputs and return findings without side effects.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+interface Rule
+{
+    /**
+     * Stable rule identifier, e.g. 'R1', used for ordering and reporting.
+     *
+     * @return string
+     */
+    public function id(): string;
+
+    /**
+     * The severity this rule emits (error gates CI; warning is reported only).
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    public function severity(): Severity;
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array;
+}

--- a/src/RouteLinting/Contracts/RuleConfiguration.php
+++ b/src/RouteLinting/Contracts/RuleConfiguration.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Contracts;
+
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+
+/**
+ * Outbound port for supplying the rule-configuration DTO.
+ *
+ * Implementers read the three strictly-separate config surfaces (verb
+ * denylist, exemption allowlist, inflector uncountables) and assemble them
+ * into a single {@see RuleConfig} DTO for consumption by the rule engine.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+interface RuleConfiguration
+{
+    /**
+     * Build the rule-config DTO from the three separate config surfaces.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig
+     *
+     * @throws \SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException
+     */
+    public function load(): RuleConfig;
+}

--- a/src/RouteLinting/Dto/AllowlistEntry.php
+++ b/src/RouteLinting/Dto/AllowlistEntry.php
@@ -5,11 +5,11 @@ namespace SineMacula\ApiToolkit\RouteLinting\Dto;
 /**
  * One exemption-allowlist entry.
  *
- * Carries the match key (a route name or URI pattern) and the written reason
- * that justifies the waiver. Emptiness of `reason` is validated upstream by
- * the config adapter (task 12); this DTO stores both values exactly as given.
- * Task 04 builds the matching and stale-waiver detection logic on top of these
- * entries.
+ * Carries the match key (a route name or URI pattern), the written reason
+ * that justifies the waiver, and an optional list of rule IDs the entry
+ * applies to. An empty `$rules` list means the waiver covers all rules.
+ * Emptiness of `reason` is validated upstream by the config adapter; this DTO
+ * stores all values exactly as given.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -21,6 +21,7 @@ final readonly class AllowlistEntry
      *
      * @param  string  $match
      * @param  string  $reason
+     * @param  list<string>  $rules
      */
     public function __construct(
 
@@ -30,5 +31,22 @@ final readonly class AllowlistEntry
         /** The required, non-empty written justification for the waiver */
         public string $reason,
 
+        /** The rule IDs covered by this entry; empty means all rules */
+        public array $rules = [],
+
     ) {}
+
+    /**
+     * Determine whether this allowlist entry covers the given rule.
+     *
+     * Returns true when the entry waives all rules (empty list) or when the
+     * given rule ID is explicitly present in the rules list.
+     *
+     * @param  string  $ruleId
+     * @return bool
+     */
+    public function covers(string $ruleId): bool
+    {
+        return $this->rules === [] || in_array($ruleId, $this->rules, true);
+    }
 }

--- a/src/RouteLinting/Dto/AllowlistEntry.php
+++ b/src/RouteLinting/Dto/AllowlistEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Dto;
+
+/**
+ * One exemption-allowlist entry.
+ *
+ * Carries the match key (a route name or URI pattern) and the written reason
+ * that justifies the waiver. Emptiness of `reason` is validated upstream by
+ * the config adapter (task 12); this DTO stores both values exactly as given.
+ * Task 04 builds the matching and stale-waiver detection logic on top of these
+ * entries.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class AllowlistEntry
+{
+    /**
+     * Create a new allowlist entry.
+     *
+     * @param  string  $match
+     * @param  string  $reason
+     */
+    public function __construct(
+
+        /** The route name or URI pattern to waive */
+        public string $match,
+
+        /** The required, non-empty written justification for the waiver */
+        public string $reason,
+
+    ) {}
+}

--- a/src/RouteLinting/Dto/RouteDescriptor.php
+++ b/src/RouteLinting/Dto/RouteDescriptor.php
@@ -7,9 +7,10 @@ namespace SineMacula\ApiToolkit\RouteLinting\Dto;
  *
  * Carries the raw, pre-normalisation route data handed in by the route-source
  * adapter: the URI as registered, the set of uppercase HTTP methods, the
- * optional route name, and a flag indicating whether the route belongs to a
- * vendor package. The domain never sees an Illuminate type; all framework
- * details are translated into this plain carrier at the adapter boundary.
+ * optional route name, a flag indicating whether the route belongs to a vendor
+ * package, and any inline suppressions declared via the `ignoreRouteLint`
+ * macro. The domain never sees an Illuminate type; all framework details are
+ * translated into this plain carrier at the adapter boundary.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -23,6 +24,7 @@ final readonly class RouteDescriptor
      * @param  array<int, string>  $methods
      * @param  string|null  $name
      * @param  bool  $isVendor
+     * @param  list<\SineMacula\ApiToolkit\RouteLinting\Dto\RouteSuppression>  $suppressions
      */
     public function __construct(
 
@@ -37,6 +39,9 @@ final readonly class RouteDescriptor
 
         /** Whether the route belongs to a vendor package */
         public bool $isVendor,
+
+        /** Inline suppressions declared via `ignoreRouteLint`; empty when none were registered */
+        public array $suppressions = [],
 
     ) {}
 }

--- a/src/RouteLinting/Dto/RouteDescriptor.php
+++ b/src/RouteLinting/Dto/RouteDescriptor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Dto;
+
+/**
+ * Inbound description of one route from the route-source adapter.
+ *
+ * Carries the raw, pre-normalisation route data handed in by the route-source
+ * adapter: the URI as registered, the set of uppercase HTTP methods, the
+ * optional route name, and a flag indicating whether the route belongs to a
+ * vendor package. The domain never sees an Illuminate type; all framework
+ * details are translated into this plain carrier at the adapter boundary.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class RouteDescriptor
+{
+    /**
+     * Create a new route descriptor.
+     *
+     * @param  string  $uri
+     * @param  array<int, string>  $methods
+     * @param  string|null  $name
+     * @param  bool  $isVendor
+     */
+    public function __construct(
+
+        /** The route URI as registered, e.g. `users/{user}` */
+        public string $uri,
+
+        /** The uppercase HTTP methods the route responds to, e.g. `['GET', 'HEAD']` */
+        public array $methods,
+
+        /** The route name, or null when the route is unnamed */
+        public ?string $name,
+
+        /** Whether the route belongs to a vendor package */
+        public bool $isVendor,
+
+    ) {}
+}

--- a/src/RouteLinting/Dto/RouteSuppression.php
+++ b/src/RouteLinting/Dto/RouteSuppression.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Dto;
+
+/**
+ * Route-local suppression declared inline via the `ignoreRouteLint` macro.
+ *
+ * Carries a list of rule IDs to suppress and the written justification supplied
+ * by the developer. An empty `$rules` list means "suppress all rules" for this
+ * route. The `covers()` helper lets the engine query suppression membership
+ * without exposing the internal representation.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class RouteSuppression
+{
+    /**
+     * Create a new route suppression.
+     *
+     * @param  list<string>  $rules
+     * @param  string  $reason
+     */
+    public function __construct(
+
+        /** The rule IDs covered by this suppression; empty means all rules */
+        public array $rules,
+
+        /** The non-empty written justification for this suppression */
+        public string $reason,
+
+    ) {}
+
+    /**
+     * Determine whether this suppression covers the given rule.
+     *
+     * Returns true when the suppression targets all rules (empty list) or when
+     * the given rule ID is explicitly present in the rules list.
+     *
+     * @param  string  $ruleId
+     * @return bool
+     */
+    public function covers(string $ruleId): bool
+    {
+        return $this->rules === [] || in_array($ruleId, $this->rules, true);
+    }
+}

--- a/src/RouteLinting/Dto/RuleConfig.php
+++ b/src/RouteLinting/Dto/RuleConfig.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Dto;
+
+/**
+ * Inbound configuration bundle from the rule-configuration adapter.
+ *
+ * Carries the three strictly-separate config surfaces handed to every rule:
+ * the verb denylist (action verbs that flag a path segment), the per-verb
+ * remediation-hint map, the exemption-allowlist entries, and the inflector
+ * uncountables. Surfaces are kept separate — verbDenylist, exemptions, and
+ * uncountables never share storage — so callers can tune each independently.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class RuleConfig
+{
+    /**
+     * Create a new rule config.
+     *
+     * @param  array<int, string>  $verbDenylist
+     * @param  array<string, string>  $remediationHints
+     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry>  $exemptions
+     * @param  array<int, string>  $uncountables
+     */
+    public function __construct(
+
+        /** Action verbs that flag a path segment as non-RESTful */
+        public array $verbDenylist,
+
+        /** Per-verb RESTful-rewrite hints, keyed by the denylisted verb */
+        public array $remediationHints,
+
+        /** Per-route exemption waivers; ships empty by default */
+        public array $exemptions,
+
+        /** Inflector uncountables honoured by the plural and verb rules */
+        public array $uncountables,
+
+    ) {}
+}

--- a/src/RouteLinting/Exceptions/StaleWaiverException.php
+++ b/src/RouteLinting/Exceptions/StaleWaiverException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Exceptions;
+
+/**
+ * Exception thrown when an allowlist entry carries an empty reason at config-read time.
+ *
+ * Every exemption entry must supply a non-empty written justification; the
+ * config adapter (task 12) validates this invariant and throws this exception
+ * when the requirement is not met. This class is declared here alongside the
+ * allowlist so both artefacts live in the same domain task.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class StaleWaiverException extends \RuntimeException {}

--- a/src/RouteLinting/ExemptionAllowlist.php
+++ b/src/RouteLinting/ExemptionAllowlist.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+use SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry;
+
+/**
+ * Domain service that suppresses waived violations and tracks stale entries.
+ *
+ * Constructed from the exemption entries supplied by the rule-configuration
+ * port, this service answers whether a given route (identified by its optional
+ * name and its URI) is covered by any allowlist entry, and records which
+ * entries were matched so unmatched entries can be reported as stale waivers
+ * after the full route table has been inspected. An empty allowlist is the
+ * shipped default; in that state every route is uninspected and no stale
+ * entries are ever reported.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ExemptionAllowlist
+{
+    /** @var array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry> */
+    private readonly array $entries;
+
+    /** @var array<int, bool> Index positions of entries that matched at least one route */
+    private array $matched = [];
+
+    /**
+     * Create a new exemption allowlist.
+     *
+     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry>  $entries
+     */
+    public function __construct(array $entries)
+    {
+        $this->entries = $entries;
+    }
+
+    /**
+     * Determine whether the given route is waived by any allowlist entry.
+     *
+     * Matches by exact route name first, then by URI shell-wildcard pattern via
+     * `fnmatch()`. The first matching entry is recorded as matched so it does
+     * not later appear in `unmatched()`. Subsequent calls that hit the same
+     * entry do not alter the match record.
+     *
+     * @param  string|null  $routeName
+     * @param  string  $uri
+     * @return bool
+     */
+    public function isExempt(?string $routeName, string $uri): bool
+    {
+        foreach ($this->entries as $index => $entry) {
+            if ($this->entryMatches($entry, $routeName, $uri)) {
+                $this->matched[$index] = true;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return the match keys of entries that never matched any live route during this run.
+     *
+     * Results are sorted ascending for determinism.
+     *
+     * @return array<int, string>
+     */
+    public function unmatched(): array
+    {
+        $stale = [];
+
+        foreach ($this->entries as $index => $entry) {
+            if (!isset($this->matched[$index])) {
+                $stale[] = $entry->match;
+            }
+        }
+
+        sort($stale);
+
+        return $stale;
+    }
+
+    /**
+     * Determine whether a single allowlist entry matches the given route.
+     *
+     * An entry matches when its `match` value equals the route name exactly, or
+     * when it matches the URI via `fnmatch()` shell-wildcard semantics.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry  $entry
+     * @param  string|null  $routeName
+     * @param  string  $uri
+     * @return bool
+     */
+    private function entryMatches(AllowlistEntry $entry, ?string $routeName, string $uri): bool
+    {
+        if ($routeName !== null && $routeName === $entry->match) {
+            return true;
+        }
+
+        return fnmatch($entry->match, $uri);
+    }
+}

--- a/src/RouteLinting/ExemptionAllowlist.php
+++ b/src/RouteLinting/ExemptionAllowlist.php
@@ -8,12 +8,16 @@ use SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry;
  * Domain service that suppresses waived violations and tracks stale entries.
  *
  * Constructed from the exemption entries supplied by the rule-configuration
- * port, this service answers whether a given route (identified by its optional
- * name and its URI) is covered by any allowlist entry, and records which
- * entries were matched so unmatched entries can be reported as stale waivers
- * after the full route table has been inspected. An empty allowlist is the
- * shipped default; in that state every route is uninspected and no stale
- * entries are ever reported.
+ * port, this service answers whether a given route carries a per-rule allowlist
+ * suppression, and records which entries were matched so unmatched entries can
+ * be reported as stale waivers after the full route table has been inspected.
+ * An empty allowlist is the shipped default; in that state no route is suppressed
+ * and no stale entries are ever reported.
+ *
+ * The two-phase protocol is:
+ * 1. Call `observe()` once per live route so pattern-match tracking is driven
+ *    by the full route table (not just routes that have violations).
+ * 2. Call `suppresses()` per violation to test per-rule coverage and record usage.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -23,8 +27,11 @@ final class ExemptionAllowlist
     /** @var array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry> */
     private readonly array $entries;
 
-    /** @var array<int, bool> Index positions of entries that matched at least one route */
+    /** @var array<int, bool> Index positions of entries whose pattern matched at least one live route */
     private array $matched = [];
+
+    /** @var array<int, bool> Index positions of entries that suppressed at least one violation */
+    private array $used = [];
 
     /**
      * Create a new exemption allowlist.
@@ -37,22 +44,51 @@ final class ExemptionAllowlist
     }
 
     /**
-     * Determine whether the given route is waived by any allowlist entry.
+     * Record that a live route has been observed.
      *
-     * Matches by exact route name first, then by URI shell-wildcard pattern via
-     * `fnmatch()`. The first matching entry is recorded as matched so it does
-     * not later appear in `unmatched()`. Subsequent calls that hit the same
-     * entry do not alter the match record.
+     * Marks every entry whose pattern matches this route as having been matched
+     * by a live route. Call once per live route before calling `suppresses()`,
+     * so that pattern-matching for stale detection covers the full route table
+     * independently of whether violations are raised.
      *
      * @param  string|null  $routeName
      * @param  string  $uri
-     * @return bool
+     * @return void
      */
-    public function isExempt(?string $routeName, string $uri): bool
+    public function observe(?string $routeName, string $uri): void
     {
         foreach ($this->entries as $index => $entry) {
             if ($this->entryMatches($entry, $routeName, $uri)) {
                 $this->matched[$index] = true;
+            }
+        }
+    }
+
+    /**
+     * Determine whether any allowlist entry suppresses the given rule on this route.
+     *
+     * Returns true when at least one entry matches by name or URI pattern AND
+     * covers the given rule ID (either the entry waives all rules, or the rule ID
+     * is explicitly in the entry's rules list). Matching entries are also recorded
+     * as having been matched by a live route (equivalent to `observe()`), and the
+     * first suppressing entry is marked as having suppressed a violation.
+     *
+     * @param  string|null  $routeName
+     * @param  string  $uri
+     * @param  string  $ruleId
+     * @return bool
+     */
+    public function suppresses(?string $routeName, string $uri, string $ruleId): bool
+    {
+        foreach ($this->entries as $index => $entry) {
+            if (!$this->entryMatches($entry, $routeName, $uri)) {
+                continue;
+            }
+
+            $this->matched[$index] = true;
+
+            if ($entry->covers($ruleId)) {
+                $this->used[$index] = true;
 
                 return true;
             }
@@ -75,6 +111,30 @@ final class ExemptionAllowlist
         foreach ($this->entries as $index => $entry) {
             if (!isset($this->matched[$index])) {
                 $stale[] = $entry->match;
+            }
+        }
+
+        sort($stale);
+
+        return $stale;
+    }
+
+    /**
+     * Return descriptive strings for entries that matched a live route but suppressed no violation.
+     *
+     * An entry in this list did match a live route pattern but none of its covered
+     * rules fired a violation on that route, meaning it is carrying a waiver that
+     * serves no purpose. Results are sorted ascending for determinism.
+     *
+     * @return array<int, string>
+     */
+    public function unused(): array
+    {
+        $stale = [];
+
+        foreach ($this->entries as $index => $entry) {
+            if (isset($this->matched[$index]) && !isset($this->used[$index])) {
+                $stale[] = sprintf('%s (suppressed nothing): %s', $entry->match, $entry->reason);
             }
         }
 

--- a/src/RouteLinting/ExemptionAllowlist.php
+++ b/src/RouteLinting/ExemptionAllowlist.php
@@ -109,7 +109,7 @@ final class ExemptionAllowlist
         $stale = [];
 
         foreach ($this->entries as $index => $entry) {
-            if (!isset($this->matched[$index])) {
+            if (!($this->matched[$index] ?? false)) {
                 $stale[] = $entry->match;
             }
         }
@@ -133,7 +133,7 @@ final class ExemptionAllowlist
         $stale = [];
 
         foreach ($this->entries as $index => $entry) {
-            if (isset($this->matched[$index]) && !isset($this->used[$index])) {
+            if (($this->matched[$index] ?? false) && !($this->used[$index] ?? false)) {
                 $stale[] = sprintf('%s (suppressed nothing): %s', $entry->match, $entry->reason);
             }
         }

--- a/src/RouteLinting/Inflection/FrameworkInflector.php
+++ b/src/RouteLinting/Inflection/FrameworkInflector.php
@@ -26,45 +26,45 @@ final class FrameworkInflector implements Inflector
     public function __construct(private readonly array $uncountables = []) {}
 
     /**
-     * Return the singular form of a segment, honouring configured uncountables.
+     * Return the singular form of a word, honouring configured uncountables.
      *
-     * Returns the value unchanged when it is an uncountable word; otherwise
+     * Returns the word unchanged when it is an uncountable word; otherwise
      * delegates to `Str::singular()`. An empty string is returned as-is.
      *
-     * @param  string  $value
+     * @param  string  $word
      * @return string
      */
     #[\Override]
-    public function singular(string $value): string
+    public function singular(string $word): string
     {
-        if ($value === '' || in_array(strtolower($value), $this->uncountables, true)) {
-            return $value;
+        if ($word === '' || in_array(strtolower($word), $this->uncountables, true)) {
+            return $word;
         }
 
-        return Str::singular($value);
+        return Str::singular($word);
     }
 
     /**
-     * Determine whether a segment is already plural.
+     * Determine whether a word is already plural.
      *
      * Uncountables are always treated as plural-safe and return `true`. For
      * other words, a word is considered plural when its singular form differs
      * from the original. An empty string always returns `false`.
      *
-     * @param  string  $value
+     * @param  string  $word
      * @return bool
      */
     #[\Override]
-    public function isPlural(string $value): bool
+    public function isPlural(string $word): bool
     {
-        if ($value === '') {
+        if ($word === '') {
             return false;
         }
 
-        if (in_array(strtolower($value), $this->uncountables, true)) {
+        if (in_array(strtolower($word), $this->uncountables, true)) {
             return true;
         }
 
-        return Str::singular($value) !== $value;
+        return Str::singular($word) !== $word;
     }
 }

--- a/src/RouteLinting/Inflection/FrameworkInflector.php
+++ b/src/RouteLinting/Inflection/FrameworkInflector.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Inflection;
+
+use Illuminate\Support\Str;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+
+/**
+ * Framework-backed inflector adapter.
+ *
+ * Wraps `Illuminate\Support\Str` singularisation with a configured list of
+ * uncountable words. Uncountables short-circuit before the framework inflector
+ * so domain nouns like "media" or "data" are never mis-singularised or
+ * incorrectly flagged as singular.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class FrameworkInflector implements Inflector
+{
+    /**
+     * Create a new framework inflector.
+     *
+     * @param  array<int, string>  $uncountables
+     */
+    public function __construct(private readonly array $uncountables = []) {}
+
+    /**
+     * Return the singular form of a segment, honouring configured uncountables.
+     *
+     * Returns the value unchanged when it is an uncountable word; otherwise
+     * delegates to `Str::singular()`. An empty string is returned as-is.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    #[\Override]
+    public function singular(string $value): string
+    {
+        if ($value === '' || in_array(strtolower($value), $this->uncountables, true)) {
+            return $value;
+        }
+
+        return Str::singular($value);
+    }
+
+    /**
+     * Determine whether a segment is already plural.
+     *
+     * Uncountables are always treated as plural-safe and return `true`. For
+     * other words, a word is considered plural when its singular form differs
+     * from the original. An empty string always returns `false`.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    #[\Override]
+    public function isPlural(string $value): bool
+    {
+        if ($value === '') {
+            return false;
+        }
+
+        if (in_array(strtolower($value), $this->uncountables, true)) {
+            return true;
+        }
+
+        return Str::singular($value) !== $value;
+    }
+}

--- a/src/RouteLinting/LintRoutes.php
+++ b/src/RouteLinting/LintRoutes.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\RouteSource;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\RuleConfiguration;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
+
+/**
+ * Application use case that composes the route-linting ports and runs the engine.
+ *
+ * Sources app-owned routes via the RouteSource port, loads rule configuration
+ * via the RuleConfiguration port, normalises each descriptor into a NormalisedRoute,
+ * runs the RouteLintEngine over it, suppresses exempt violations via the
+ * ExemptionAllowlist, and returns a populated RouteLintReport. Stale allowlist
+ * entries — entries that matched no live route — are recorded on the report.
+ *
+ * This class carries no framework dependency; all I/O is mediated through the
+ * injected ports. Determinism (NFR-01) is achieved by sorting descriptors by a
+ * stable identity key before inspection so two runs over the same route table
+ * and configuration produce byte-identical verdicts.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LintRoutes
+{
+    /**
+     * Create a new lint-routes use case.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Contracts\RouteSource  $routeSource
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Contracts\RuleConfiguration  $configuration
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintEngine  $engine
+     */
+    public function __construct(
+        private readonly RouteSource $routeSource,
+        private readonly RuleConfiguration $configuration,
+        private readonly RouteLintEngine $engine,
+    ) {}
+
+    /**
+     * Run the linter over every app-owned route and return the verdict.
+     *
+     * Steps:
+     * 1. Load the RuleConfig (may throw StaleWaiverException; propagates to caller).
+     * 2. Build the ExemptionAllowlist from config exemptions.
+     * 3. Source app-owned RouteDescriptors.
+     * 4. Sort descriptors deterministically by stable identity key (NFR-01).
+     * 5. For each descriptor: normalise, run the engine, suppress exempt violations.
+     * 6. Record unmatched allowlist entries as stale waivers on the report.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\RouteLintReport
+     *
+     * @throws \SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException
+     */
+    public function lint(): RouteLintReport
+    {
+        $config    = $this->configuration->load();
+        $allowlist = new ExemptionAllowlist($config->exemptions);
+        $report    = new RouteLintReport;
+
+        $descriptors = $this->routeSource->appRoutes();
+        $descriptors = $this->sortDescriptors($descriptors);
+
+        foreach ($descriptors as $descriptor) {
+            $normalised = $this->normalise($descriptor);
+            $violations = $this->engine->inspect($normalised, $config);
+            $exempt     = $allowlist->isExempt($descriptor->name, $descriptor->uri);
+
+            if ($exempt) {
+                continue;
+            }
+
+            foreach ($violations as $violation) {
+                $report->addViolation($violation);
+            }
+        }
+
+        foreach ($allowlist->unmatched() as $key) {
+            $report->addStaleWaiver($key);
+        }
+
+        return $report;
+    }
+
+    /**
+     * Sort a list of route descriptors by their stable identity key.
+     *
+     * The identity key is: sorted HTTP methods joined by comma, space, the URI,
+     * and (when named) space and the name — matching NormalisedRoute::identity().
+     * Sorting here before normalisation ensures the traversal order is stable
+     * regardless of the router's enumeration order (NFR-01).
+     *
+     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor>  $descriptors
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor>
+     */
+    private function sortDescriptors(array $descriptors): array
+    {
+        usort($descriptors, fn (RouteDescriptor $a, RouteDescriptor $b): int => $this->descriptorKey($a) <=> $this->descriptorKey($b));
+
+        return $descriptors;
+    }
+
+    /**
+     * Build the stable sort key for a RouteDescriptor.
+     *
+     * Mirrors the identity key produced by NormalisedRoute::identity() so
+     * sorting before and after normalisation yields the same order.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor  $descriptor
+     * @return string
+     */
+    private function descriptorKey(RouteDescriptor $descriptor): string
+    {
+        $methods = $descriptor->methods;
+        sort($methods);
+
+        $key = implode(',', $methods) . ' ' . $descriptor->uri;
+
+        if ($descriptor->name !== null) {
+            $key .= ' ' . $descriptor->name;
+        }
+
+        return $key;
+    }
+
+    /**
+     * Normalise a RouteDescriptor into a NormalisedRoute.
+     *
+     * Splits the URI on `/` (preserving empty segments for slash-sanity detection)
+     * and extracts parameter names by stripping the `{` and `}` braces from any
+     * segment that starts with `{`.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor  $descriptor
+     * @return \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute
+     */
+    private function normalise(RouteDescriptor $descriptor): NormalisedRoute
+    {
+        $segments   = $this->splitSegments($descriptor->uri);
+        $parameters = $this->extractParameters($segments);
+
+        return new NormalisedRoute(
+            uri: $descriptor->uri,
+            methods: $descriptor->methods,
+            name: $descriptor->name,
+            segments: $segments,
+            parameters: $parameters,
+        );
+    }
+
+    /**
+     * Split a URI string into segments on the `/` delimiter.
+     *
+     * Empty segments are preserved so that trailing-slash and duplicate-slash
+     * defects remain detectable by the SlashSanityRule.
+     *
+     * @param  string  $uri
+     * @return array<int, string>
+     */
+    private function splitSegments(string $uri): array
+    {
+        return explode('/', $uri);
+    }
+
+    /**
+     * Extract route parameter names from a list of URI segments.
+     *
+     * A segment is a route parameter when it starts with `{`. The surrounding
+     * `{` and `}` braces are stripped from the returned names.
+     *
+     * @param  array<int, string>  $segments
+     * @return array<int, string>
+     */
+    private function extractParameters(array $segments): array
+    {
+        $parameters = [];
+
+        foreach ($segments as $segment) {
+            if (str_starts_with($segment, '{')) {
+                $parameters[] = trim($segment, '{}');
+            }
+        }
+
+        return $parameters;
+    }
+}

--- a/src/RouteLinting/LintRoutes.php
+++ b/src/RouteLinting/LintRoutes.php
@@ -16,9 +16,10 @@ use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
  * entries — entries that matched no live route — are recorded on the report.
  *
  * This class carries no framework dependency; all I/O is mediated through the
- * injected ports. Determinism (NFR-01) is achieved by sorting descriptors by a
- * stable identity key before inspection so two runs over the same route table
- * and configuration produce byte-identical verdicts.
+ * injected ports. Determinism (NFR-01) is owned by RouteLintReport, which
+ * returns violations and stale entries in a stable total order regardless of
+ * the order routes are inspected, so two runs over the same route table and
+ * configuration produce byte-identical verdicts.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -45,10 +46,9 @@ final class LintRoutes
      * 1. Load the RuleConfig (may throw StaleWaiverException; propagates to caller).
      * 2. Build the ExemptionAllowlist from config exemptions.
      * 3. Source app-owned RouteDescriptors.
-     * 4. Sort descriptors deterministically by stable identity key (NFR-01).
-     * 5. Observe every descriptor so allowlist pattern-match tracking covers all live routes.
-     * 6. For each descriptor: normalise, run the engine, apply per-rule suppression.
-     * 7. Record stale inline suppressions, unmatched allowlist entries, and unused allowlist entries.
+     * 4. Observe every descriptor so allowlist pattern-match tracking covers all live routes.
+     * 5. For each descriptor: normalise, run the engine, apply per-rule suppression.
+     * 6. Record stale inline suppressions, unmatched allowlist entries, and unused allowlist entries.
      *
      * @return \SineMacula\ApiToolkit\RouteLinting\RouteLintReport
      *
@@ -61,7 +61,6 @@ final class LintRoutes
         $report    = new RouteLintReport;
 
         $descriptors = $this->routeSource->appRoutes();
-        $descriptors = $this->sortDescriptors($descriptors);
 
         foreach ($descriptors as $descriptor) {
             $allowlist->observe($descriptor->name, $descriptor->uri);
@@ -74,7 +73,7 @@ final class LintRoutes
             $inlineUsed = $this->applyViolations($descriptor, $allowlist, $report, $violations);
 
             foreach ($descriptor->suppressions as $suppression) {
-                if (!isset($inlineUsed[spl_object_id($suppression)])) {
+                if (!($inlineUsed[spl_object_id($suppression)] ?? false)) {
                     $rules = $suppression->rules === [] ? 'all rules' : implode(', ', $suppression->rules);
                     $report->addStaleWaiver(sprintf(
                         '%s (suppressed nothing, rules: %s): %s',
@@ -140,47 +139,6 @@ final class LintRoutes
         }
 
         return $inlineUsed;
-    }
-
-    /**
-     * Sort a list of route descriptors by their stable identity key.
-     *
-     * The identity key is: sorted HTTP methods joined by comma, space, the URI,
-     * and (when named) space and the name — matching NormalisedRoute::identity().
-     * Sorting here before normalisation ensures the traversal order is stable
-     * regardless of the router's enumeration order (NFR-01).
-     *
-     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor>  $descriptors
-     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor>
-     */
-    private function sortDescriptors(array $descriptors): array
-    {
-        usort($descriptors, fn (RouteDescriptor $a, RouteDescriptor $b): int => $this->descriptorKey($a) <=> $this->descriptorKey($b));
-
-        return $descriptors;
-    }
-
-    /**
-     * Build the stable sort key for a RouteDescriptor.
-     *
-     * Mirrors the identity key produced by NormalisedRoute::identity() so
-     * sorting before and after normalisation yields the same order.
-     *
-     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor  $descriptor
-     * @return string
-     */
-    private function descriptorKey(RouteDescriptor $descriptor): string
-    {
-        $methods = $descriptor->methods;
-        sort($methods);
-
-        $key = implode(',', $methods) . ' ' . $descriptor->uri;
-
-        if ($descriptor->name !== null) {
-            $key .= ' ' . $descriptor->name;
-        }
-
-        return $key;
     }
 
     /**

--- a/src/RouteLinting/LintRoutes.php
+++ b/src/RouteLinting/LintRoutes.php
@@ -46,8 +46,9 @@ final class LintRoutes
      * 2. Build the ExemptionAllowlist from config exemptions.
      * 3. Source app-owned RouteDescriptors.
      * 4. Sort descriptors deterministically by stable identity key (NFR-01).
-     * 5. For each descriptor: normalise, run the engine, suppress exempt violations.
-     * 6. Record unmatched allowlist entries as stale waivers on the report.
+     * 5. Observe every descriptor so allowlist pattern-match tracking covers all live routes.
+     * 6. For each descriptor: normalise, run the engine, apply per-rule suppression.
+     * 7. Record stale inline suppressions, unmatched allowlist entries, and unused allowlist entries.
      *
      * @return \SineMacula\ApiToolkit\RouteLinting\RouteLintReport
      *
@@ -63,16 +64,25 @@ final class LintRoutes
         $descriptors = $this->sortDescriptors($descriptors);
 
         foreach ($descriptors as $descriptor) {
+            $allowlist->observe($descriptor->name, $descriptor->uri);
+        }
+
+        foreach ($descriptors as $descriptor) {
             $normalised = $this->normalise($descriptor);
             $violations = $this->engine->inspect($normalised, $config);
-            $exempt     = $allowlist->isExempt($descriptor->name, $descriptor->uri);
 
-            if ($exempt) {
-                continue;
-            }
+            $inlineUsed = $this->applyViolations($descriptor, $allowlist, $report, $violations);
 
-            foreach ($violations as $violation) {
-                $report->addViolation($violation);
+            foreach ($descriptor->suppressions as $suppression) {
+                if (!isset($inlineUsed[spl_object_id($suppression)])) {
+                    $rules = $suppression->rules === [] ? 'all rules' : implode(', ', $suppression->rules);
+                    $report->addStaleWaiver(sprintf(
+                        '%s (suppressed nothing, rules: %s): %s',
+                        $normalised->identity(),
+                        $rules,
+                        $suppression->reason,
+                    ));
+                }
             }
         }
 
@@ -80,7 +90,56 @@ final class LintRoutes
             $report->addStaleWaiver($key);
         }
 
+        foreach ($allowlist->unused() as $entry) {
+            $report->addStaleWaiver($entry);
+        }
+
         return $report;
+    }
+
+    /**
+     * Apply per-rule suppression to a set of violations for one descriptor.
+     *
+     * For each violation, checks inline suppressions first (in declaration order),
+     * then falls back to the config allowlist. Violations that pass both checks
+     * are added to the report. Returns an object-ID map of inline suppressions
+     * that fired on at least one violation, keyed by `spl_object_id`.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor  $descriptor
+     * @param  \SineMacula\ApiToolkit\RouteLinting\ExemptionAllowlist  $allowlist
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintReport  $report
+     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>  $violations
+     * @return array<int, true>
+     */
+    private function applyViolations(
+        RouteDescriptor $descriptor,
+        ExemptionAllowlist $allowlist,
+        RouteLintReport $report,
+        array $violations,
+    ): array {
+        $inlineUsed = [];
+
+        foreach ($violations as $violation) {
+            $suppressed = false;
+
+            foreach ($descriptor->suppressions as $suppression) {
+                if ($suppression->covers($violation->ruleId)) {
+                    $inlineUsed[spl_object_id($suppression)] = true;
+                    $suppressed                              = true;
+                    break;
+                }
+            }
+
+            if (!$suppressed && $allowlist->suppresses($descriptor->name, $descriptor->uri, $violation->ruleId)) {
+                $suppressed = true;
+            }
+
+            if (!$suppressed) {
+                $report->addViolation($violation);
+            }
+        }
+
+        return $inlineUsed;
     }
 
     /**

--- a/src/RouteLinting/NormalisedRoute.php
+++ b/src/RouteLinting/NormalisedRoute.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+/**
+ * Pure value object representing a route under inspection.
+ *
+ * Carries the normalised properties extracted from a raw route descriptor and
+ * exposes a stable identity key used for deterministic ordering and reporting.
+ * All properties are derived from the route as registered; no framework types
+ * cross the domain boundary.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class NormalisedRoute
+{
+    /**
+     * Create a new normalised route.
+     *
+     * @param  string  $uri
+     * @param  array<int, string>  $methods
+     * @param  string|null  $name
+     * @param  array<int, string>  $segments
+     * @param  array<int, string>  $parameters
+     */
+    public function __construct(
+
+        /** The route URI as registered, e.g. `users/{user}` (no leading slash assumed; stored as given) */
+        public string $uri,
+
+        /** Uppercase HTTP methods for this route, e.g. `['GET', 'HEAD']` */
+        public array $methods,
+
+        /** The route name, or null when the route is unnamed */
+        public ?string $name,
+
+        /** URI split on `/`, with empty segments preserved so trailing/duplicate slashes remain detectable */
+        public array $segments,
+
+        /** Route parameter names without braces, e.g. `['user']` */
+        public array $parameters,
+
+    ) {}
+
+    /**
+     * Return a stable identity key for deterministic ordering and reporting.
+     *
+     * The key is: HTTP methods sorted ascending joined by `,`, then a space,
+     * then the URI, then (when the route has a name) a space and the name.
+     * Example: methods `['HEAD','GET']`, uri `users`, name `users.index`
+     * yields `GET,HEAD users users.index`.
+     *
+     * @return string
+     */
+    public function identity(): string
+    {
+        $sortedMethods = $this->methods;
+        sort($sortedMethods);
+
+        $key = implode(',', $sortedMethods) . ' ' . $this->uri;
+
+        if ($this->name !== null) {
+            $key .= ' ' . $this->name;
+        }
+
+        return $key;
+    }
+}

--- a/src/RouteLinting/Output/ConsoleLintReporter.php
+++ b/src/RouteLinting/Output/ConsoleLintReporter.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Output;
+
+use Illuminate\Console\OutputStyle;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\LintReporter;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintReport;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Console adapter for the LintReporter port.
+ *
+ * Renders a RouteLintReport to the Artisan command's output: error violations
+ * are grouped under an error header, warning violations under a warning header,
+ * and stale-waiver entries under a dedicated stale-waivers header. When the
+ * report is clean (no errors, warnings, or stale entries) a single success line
+ * is written instead. Empty sections are silently skipped; the reporter never
+ * influences the exit code.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ConsoleLintReporter implements LintReporter
+{
+    /**
+     * Create a new console lint reporter.
+     *
+     * @param  \Illuminate\Console\OutputStyle  $output
+     */
+    public function __construct(private readonly OutputStyle $output) {}
+
+    /**
+     * Render the report (findings grouped by severity, plus stale-waiver findings) to the invoking surface.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintReport  $report
+     * @return void
+     */
+    #[\Override]
+    public function report(RouteLintReport $report): void
+    {
+        if (!$report->hasErrors() && $report->warnings() === [] && $report->staleWaivers() === []) {
+            $this->output->info('All routes conform to the RESTful conventions.');
+
+            return;
+        }
+
+        $this->renderErrors($report->errors());
+        $this->renderWarnings($report->warnings());
+        $this->renderStaleWaivers($report->staleWaivers());
+    }
+
+    /**
+     * Render error-severity violations, skipping the section when the list is empty.
+     *
+     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>  $errors
+     * @return void
+     */
+    private function renderErrors(array $errors): void
+    {
+        if ($errors === []) {
+            return;
+        }
+
+        $this->output->error('Route linting errors:');
+
+        foreach ($errors as $violation) {
+            $this->output->writeln($this->formatViolation($violation));
+        }
+    }
+
+    /**
+     * Render warning-severity violations, skipping the section when the list is empty.
+     *
+     * @param  array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>  $warnings
+     * @return void
+     */
+    private function renderWarnings(array $warnings): void
+    {
+        if ($warnings === []) {
+            return;
+        }
+
+        $this->output->warning('Route linting warnings:');
+
+        foreach ($warnings as $violation) {
+            $this->output->writeln($this->formatViolation($violation));
+        }
+    }
+
+    /**
+     * Render stale-waiver entries, skipping the section when the list is empty.
+     *
+     * @param  array<int, string>  $staleWaivers
+     * @return void
+     */
+    private function renderStaleWaivers(array $staleWaivers): void
+    {
+        if ($staleWaivers === []) {
+            return;
+        }
+
+        $this->output->warning('Stale allowlist entries (matched no live route):');
+
+        foreach ($staleWaivers as $entry) {
+            $this->output->writeln(sprintf('  - %s', $entry));
+        }
+    }
+
+    /**
+     * Format a single violation as a console line.
+     *
+     * Produces: `  [R1] GET /users (getUsers) -- Hint: use a noun-based path instead`
+     * When remediationHint is null the hint segment is omitted.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation
+     * @return string
+     */
+    private function formatViolation(Violation $violation): string
+    {
+        $line = sprintf(
+            '  [%s] %s (%s)',
+            $violation->ruleId,
+            $violation->routeIdentity,
+            $violation->offendingSurface,
+        );
+
+        if ($violation->remediationHint !== null) {
+            $line .= sprintf(' -- Hint: %s', $violation->remediationHint);
+        }
+
+        return $line;
+    }
+}

--- a/src/RouteLinting/Output/ConsoleLintReporter.php
+++ b/src/RouteLinting/Output/ConsoleLintReporter.php
@@ -99,7 +99,7 @@ final class ConsoleLintReporter implements LintReporter
             return;
         }
 
-        $this->output->warning('Stale allowlist entries (matched no live route):');
+        $this->output->warning('Stale waivers / unused suppressions:');
 
         foreach ($staleWaivers as $entry) {
             $this->output->writeln(sprintf('  - %s', $entry));

--- a/src/RouteLinting/RouteLintEngine.php
+++ b/src/RouteLinting/RouteLintEngine.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+
+/**
+ * Pure ordered rule-set orchestrator for a single route.
+ *
+ * Runs each registered rule over a single normalised route and returns the
+ * aggregated violations in a deterministic order. Rules are executed in the
+ * fixed order they were supplied to the constructor — no sorting, no
+ * randomness, no global state — so calling inspect() twice with the same
+ * inputs returns byte-identical arrays (NFR-01).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RouteLintEngine
+{
+    /** @var array<int|string, \SineMacula\ApiToolkit\RouteLinting\Contracts\Rule> */
+    private readonly array $rules;
+
+    /**
+     * Create a new route lint engine.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Contracts\Rule  ...$rules
+     */
+    public function __construct(Rule ...$rules)
+    {
+        $this->rules = $rules;
+    }
+
+    /**
+     * Run every rule over the given normalised route and return the aggregated violations.
+     *
+     * Rules are executed in the fixed order they were supplied to the constructor.
+     * The returned array preserves that order — no additional sorting is applied
+     * here; deterministic final ordering is the report's responsibility.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $violations = [];
+
+        foreach ($this->rules as $rule) {
+            array_push($violations, ...$rule->inspect($route, $config));
+        }
+
+        return $violations;
+    }
+}

--- a/src/RouteLinting/RouteLintReport.php
+++ b/src/RouteLinting/RouteLintReport.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+/**
+ * Mutable verdict aggregate for a route-linting run.
+ *
+ * Collects violations and stale-waiver entries as they are discovered, then
+ * exposes them in a deterministic total order so two runs over the same inputs
+ * produce byte-identical output. The error gate (`hasErrors()`) is driven
+ * solely by ERROR-severity violations; WARNING-severity findings and stale
+ * waivers are surfaced but do not raise the gate.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RouteLintReport
+{
+    /** @var array<int, \SineMacula\ApiToolkit\RouteLinting\Violation> */
+    private array $violations = [];
+
+    /** @var array<int, string> */
+    private array $staleWaivers = [];
+
+    /**
+     * Add a violation to the report.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation
+     * @return void
+     */
+    public function addViolation(Violation $violation): void
+    {
+        $this->violations[] = $violation;
+    }
+
+    /**
+     * Record an allowlist entry that matched no live route.
+     *
+     * @param  string  $entry
+     * @return void
+     */
+    public function addStaleWaiver(string $entry): void
+    {
+        $this->staleWaivers[] = $entry;
+    }
+
+    /**
+     * Return ERROR-severity violations in a deterministic total order.
+     *
+     * Sorted by: routeIdentity ASC, then ruleId ASC, then offendingSurface ASC.
+     *
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    public function errors(): array
+    {
+        return $this->sorted(Severity::ERROR);
+    }
+
+    /**
+     * Return WARNING-severity violations in a deterministic total order.
+     *
+     * Sorted by: routeIdentity ASC, then ruleId ASC, then offendingSurface ASC.
+     *
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    public function warnings(): array
+    {
+        return $this->sorted(Severity::WARNING);
+    }
+
+    /**
+     * Return stale allowlist entries sorted ascending.
+     *
+     * @return array<int, string>
+     */
+    public function staleWaivers(): array
+    {
+        $entries = $this->staleWaivers;
+        sort($entries);
+
+        return $entries;
+    }
+
+    /**
+     * Determine whether the report contains any ERROR-severity violations.
+     *
+     * @return bool
+     */
+    public function hasErrors(): bool
+    {
+        return $this->errors() !== [];
+    }
+
+    /**
+     * Filter violations by severity and sort them by the deterministic composite key.
+     *
+     * The composite key is: routeIdentity ASC, then ruleId ASC, then
+     * offendingSurface ASC. This total order guarantees that two runs over
+     * the same inputs produce byte-identical arrays regardless of insertion
+     * order (NFR-01).
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Severity  $severity
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    private function sorted(Severity $severity): array
+    {
+        $filtered = array_filter(
+            $this->violations,
+            fn (Violation $violation) => $violation->severity === $severity,
+        );
+
+        usort($filtered, fn (Violation $a, Violation $b): int => $a->routeIdentity <=> $b->routeIdentity
+                ?: $a->ruleId                                                      <=> $b->ruleId
+                ?: $a->offendingSurface                                            <=> $b->offendingSurface);
+
+        return $filtered;
+    }
+}

--- a/src/RouteLinting/Rules/ApiResourceAlignmentRule.php
+++ b/src/RouteLinting/Rules/ApiResourceAlignmentRule.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R9: apiResource-alignment warning.
+ *
+ * Flags HTML-only form actions (`create` and `edit`) that appear as the final
+ * literal segment of a URI on an API surface. These segments correspond to
+ * Laravel's `create` and `edit` resource actions, which render HTML forms and
+ * have no valid place in a JSON API. The check is restricted to the final
+ * literal segment to keep precision high and avoid false positives on resource
+ * names that happen to contain these strings in a non-terminal position.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ApiResourceAlignmentRule implements Rule
+{
+    /** HTML-only action segments that must not appear as the final literal URI segment on an API surface. */
+    private const HTML_ONLY_ACTIONS = ['create', 'edit'];
+
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R9';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::WARNING;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $lastLiteral = $this->lastLiteralSegment($route->segments);
+
+        if ($lastLiteral === null || !in_array($lastLiteral, self::HTML_ONLY_ACTIONS, true)) {
+            return [];
+        }
+
+        return [
+            new Violation(
+                ruleId: $this->id(),
+                severity: Severity::WARNING,
+                routeIdentity: $route->identity(),
+                offendingSurface: $lastLiteral,
+                remediationHint: null,
+            ),
+        ];
+    }
+
+    /**
+     * Return the final non-empty, non-parameter segment, or null when none exists.
+     *
+     * @param  array<int, string>  $segments
+     * @return string|null
+     */
+    private function lastLiteralSegment(array $segments): ?string
+    {
+        foreach (array_reverse($segments) as $segment) {
+            if ($segment === '' || str_starts_with($segment, '{')) {
+                continue;
+            }
+
+            return $segment;
+        }
+
+        return null;
+    }
+}

--- a/src/RouteLinting/Rules/ApiResourceAlignmentRule.php
+++ b/src/RouteLinting/Rules/ApiResourceAlignmentRule.php
@@ -67,7 +67,7 @@ final class ApiResourceAlignmentRule implements Rule
         return [
             new Violation(
                 ruleId: $this->id(),
-                severity: Severity::WARNING,
+                severity: $this->severity(),
                 routeIdentity: $route->identity(),
                 offendingSurface: $lastLiteral,
                 remediationHint: null,

--- a/src/RouteLinting/Rules/KebabCaseRule.php
+++ b/src/RouteLinting/Rules/KebabCaseRule.php
@@ -62,7 +62,7 @@ final class KebabCaseRule implements Rule
             if (!preg_match('/^[a-z0-9]+(-[a-z0-9]+)*$/', $segment)) {
                 $violations[] = new Violation(
                     ruleId: $this->id(),
-                    severity: Severity::ERROR,
+                    severity: $this->severity(),
                     routeIdentity: $route->identity(),
                     offendingSurface: $segment,
                     remediationHint: null,

--- a/src/RouteLinting/Rules/KebabCaseRule.php
+++ b/src/RouteLinting/Rules/KebabCaseRule.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R2: Kebab-case segment enforcement.
+ *
+ * Flags any literal URI segment that does not conform to kebab-case, i.e.
+ * does not match the pattern `^[a-z0-9]+(-[a-z0-9]+)*$`. Route-parameter
+ * segments (those wrapped in `{...}`) and empty segments are ignored.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class KebabCaseRule implements Rule
+{
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R2';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::ERROR;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $violations = [];
+
+        foreach ($route->segments as $segment) {
+            if ($segment === '' || str_starts_with($segment, '{')) {
+                continue;
+            }
+
+            if (!preg_match('/^[a-z0-9]+(-[a-z0-9]+)*$/', $segment)) {
+                $violations[] = new Violation(
+                    ruleId: $this->id(),
+                    severity: Severity::ERROR,
+                    routeIdentity: $route->identity(),
+                    offendingSurface: $segment,
+                    remediationHint: null,
+                );
+            }
+        }
+
+        return $violations;
+    }
+}

--- a/src/RouteLinting/Rules/LowercaseRule.php
+++ b/src/RouteLinting/Rules/LowercaseRule.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R3: Lowercase-only segment enforcement.
+ *
+ * Flags any literal URI segment that contains one or more uppercase ASCII
+ * letters (A–Z). Route-parameter segments (those wrapped in `{...}`) and
+ * empty segments are ignored.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LowercaseRule implements Rule
+{
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R3';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::ERROR;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $violations = [];
+
+        foreach ($route->segments as $segment) {
+            if ($segment === '' || str_starts_with($segment, '{')) {
+                continue;
+            }
+
+            if ($segment !== strtolower($segment)) {
+                $violations[] = new Violation(
+                    ruleId: $this->id(),
+                    severity: Severity::ERROR,
+                    routeIdentity: $route->identity(),
+                    offendingSurface: $segment,
+                    remediationHint: null,
+                );
+            }
+        }
+
+        return $violations;
+    }
+}

--- a/src/RouteLinting/Rules/LowercaseRule.php
+++ b/src/RouteLinting/Rules/LowercaseRule.php
@@ -62,7 +62,7 @@ final class LowercaseRule implements Rule
             if ($segment !== strtolower($segment)) {
                 $violations[] = new Violation(
                     ruleId: $this->id(),
-                    severity: Severity::ERROR,
+                    severity: $this->severity(),
                     routeIdentity: $route->identity(),
                     offendingSurface: $segment,
                     remediationHint: null,

--- a/src/RouteLinting/Rules/NestingDepthRule.php
+++ b/src/RouteLinting/Rules/NestingDepthRule.php
@@ -70,7 +70,7 @@ final class NestingDepthRule implements Rule
         return [
             new Violation(
                 ruleId: $this->id(),
-                severity: Severity::WARNING,
+                severity: $this->severity(),
                 routeIdentity: $route->identity(),
                 offendingSurface: $route->uri,
                 remediationHint: null,

--- a/src/RouteLinting/Rules/NestingDepthRule.php
+++ b/src/RouteLinting/Rules/NestingDepthRule.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R11: Nesting-depth smell warning.
+ *
+ * Flags routes whose URI nests more than three collection levels. A collection
+ * level is each literal (non-parameter, non-empty) segment excluding common
+ * API prefix segments (`api` and version tokens matching `v\d+`). Nesting
+ * beyond three levels indicates a URI that could be restructured as a
+ * top-level or shallower resource, reducing coupling between resource types.
+ * A depth of exactly three is clean; four or more triggers a warning.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class NestingDepthRule implements Rule
+{
+    /** Maximum collection levels before a warning is raised. */
+    private const MAX_DEPTH = 3;
+
+    /** Literal prefix segments excluded from the collection-level count. */
+    private const EXCLUDED_PREFIXES = ['api'];
+
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R11';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::WARNING;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $depth = $this->collectionDepth($route->segments);
+
+        if ($depth <= self::MAX_DEPTH) {
+            return [];
+        }
+
+        return [
+            new Violation(
+                ruleId: $this->id(),
+                severity: Severity::WARNING,
+                routeIdentity: $route->identity(),
+                offendingSurface: $route->uri,
+                remediationHint: null,
+            ),
+        ];
+    }
+
+    /**
+     * Count the number of collection-level literal segments in the given segment list.
+     *
+     * Empty segments, route-parameter segments, `api`, and version-prefix tokens
+     * (`v` followed by one or more digits) are excluded from the count.
+     *
+     * @param  array<int, string>  $segments
+     * @return int
+     */
+    private function collectionDepth(array $segments): int
+    {
+        $depth = 0;
+
+        foreach ($segments as $segment) {
+            if ($segment === '' || str_starts_with($segment, '{')) {
+                continue;
+            }
+
+            if (in_array($segment, self::EXCLUDED_PREFIXES, true)) {
+                continue;
+            }
+
+            if (preg_match('/^v\d+$/i', $segment)) {
+                continue;
+            }
+
+            $depth++;
+        }
+
+        return $depth;
+    }
+}

--- a/src/RouteLinting/Rules/PluralCollectionsRule.php
+++ b/src/RouteLinting/Rules/PluralCollectionsRule.php
@@ -88,7 +88,7 @@ final class PluralCollectionsRule implements Rule
 
             $violations[] = new Violation(
                 ruleId: $this->id(),
-                severity: Severity::ERROR,
+                severity: $this->severity(),
                 routeIdentity: $route->identity(),
                 offendingSurface: $segment,
                 remediationHint: null,

--- a/src/RouteLinting/Rules/PluralCollectionsRule.php
+++ b/src/RouteLinting/Rules/PluralCollectionsRule.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R4: Plural-collections enforcement.
+ *
+ * Flags every literal URI segment that represents a resource collection but is
+ * not plural. A segment is treated as a collection when it is immediately
+ * followed by a route-parameter segment (`{param}`), or when it is the last
+ * literal segment of the path (a top-level collection). Parameter segments and
+ * empty segments are never evaluated. Uncountable nouns configured in the
+ * active rule config are treated as plural-safe and never flagged.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class PluralCollectionsRule implements Rule
+{
+    /**
+     * Create a new plural collections rule.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector  $inflector
+     */
+    public function __construct(private readonly Inflector $inflector) {}
+
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R4';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::ERROR;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $violations = [];
+        $segments   = $route->segments;
+        $total      = count($segments);
+
+        for ($i = 0; $i < $total; $i++) {
+            $segment = $segments[$i];
+
+            if ($segment === '' || str_starts_with($segment, '{')) {
+                continue;
+            }
+
+            if (!$this->isCollectionSegment($i, $segments)) {
+                continue;
+            }
+
+            if (in_array($segment, $config->uncountables, true)) {
+                continue;
+            }
+
+            if ($this->inflector->isPlural($segment)) {
+                continue;
+            }
+
+            $violations[] = new Violation(
+                ruleId: $this->id(),
+                severity: Severity::ERROR,
+                routeIdentity: $route->identity(),
+                offendingSurface: $segment,
+                remediationHint: null,
+            );
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Determine whether the segment at the given index is a collection segment.
+     *
+     * A segment is a collection when it is immediately followed by a
+     * route-parameter segment, or when every subsequent segment is either
+     * empty or a route parameter (i.e. it is the final literal segment).
+     *
+     * @param  int  $index
+     * @param  array<int, string>  $segments
+     * @return bool
+     */
+    private function isCollectionSegment(int $index, array $segments): bool
+    {
+        $next = $segments[$index + 1] ?? null;
+
+        if ($next !== null && str_starts_with($next, '{')) {
+            return true;
+        }
+
+        // The segment is the final literal segment when every subsequent
+        // segment is either empty or a route parameter.
+        for ($j = $index + 1; $j < count($segments); $j++) {
+            if ($segments[$j] !== '' && !str_starts_with($segments[$j], '{')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/RouteLinting/Rules/RouteNameRule.php
+++ b/src/RouteLinting/Rules/RouteNameRule.php
@@ -66,7 +66,7 @@ final class RouteNameRule implements Rule
             : [
                 new Violation(
                     ruleId: $this->id(),
-                    severity: Severity::WARNING,
+                    severity: $this->severity(),
                     routeIdentity: $route->identity(),
                     offendingSurface: $route->name,
                     remediationHint: null,

--- a/src/RouteLinting/Rules/RouteNameRule.php
+++ b/src/RouteLinting/Rules/RouteNameRule.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R8: Route-name convention enforcement.
+ *
+ * Flags any named route whose name does not follow the `{resource}.{action}`
+ * convention, where the action (the substring after the last `.`) must be one
+ * of the seven canonical RESTful actions: index, show, store, update, destroy,
+ * create, edit. Unnamed routes are silently skipped. A name whose resource
+ * part (before the last `.`) is empty (e.g. `.index`) is also flagged.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RouteNameRule implements Rule
+{
+    /** The canonical RESTful actions that are permitted as the final name segment. */
+    private const ALLOWED_ACTIONS = ['index', 'show', 'store', 'update', 'destroy', 'create', 'edit'];
+
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R8';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::WARNING;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        if ($route->name === null) {
+            return [];
+        }
+
+        return $this->conformsToConvention($route->name)
+            ? []
+            : [
+                new Violation(
+                    ruleId: $this->id(),
+                    severity: Severity::WARNING,
+                    routeIdentity: $route->identity(),
+                    offendingSurface: $route->name,
+                    remediationHint: null,
+                ),
+            ];
+    }
+
+    /**
+     * Determine whether a route name follows the {resource}.{action} convention.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    private function conformsToConvention(string $name): bool
+    {
+        $lastDot = strrpos($name, '.');
+
+        if ($lastDot === false || $lastDot === 0) {
+            return false;
+        }
+
+        $action   = substr($name, $lastDot + 1);
+        $resource = substr($name, 0, $lastDot);
+
+        return $resource !== '' && in_array($action, self::ALLOWED_ACTIONS, true);
+    }
+}

--- a/src/RouteLinting/Rules/SlashSanityRule.php
+++ b/src/RouteLinting/Rules/SlashSanityRule.php
@@ -69,7 +69,7 @@ final class SlashSanityRule implements Rule
         return [
             new Violation(
                 ruleId: $this->id(),
-                severity: Severity::ERROR,
+                severity: $this->severity(),
                 routeIdentity: $route->identity(),
                 offendingSurface: $uri,
                 remediationHint: null,

--- a/src/RouteLinting/Rules/SlashSanityRule.php
+++ b/src/RouteLinting/Rules/SlashSanityRule.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R5: Slash-sanity enforcement.
+ *
+ * Flags any route URI that contains a trailing slash or a duplicate (empty)
+ * slash. One violation is emitted per offending route regardless of how many
+ * defects are present. The root path and empty URIs are excluded from
+ * inspection because they are not REST collection URIs.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class SlashSanityRule implements Rule
+{
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R5';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::ERROR;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $uri = $route->uri;
+
+        if ($uri === '' || $uri === '/') {
+            return [];
+        }
+
+        $hasTrailingSlash  = str_ends_with($uri, '/');
+        $hasDuplicateSlash = str_contains($uri, '//');
+
+        if (!$hasTrailingSlash && !$hasDuplicateSlash) {
+            return [];
+        }
+
+        return [
+            new Violation(
+                ruleId: $this->id(),
+                severity: Severity::ERROR,
+                routeIdentity: $route->identity(),
+                offendingSurface: $uri,
+                remediationHint: null,
+            ),
+        ];
+    }
+}

--- a/src/RouteLinting/Rules/StandardMethodsRule.php
+++ b/src/RouteLinting/Rules/StandardMethodsRule.php
@@ -70,7 +70,7 @@ final class StandardMethodsRule implements Rule
         return [
             new Violation(
                 ruleId: $this->id(),
-                severity: Severity::ERROR,
+                severity: $this->severity(),
                 routeIdentity: $route->identity(),
                 offendingSurface: implode(', ', $nonStandard),
                 remediationHint: null,

--- a/src/RouteLinting/Rules/StandardMethodsRule.php
+++ b/src/RouteLinting/Rules/StandardMethodsRule.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Rule R7: Standard HTTP methods only.
+ *
+ * Flags any route that carries at least one HTTP method outside the standard
+ * set (GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS). This catches routes
+ * registered with Route::any() or a custom/non-standard verb such as PURGE.
+ * An empty methods array produces no violation (defensive guard).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class StandardMethodsRule implements Rule
+{
+    /** The RFC-standard HTTP methods that the linter accepts without complaint. */
+    private const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R7';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::ERROR;
+    }
+
+    /**
+     * Inspect one normalised route and return zero or more violations.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $nonStandard = array_values(array_filter(
+            $route->methods,
+            static fn (string $method): bool => !in_array($method, self::ALLOWED_METHODS, true),
+        ));
+
+        if ($nonStandard === []) {
+            return [];
+        }
+
+        sort($nonStandard);
+
+        return [
+            new Violation(
+                ruleId: $this->id(),
+                severity: Severity::ERROR,
+                routeIdentity: $route->identity(),
+                offendingSurface: implode(', ', $nonStandard),
+                remediationHint: null,
+            ),
+        ];
+    }
+}

--- a/src/RouteLinting/Rules/Support/SegmentNormaliser.php
+++ b/src/RouteLinting/Rules/Support/SegmentNormaliser.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules\Support;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+
+/**
+ * Deterministic 6-step pipeline that reduces a URI to candidate verb-test words.
+ *
+ * The pipeline is a pure function of its inputs — no randomness, no external
+ * state. Steps: split on `/`, drop route parameters, drop version/prefix
+ * segments, decompose compound segments across camelCase/kebab/snake/dot
+ * boundaries, lowercase every word, then singularise via the injected
+ * Inflector port (uncountable words bypass singularisation and pass through
+ * unchanged).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class SegmentNormaliser
+{
+    /**
+     * Create a new segment normaliser.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector  $inflector
+     */
+    public function __construct(private Inflector $inflector) {}
+
+    /**
+     * Reduce a raw URI path to its candidate verb-test words.
+     *
+     * Applies the 6-step pipeline in order: split path, drop route parameters,
+     * drop version/prefix segments, decompose compound segments, lowercase, and
+     * singularise. Uncountable words are passed through unchanged. Returns the
+     * flat ordered list of candidate words across all surviving segments.
+     *
+     * @param  string  $uri
+     * @param  array<int, string>  $uncountables
+     * @return array<int, string>
+     */
+    public function normalise(string $uri, array $uncountables): array
+    {
+        // Step 1 — split on '/' and discard empty segments
+        $segments = array_values(array_filter(explode('/', $uri), fn (string $s): bool => $s !== ''));
+
+        // Step 2 — drop route parameters (wrapped in braces, optional or required)
+        $segments = array_values(array_filter($segments, fn (string $s): bool => !preg_match('/^\{[^}]+}$/', $s)));
+
+        // Step 3 — drop version segments (v1, v2, …) and the literal 'api' prefix
+        $segments = array_values(array_filter($segments, fn (string $s): bool => !preg_match('/^v\d+$/i', $s) && strtolower($s) !== 'api'));
+
+        // Step 4 — decompose compound segments across camelCase, kebab, snake, and dot boundaries
+        $words = [];
+
+        foreach ($segments as $segment) {
+            // Insert a space before each uppercase letter preceded by a lowercase letter (camelCase boundary)
+            $spaced = preg_replace('/([a-z])([A-Z])/', '$1 $2', $segment) ?? $segment;
+
+            // Split on whitespace, hyphen, underscore, and dot; guard against preg_split returning false
+            $parts = preg_split('/[\s\-_.]+/', $spaced) ?: [];
+
+            foreach ($parts as $part) {
+                if ($part !== '') {
+                    $words[] = $part;
+                }
+            }
+        }
+
+        // Step 5 — lowercase every decomposed word
+        $words = array_map('strtolower', $words);
+
+        // Step 6 — singularise each word via the injected inflector port;
+        // uncountable words bypass singularisation and are returned as-is
+        return array_map(
+            fn (string $word): string => in_array($word, $uncountables, true)
+                ? $word
+                : $this->inflector->singular($word),
+            $words,
+        );
+    }
+}

--- a/src/RouteLinting/Rules/Support/VerbDenylist.php
+++ b/src/RouteLinting/Rules/Support/VerbDenylist.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules\Support;
+
+/**
+ * Membership oracle and remediation-hint lookup for the verb denylist.
+ *
+ * Answers two questions: is a given normalised candidate word a denylisted
+ * action verb, and what RESTful rewrite hint is associated with it? The
+ * denylist is the single global tuning surface — removing a verb from
+ * construction makes contains() return false for it, without needing per-route
+ * exemptions.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class VerbDenylist
+{
+    /**
+     * Lowercase-indexed set of denylisted verbs, keyed by verb for O(1) lookup.
+     *
+     * @var array<string, true>
+     */
+    private array $verbIndex;
+
+    /**
+     * Create a new verb denylist.
+     *
+     * @param  array<int, string>  $verbs
+     * @param  array<string, string>  $hints
+     */
+    public function __construct(
+        array $verbs,
+        private readonly array $hints,
+    ) {
+        $this->verbIndex = array_fill_keys(
+            array_map('strtolower', $verbs),
+            true,
+        );
+    }
+
+    /**
+     * Determine whether the given normalised candidate word is a denylisted action verb.
+     *
+     * @param  string  $word
+     * @return bool
+     */
+    public function contains(string $word): bool
+    {
+        return isset($this->verbIndex[strtolower($word)]);
+    }
+
+    /**
+     * Return the remediation hint for a denylisted verb, or null when none is configured.
+     *
+     * @param  string  $word
+     * @return string|null
+     */
+    public function hint(string $word): ?string
+    {
+        return $this->hints[strtolower($word)] ?? null;
+    }
+}

--- a/src/RouteLinting/Rules/VerbInPathRule.php
+++ b/src/RouteLinting/Rules/VerbInPathRule.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Rules;
+
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+
+/**
+ * Error-severity rule R1: flags action verbs embedded in URI path segments.
+ *
+ * Reduces the route URI to candidate words via the SegmentNormaliser pipeline
+ * (split, drop parameters, drop version/prefix, decompose compound, lowercase,
+ * singularise), then tests each candidate against the VerbDenylist. Each
+ * distinct denylisted verb found across the route's segments produces one
+ * error-severity Violation carrying the verb as the offending surface and the
+ * configured RESTful-rewrite hint. A clean plural collection such as `/users`
+ * normalises to the noun `user` which is not a verb and is never flagged.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class VerbInPathRule implements Rule
+{
+    /**
+     * Create a new verb-in-path rule.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser  $normaliser
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist  $denylist
+     */
+    public function __construct(
+        private readonly SegmentNormaliser $normaliser,
+        private readonly VerbDenylist $denylist,
+    ) {}
+
+    /**
+     * Return the stable rule identifier.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function id(): string
+    {
+        return 'R1';
+    }
+
+    /**
+     * Return the severity tier for this rule.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+     */
+    #[\Override]
+    public function severity(): Severity
+    {
+        return Severity::ERROR;
+    }
+
+    /**
+     * Inspect the route for action verbs in path segments and return one violation per distinct offender.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+     */
+    #[\Override]
+    public function inspect(NormalisedRoute $route, RuleConfig $config): array
+    {
+        $words      = $this->normaliser->normalise($route->uri, $config->uncountables);
+        $violations = [];
+        $seen       = [];
+
+        foreach ($words as $word) {
+            if (isset($seen[$word]) || !$this->denylist->contains($word)) {
+                continue;
+            }
+
+            $seen[$word]  = true;
+            $violations[] = new Violation(
+                ruleId: 'R1',
+                severity: Severity::ERROR,
+                routeIdentity: $route->identity(),
+                offendingSurface: $word,
+                remediationHint: $this->denylist->hint($word),
+            );
+        }
+
+        return $violations;
+    }
+}

--- a/src/RouteLinting/Rules/VerbInPathRule.php
+++ b/src/RouteLinting/Rules/VerbInPathRule.php
@@ -80,8 +80,8 @@ final class VerbInPathRule implements Rule
 
             $seen[$word]  = true;
             $violations[] = new Violation(
-                ruleId: 'R1',
-                severity: Severity::ERROR,
+                ruleId: $this->id(),
+                severity: $this->severity(),
                 routeIdentity: $route->identity(),
                 offendingSurface: $word,
                 remediationHint: $this->denylist->hint($word),

--- a/src/RouteLinting/Rules/VerbInPathRule.php
+++ b/src/RouteLinting/Rules/VerbInPathRule.php
@@ -74,7 +74,7 @@ final class VerbInPathRule implements Rule
         $seen       = [];
 
         foreach ($words as $word) {
-            if (isset($seen[$word]) || !$this->denylist->contains($word)) {
+            if (($seen[$word] ?? false) || !$this->denylist->contains($word)) {
                 continue;
             }
 

--- a/src/RouteLinting/Severity.php
+++ b/src/RouteLinting/Severity.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+/**
+ * The severity tier for a route-linting finding.
+ *
+ * ERROR-severity violations gate CI (the command exits non-zero when any are
+ * present). WARNING-severity violations are surfaced but do not raise the error
+ * gate. Every rule declares its tier through this enum so callers never
+ * hard-code string comparisons against finding metadata.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+enum Severity: string
+{
+    /** A finding that must be resolved before the route passes the linter gate. */
+    case ERROR = 'error';
+
+    /** A finding that is surfaced for awareness but does not block the gate. */
+    case WARNING = 'warning';
+}

--- a/src/RouteLinting/Sources/RouterRouteSource.php
+++ b/src/RouteLinting/Sources/RouterRouteSource.php
@@ -94,7 +94,7 @@ final class RouterRouteSource implements RouteSource
     /**
      * Determine whether a closure-backed route's defining file is under vendor.
      *
-     * @param  \Closure(): mixed  $closure
+     * @param  \Closure(): void  $closure
      * @return bool
      */
     private function isClosureVendor(\Closure $closure): bool

--- a/src/RouteLinting/Sources/RouterRouteSource.php
+++ b/src/RouteLinting/Sources/RouterRouteSource.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use SineMacula\ApiToolkit\RouteLinting\Contracts\RouteSource;
 use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteSuppression;
 
 /**
  * Route-source adapter backed by the Laravel router.
@@ -65,7 +66,43 @@ final class RouterRouteSource implements RouteSource
             methods: $route->methods(),
             name: $route->getName(),
             isVendor: $this->isVendorRoute($route),
+            suppressions: $this->buildSuppressions($route),
         );
+    }
+
+    /**
+     * Extract inline suppressions from the route action array.
+     *
+     * Reads the `api-toolkit::lint-ignore` key written by the `ignoreRouteLint`
+     * macro. Each entry must be an array with a `rules` array and a `reason`
+     * string; entries that do not conform to this shape are silently skipped so
+     * a corrupt route cache never crashes the linter.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return list<\SineMacula\ApiToolkit\RouteLinting\Dto\RouteSuppression>
+     */
+    private function buildSuppressions(Route $route): array
+    {
+        $raw = $route->getAction('api-toolkit::lint-ignore');
+
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        $suppressions = [];
+
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $rules  = isset($entry['rules'])  && is_array($entry['rules']) ? array_values($entry['rules']) : [];
+            $reason = isset($entry['reason']) && is_string($entry['reason']) ? $entry['reason'] : '';
+
+            $suppressions[] = new RouteSuppression($rules, $reason);
+        }
+
+        return $suppressions;
     }
 
     /**

--- a/src/RouteLinting/Sources/RouterRouteSource.php
+++ b/src/RouteLinting/Sources/RouterRouteSource.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Sources;
+
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\RouteSource;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
+
+/**
+ * Route-source adapter backed by the Laravel router.
+ *
+ * Enumerates the live route table via `Router::getRoutes()` after a full
+ * application boot — the same source that `route:list` consumes — and maps
+ * each route to a `RouteDescriptor` DTO. Vendor routes (whose defining class
+ * or closure resolves to a file under the `vendor/` directory) are excluded
+ * from the returned set; the domain never sees a framework `Route` object.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RouterRouteSource implements RouteSource
+{
+    /** @var string The path segment used to identify vendor-owned files. */
+    private const string VENDOR_SEGMENT = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR;
+
+    /**
+     * Create a new router-backed route source.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     */
+    public function __construct(private readonly Router $router) {}
+
+    /**
+     * Enumerate every app-owned route, excluding vendor routes.
+     *
+     * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor>
+     */
+    #[\Override]
+    public function appRoutes(): array
+    {
+        $descriptors = [];
+
+        foreach ($this->router->getRoutes()->getRoutes() as $route) {
+            $descriptor = $this->toDescriptor($route);
+
+            if (!$descriptor->isVendor) {
+                $descriptors[] = $descriptor;
+            }
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * Map a single framework route to a descriptor DTO.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return \SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor
+     */
+    private function toDescriptor(Route $route): RouteDescriptor
+    {
+        return new RouteDescriptor(
+            uri: $route->uri(),
+            methods: $route->methods(),
+            name: $route->getName(),
+            isVendor: $this->isVendorRoute($route),
+        );
+    }
+
+    /**
+     * Determine whether a route belongs to a vendor package.
+     *
+     * Resolution strategy mirrors `route:list --except-vendor`:
+     * - Closure routes: reflect the closure's defining file.
+     * - Controller routes: reflect the controller class's defining file.
+     * - Unresolvable sources default to app-owned (false) so no app route is
+     *   silently dropped.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     */
+    private function isVendorRoute(Route $route): bool
+    {
+        $uses = $route->getAction('uses');
+
+        if ($uses instanceof \Closure) {
+            return $this->isClosureVendor($uses);
+        }
+
+        return is_string($uses) && $this->isControllerVendor($route);
+    }
+
+    /**
+     * Determine whether a closure-backed route's defining file is under vendor.
+     *
+     * @param  \Closure(): mixed  $closure
+     * @return bool
+     */
+    private function isClosureVendor(\Closure $closure): bool
+    {
+        try {
+            $file = (new \ReflectionFunction($closure))->getFileName();
+        } catch (\ReflectionException) {
+            return false;
+        }
+
+        return $this->fileIsVendor($file ?: null);
+    }
+
+    /**
+     * Determine whether a controller-backed route's defining class file is under vendor.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     */
+    private function isControllerVendor(Route $route): bool
+    {
+        $controllerClass = $route->getControllerClass();
+
+        if ($controllerClass === null) {
+            return false;
+        }
+
+        return $this->fileIsVendor($this->classFile($controllerClass));
+    }
+
+    /**
+     * Determine whether an absolute file path lives under a vendor directory.
+     *
+     * @param  string|null  $file
+     * @return bool
+     */
+    private function fileIsVendor(?string $file): bool
+    {
+        if ($file === null) {
+            return false;
+        }
+
+        return str_contains($file, self::VENDOR_SEGMENT);
+    }
+
+    /**
+     * Resolve the absolute file path that defines a given class.
+     *
+     * @param  string  $class
+     * @return string|null
+     */
+    private function classFile(string $class): ?string
+    {
+        try {
+            return (new \ReflectionClass($class))->getFileName() ?: null;
+        } catch (\ReflectionException) {
+            return null;
+        }
+    }
+}

--- a/src/RouteLinting/Support/RouteLintMacros.php
+++ b/src/RouteLinting/Support/RouteLintMacros.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting\Support;
+
+use Illuminate\Routing\Route;
+use SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException;
+
+/**
+ * Registers route macros used by the route-lint suppression feature.
+ *
+ * The static `register()` entry point is idempotent — it checks for an
+ * existing macro before binding — so it is safe to call from service-provider
+ * `boot()` methods without risk of double-registration across test resets or
+ * multiple provider loads.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RouteLintMacros
+{
+    /**
+     * Register all route-lint macros onto the Illuminate Route class.
+     *
+     * Idempotent: skips registration when the macro already exists.
+     *
+     * @return void
+     */
+    public static function register(): void
+    {
+        if (Route::hasMacro('ignoreRouteLint')) {
+            return;
+        }
+
+        /*
+         * Suppress one or more route-lint rules for this route.
+         *
+         * Pass an empty `$ruleIds` array to suppress all rules. Multiple calls
+         * accumulate; each call appends an independent suppression entry to the
+         * route action. Data is stored as plain arrays so it survives
+         * `route:cache` serialisation.
+         *
+         * @param  list<string>  $ruleIds  Rule IDs to suppress; empty list means all rules.
+         * @param  string  $reason  Non-empty written justification for this suppression.
+         * @return \Illuminate\Routing\Route
+         *
+         * @throws \SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException
+         */
+        Route::macro('ignoreRouteLint', function (array $ruleIds, string $reason): Route {
+            // @var \Illuminate\Routing\Route $this
+            if (trim($reason) === '') {
+                throw new StaleWaiverException('A non-empty reason is required for ignoreRouteLint().');
+            }
+
+            $this->action['api-toolkit::lint-ignore'][] = [
+                'rules'  => array_values($ruleIds),
+                'reason' => $reason,
+            ];
+
+            return $this;
+        });
+    }
+}

--- a/src/RouteLinting/Violation.php
+++ b/src/RouteLinting/Violation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SineMacula\ApiToolkit\RouteLinting;
+
+/**
+ * Immutable finding emitted by a route-linting rule.
+ *
+ * Carries the rule that triggered the finding, its severity tier, the stable
+ * identity of the offending route, the specific surface that violated the rule,
+ * and an optional RESTful-rewrite hint where the rule can suggest one.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class Violation
+{
+    /**
+     * Create a new violation.
+     *
+     * @param  string  $ruleId
+     * @param  \SineMacula\ApiToolkit\RouteLinting\Severity  $severity
+     * @param  string  $routeIdentity
+     * @param  string  $offendingSurface
+     * @param  string|null  $remediationHint
+     */
+    public function __construct(
+
+        /** Stable rule identifier, e.g. `R1` */
+        public string $ruleId,
+
+        /** Severity tier: ERROR gates CI, WARNING is reported only */
+        public Severity $severity,
+
+        /** The `NormalisedRoute::identity()` of the offending route */
+        public string $routeIdentity,
+
+        /** The offending segment, route name, or method+URI shape */
+        public string $offendingSurface,
+
+        /** A RESTful-rewrite hint where the rule provides one, or null */
+        public ?string $remediationHint,
+
+    ) {}
+}

--- a/tests/Fixtures/Controllers/RouteLintController.php
+++ b/tests/Fixtures/Controllers/RouteLintController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures\Controllers;
+
+/**
+ * Minimal fixture controller for route linter integration tests.
+ *
+ * Provides a named action method so the route linter adapter can resolve
+ * the controller class file and confirm it is app-owned (not under vendor).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+class RouteLintController
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @return array<string, bool>
+     */
+    public function index(): array
+    {
+        return ['ok' => true];
+    }
+}

--- a/tests/Integration/Console/LintRoutesCommandTest.php
+++ b/tests/Integration/Console/LintRoutesCommandTest.php
@@ -109,6 +109,48 @@ class LintRoutesCommandTest extends TestCase
     }
 
     /**
+     * Test that a route whose only error is inline-suppressed exits zero, and
+     * that the unused suppression (the route is otherwise clean) is surfaced in
+     * the output but does not change the exit code.
+     *
+     * @return void
+     */
+    public function testInlineSuppressedRouteExitsZeroAndSurfacesStaleSuppression(): void
+    {
+        $this->seedConfig();
+
+        // /users is a clean route; the inline suppression for R1 fires on nothing
+        $this->getRouter()->get('users', fn () => [])
+            ->name('users.index')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'Unnecessary waiver added for demonstration.');
+
+        $this->runCommand()
+            ->expectsOutputToContain('Stale waivers / unused suppressions')
+            ->expectsOutputToContain('suppressed nothing')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * Test that a route whose only error is fully suppressed by an inline
+     * suppression (all rules) exits zero.
+     *
+     * @return void
+     */
+    public function testFullyInlineSuppressedRouteExitsZero(): void
+    {
+        $this->seedConfig();
+
+        // /getUsers triggers R1; inline suppression covers all rules
+        $this->getRouter()->get('getUsers', fn () => [])
+            ->name('get-users')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint([], 'All rules suppressed for this legacy route.');
+
+        $this->runCommand()->assertExitCode(0);
+    }
+
+    /**
      * Run the lint-routes command.
      *
      * @return \Illuminate\Testing\PendingCommand

--- a/tests/Integration/Console/LintRoutesCommandTest.php
+++ b/tests/Integration/Console/LintRoutesCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Integration\Console;
+
+use Illuminate\Routing\Router;
+use Illuminate\Testing\PendingCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Console\LintRoutesCommand;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the LintRoutesCommand Artisan command.
+ *
+ * Registers fixture routes on the booted framework router and drives the
+ * command via Testbench's artisan() helper, asserting exit codes and output.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(LintRoutesCommand::class)]
+class LintRoutesCommandTest extends TestCase
+{
+    /** @var string The command signature under test. */
+    private const string COMMAND = 'api-toolkit:lint-routes';
+
+    /** @var array<int, string> Default verb denylist used across tests. */
+    private const VERB_DENYLIST = [
+        'get', 'list', 'create', 'add', 'update', 'edit', 'delete',
+        'remove', 'cancel', 'login', 'logout', 'search', 'fetch',
+    ];
+
+    /**
+     * Test that the command exits non-zero when an error-severity violation is present.
+     *
+     * @return void
+     */
+    public function testExitsNonZeroWhenErrorViolationPresent(): void
+    {
+        $this->seedConfig();
+
+        $this->getRouter()->get('getUsers', fn () => [])->name('get-users');
+
+        $this->runCommand()->assertExitCode(1);
+    }
+
+    /**
+     * Test that the command exits zero when the route table is clean.
+     *
+     * @return void
+     */
+    public function testExitsZeroWhenTableIsClean(): void
+    {
+        $this->seedConfig();
+
+        $this->getRouter()->get('users', fn () => [])->name('users.index');
+
+        $this->runCommand()->assertExitCode(0);
+    }
+
+    /**
+     * Test that the command prints error findings in the output before failing.
+     *
+     * @return void
+     */
+    public function testPrintsFindingsBeforeFailing(): void
+    {
+        $this->seedConfig();
+
+        $this->getRouter()->get('getUsers', fn () => [])->name('get-users');
+
+        $this->runCommand()
+            ->expectsOutputToContain('Route linting errors')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * Test that a misconfigured waiver (entry without a reason) exits non-zero with an error message.
+     *
+     * @return void
+     */
+    public function testMisconfiguredWaiverFailsTheCommand(): void
+    {
+        $this->seedConfig([
+            ['match' => 'legacy.route'],
+        ]);
+
+        $this->getRouter()->get('users', fn () => [])->name('users.index');
+
+        $this->runCommand()
+            ->expectsOutputToContain('missing a required reason')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * Test that a route table with only warning-severity findings exits zero.
+     *
+     * @return void
+     */
+    public function testWarningOnlyTableExitsZero(): void
+    {
+        $this->seedConfig();
+
+        // A named route whose name does not follow {resource}.{action} — triggers R8 (warning)
+        $this->getRouter()->get('users', fn () => [])->name('users.getAll');
+
+        $this->runCommand()->assertExitCode(0);
+    }
+
+    /**
+     * Run the lint-routes command.
+     *
+     * @return \Illuminate\Testing\PendingCommand
+     */
+    private function runCommand(): PendingCommand
+    {
+        $command = $this->artisan(self::COMMAND);
+
+        assert($command instanceof PendingCommand);
+
+        return $command;
+    }
+
+    /**
+     * Seed the route_linting config section.
+     *
+     * @param  array<int, array<string, string>>  $exemptions
+     * @return void
+     */
+    private function seedConfig(array $exemptions = []): void
+    {
+        config()->set('api-toolkit.route_linting.verb_denylist', self::VERB_DENYLIST);
+        config()->set('api-toolkit.route_linting.remediation_hints', []);
+        config()->set('api-toolkit.route_linting.exemptions', $exemptions);
+        config()->set('api-toolkit.route_linting.uncountables', []);
+    }
+
+    /**
+     * Get the router instance bound to the booted application.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    private function getRouter(): Router
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Routing\Router */
+        return $this->app->make('router');
+    }
+}

--- a/tests/Integration/RouteLinting/LintRoutesTest.php
+++ b/tests/Integration/RouteLinting/LintRoutesTest.php
@@ -9,8 +9,10 @@ use SineMacula\ApiToolkit\RouteLinting\Inflection\FrameworkInflector;
 use SineMacula\ApiToolkit\RouteLinting\LintRoutes;
 use SineMacula\ApiToolkit\RouteLinting\RouteLintEngine;
 use SineMacula\ApiToolkit\RouteLinting\RouteLintReport;
+use SineMacula\ApiToolkit\RouteLinting\Rules\ApiResourceAlignmentRule;
 use SineMacula\ApiToolkit\RouteLinting\Rules\KebabCaseRule;
 use SineMacula\ApiToolkit\RouteLinting\Rules\LowercaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\NestingDepthRule;
 use SineMacula\ApiToolkit\RouteLinting\Rules\PluralCollectionsRule;
 use SineMacula\ApiToolkit\RouteLinting\Rules\RouteNameRule;
 use SineMacula\ApiToolkit\RouteLinting\Rules\SlashSanityRule;
@@ -214,6 +216,8 @@ class LintRoutesTest extends TestCase
             new SlashSanityRule,
             new StandardMethodsRule,
             new RouteNameRule,
+            new ApiResourceAlignmentRule,
+            new NestingDepthRule,
         );
 
         return new LintRoutes(

--- a/tests/Integration/RouteLinting/LintRoutesTest.php
+++ b/tests/Integration/RouteLinting/LintRoutesTest.php
@@ -167,6 +167,132 @@ class LintRoutesTest extends TestCase
     }
 
     /**
+     * Test that an inline suppression on a route drops exactly that rule's error while
+     * a different rule on the same route still reports (per-rule inline suppression).
+     *
+     * Route /getUsers triggers R1 (verb in path) and R2 (camelCase).
+     * Suppressing only R1 inline leaves R2 still reported.
+     *
+     * @return void
+     */
+    public function testInlineSuppressionDropsOnlyTargetedRule(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('getUsers', fn () => [])
+            ->name('get-users')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'Verb in path is intentional for this legacy endpoint.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R1 is suppressed inline; it must not appear in the report
+        $r1Violations = array_values(array_filter($report->errors(), fn ($v) => $v->ruleId === 'R1'));
+        static::assertSame([], $r1Violations, 'R1 must be suppressed by the inline suppression.');
+
+        // R2 (camelCase) is NOT covered by the inline suppression and must still be reported
+        $r2Violations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId === 'R2',
+        ));
+        static::assertNotEmpty($r2Violations, 'R2 must still be reported on the same route.');
+    }
+
+    /**
+     * Test that a config allowlist entry with an explicit rules list suppresses
+     * only the listed rules (per-rule config suppression).
+     *
+     * @return void
+     */
+    public function testConfigExemptionWithRulesIsPerRule(): void
+    {
+        $this->seedDefaultConfig([
+            [
+                'match'  => 'login',
+                'reason' => 'Legacy auth endpoint; R1 only waived.',
+                'rules'  => ['R1'],
+            ],
+        ]);
+
+        $router = $this->getRouter();
+        $router->post('login', fn () => [])->name('auth.login');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R1 is waived by the config entry; it must not appear in errors
+        $r1Violations = array_values(array_filter($report->errors(), fn ($v) => $v->ruleId === 'R1'));
+        static::assertSame([], $r1Violations, 'R1 must be suppressed by the config exemption.');
+
+        // Other rules on /login are NOT waived and must still appear
+        $otherViolations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId !== 'R1',
+        ));
+        static::assertNotEmpty($otherViolations, 'Non-R1 violations on /login must still be reported.');
+    }
+
+    /**
+     * Test that an inline suppression that suppresses no violation produces a
+     * stale entry on the report (unused inline suppression detection).
+     *
+     * Route /users is clean; the inline suppression for R1 fires on nothing.
+     *
+     * @return void
+     */
+    public function testUnusedInlineSuppressionIsReportedAsStale(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('users', fn () => [])
+            ->name('users.index')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'Pre-emptive suppression that turns out to be unnecessary.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // The route is clean (no R1 violation), so the inline suppression is stale
+        $staleWaivers = $report->staleWaivers();
+        static::assertNotEmpty($staleWaivers, 'An unused inline suppression must appear as a stale entry.');
+
+        $staleString = implode(' ', $staleWaivers);
+        static::assertStringContainsString('suppressed nothing', $staleString);
+        static::assertStringContainsString('Pre-emptive suppression that turns out to be unnecessary.', $staleString);
+    }
+
+    /**
+     * Test that a config entry without a rules list suppresses all violations on
+     * its route (backward-compatibility: omitting rules means all rules).
+     *
+     * @return void
+     */
+    public function testConfigExemptionWithoutRulesSuppressesAllViolations(): void
+    {
+        $this->seedDefaultConfig([
+            [
+                'match'  => 'login',
+                'reason' => 'Legacy endpoint kept for backward compatibility.',
+            ],
+        ]);
+
+        $router = $this->getRouter();
+        $router->post('login', fn () => [])->name('auth.login');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // All violations on /login are suppressed; no errors or warnings expected for that route
+        $loginViolations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => str_contains($v->routeIdentity, 'login'),
+        ));
+        static::assertSame([], $loginViolations, 'All violations on an all-rules-waived route must be suppressed.');
+
+        // The allowlist entry matched a live route and suppressed violations — not stale
+        static::assertSame([], $report->staleWaivers(), 'A used config entry must not appear as stale.');
+    }
+
+    /**
      * Test that two runs over the same route table and config produce byte-identical verdicts (TAC-15-05 / NFR-01).
      *
      * @return void

--- a/tests/Integration/RouteLinting/LintRoutesTest.php
+++ b/tests/Integration/RouteLinting/LintRoutesTest.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Tests\Integration\RouteLinting;
+
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Configuration\ConfigRuleConfiguration;
+use SineMacula\ApiToolkit\RouteLinting\Inflection\FrameworkInflector;
+use SineMacula\ApiToolkit\RouteLinting\LintRoutes;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintEngine;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintReport;
+use SineMacula\ApiToolkit\RouteLinting\Rules\KebabCaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\LowercaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\PluralCollectionsRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\RouteNameRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\SlashSanityRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\StandardMethodsRule;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist;
+use SineMacula\ApiToolkit\RouteLinting\Rules\VerbInPathRule;
+use SineMacula\ApiToolkit\RouteLinting\Sources\RouterRouteSource;
+use Tests\TestCase;
+
+/**
+ * End-to-end integration tests for the LintRoutes use case.
+ *
+ * Drives the use case against a fixture route table registered on the booted
+ * framework router. Config is seeded via `config()->set()` so each test can
+ * control the verb denylist, exemptions, and uncountables independently.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(LintRoutes::class)]
+class LintRoutesTest extends TestCase
+{
+    /**
+     * Default verb denylist that covers the fixture offenders used by most tests.
+     *
+     * @var array<int, string>
+     */
+    private const VERB_DENYLIST = [
+        'get', 'list', 'create', 'add', 'update', 'edit', 'delete',
+        'remove', 'cancel', 'login', 'logout', 'search', 'fetch',
+        'transfer', 'check', 'process', 'submit',
+    ];
+
+    /**
+     * Test that the five common offenders are flagged by defaults and /users is clean (TAC-15-01).
+     *
+     * Fixture routes: /getUsers, /users/create, /order/{id}/cancel, /login,
+     * /userProfiles each produce at least one violation; /users produces none.
+     *
+     * @return void
+     */
+    public function testFlagsCommonOffendersWithDefaults(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('getUsers', fn () => [])->name('get-users');
+        $router->post('users/create', fn () => [])->name('users.create-action');
+        $router->post('order/{id}/cancel', fn () => [])->name('order.cancel');
+        $router->post('login', fn () => [])->name('auth.login');
+        $router->get('userProfiles', fn () => [])->name('user-profiles');
+        $router->get('users', fn () => [])->name('users.index');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        $offendingIdentities = $this->collectOffendingIdentities($report);
+
+        static::assertNotEmpty($report->errors(), 'Expected at least one error-severity violation.');
+
+        // Each offending route must have at least one finding
+        static::assertTrue($this->hasViolationForUri($report, 'getUsers'), '/getUsers should be flagged');
+        static::assertTrue($this->hasViolationForUri($report, 'users/create'), '/users/create should be flagged');
+        static::assertTrue($this->hasViolationForUri($report, 'order/{id}/cancel'), '/order/{id}/cancel should be flagged');
+        static::assertTrue($this->hasViolationForUri($report, 'login'), '/login should be flagged');
+        static::assertTrue($this->hasViolationForUri($report, 'userProfiles'), '/userProfiles should be flagged');
+
+        // The control route must be clean
+        static::assertNotContains('GET,HEAD users users.index', $offendingIdentities, '/users should be clean');
+    }
+
+    /**
+     * Test that an exempted violating route has its violation suppressed and is not stale (TAC-15-02).
+     *
+     * @return void
+     */
+    public function testExemptedViolationIsSuppressed(): void
+    {
+        $this->seedDefaultConfig([
+            [
+                'match'  => 'login',
+                'reason' => 'Legacy endpoint kept for backward compatibility.',
+            ],
+        ]);
+
+        $router = $this->getRouter();
+        $router->post('login', fn () => [])->name('auth.login');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // The /login route is violating but covered by an allowlist entry — no errors expected
+        static::assertSame([], $report->errors(), 'Violation for exempted route should be suppressed.');
+
+        // The allowlist entry matched a live route — no stale waivers
+        static::assertSame([], $report->staleWaivers(), 'Matched entry must not appear as stale.');
+    }
+
+    /**
+     * Test that an allowlist entry matching no live route appears in staleWaivers() (TAC-15-03).
+     *
+     * @return void
+     */
+    public function testStaleWaiverIsReported(): void
+    {
+        $this->seedDefaultConfig([
+            [
+                'match'  => 'no-such-route',
+                'reason' => 'Was needed for the old API; route no longer exists.',
+            ],
+        ]);
+
+        $router = $this->getRouter();
+        $router->get('users', fn () => [])->name('users.index');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        static::assertContains('no-such-route', $report->staleWaivers(), 'Unmatched entry must be reported as stale.');
+    }
+
+    /**
+     * Test that removing a verb from the denylist clears the R1 finding without creating an exemption (TAC-15-04).
+     *
+     * Removing `transfer` from the denylist means /transfers is clean for R1;
+     * no allowlist entry is configured, so staleWaivers() stays empty.
+     *
+     * @return void
+     */
+    public function testHomographRemovalClearsVerbFindingWithoutExemption(): void
+    {
+        // Denylist WITHOUT 'transfer' — it was removed as a homograph
+        $denylistWithoutTransfer = array_values(array_filter(
+            self::VERB_DENYLIST,
+            fn (string $v): bool => $v !== 'transfer',
+        ));
+
+        $this->seedDefaultConfig([], $denylistWithoutTransfer);
+
+        $router = $this->getRouter();
+        $router->get('transfers', fn () => [])->name('transfers.index');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // No R1 violation for /transfers because 'transfer' was removed from the denylist
+        $r1Violations = array_filter($report->errors(), fn ($v) => $v->ruleId === 'R1');
+
+        static::assertSame([], array_values($r1Violations), 'No R1 violation expected after homograph removal.');
+
+        // No exemption entry was created — allowlist stays empty, no stale waivers
+        static::assertSame([], $report->staleWaivers(), 'No exemption entry should be stale when using denylist tuning.');
+    }
+
+    /**
+     * Test that two runs over the same route table and config produce byte-identical verdicts (TAC-15-05 / NFR-01).
+     *
+     * @return void
+     */
+    public function testRepeatableVerdictAcrossTwoRuns(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('getUsers', fn () => [])->name('get-users');
+        $router->post('users/create', fn () => [])->name('users.create-action');
+        $router->get('users', fn () => [])->name('users.index');
+
+        $useCase = $this->buildUseCase($router);
+
+        $firstReport  = $useCase->lint();
+        $secondReport = $useCase->lint();
+
+        static::assertSame(
+            $this->serialiseReport($firstReport),
+            $this->serialiseReport($secondReport),
+            'Two runs over the same inputs must produce identical verdicts (NFR-01).',
+        );
+    }
+
+    /**
+     * Build the LintRoutes use case with real adapters against the given router.
+     *
+     * Constructs the full collaborator graph directly (no container) so the test
+     * is self-contained and free of binding-registrar dependencies from other tasks.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return \SineMacula\ApiToolkit\RouteLinting\LintRoutes
+     */
+    private function buildUseCase(Router $router): LintRoutes
+    {
+        $inflector = new FrameworkInflector;
+
+        $engine = new RouteLintEngine(
+            new VerbInPathRule(new SegmentNormaliser($inflector), new VerbDenylist(
+                config('api-toolkit.route_linting.verb_denylist', []),
+                config('api-toolkit.route_linting.remediation_hints', []),
+            )),
+            new KebabCaseRule,
+            new LowercaseRule,
+            new PluralCollectionsRule($inflector),
+            new SlashSanityRule,
+            new StandardMethodsRule,
+            new RouteNameRule,
+        );
+
+        return new LintRoutes(
+            new RouterRouteSource($router),
+            new ConfigRuleConfiguration,
+            $engine,
+        );
+    }
+
+    /**
+     * Seed the route_linting config section used by ConfigRuleConfiguration.
+     *
+     * @param  array<int, array<string, string>>  $exemptions
+     * @param  array<int, string>|null  $verbDenylist
+     * @return void
+     */
+    private function seedDefaultConfig(array $exemptions = [], ?array $verbDenylist = null): void
+    {
+        config()->set('api-toolkit.route_linting.verb_denylist', $verbDenylist ?? self::VERB_DENYLIST);
+        config()->set('api-toolkit.route_linting.remediation_hints', []);
+        config()->set('api-toolkit.route_linting.exemptions', $exemptions);
+        config()->set('api-toolkit.route_linting.uncountables', []);
+    }
+
+    /**
+     * Get a fresh router instance bound to the booted application.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    private function getRouter(): Router
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Routing\Router */
+        return $this->app->make('router');
+    }
+
+    /**
+     * Collect the distinct route-identity strings that have at least one violation in the report.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintReport  $report
+     * @return array<int, string>
+     */
+    private function collectOffendingIdentities(RouteLintReport $report): array
+    {
+        $identities = [];
+
+        foreach (array_merge($report->errors(), $report->warnings()) as $violation) {
+            $identities[$violation->routeIdentity] = true;
+        }
+
+        return array_keys($identities);
+    }
+
+    /**
+     * Determine whether any violation in the report references the given URI.
+     *
+     * Matches by checking whether the route identity string contains the URI
+     * segment (the identity format is `METHODS uri [name]`).
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintReport  $report
+     * @param  string  $uri
+     * @return bool
+     */
+    private function hasViolationForUri(RouteLintReport $report, string $uri): bool
+    {
+        foreach (array_merge($report->errors(), $report->warnings()) as $violation) {
+            if (str_contains($violation->routeIdentity, ' ' . $uri . ' ') || str_ends_with($violation->routeIdentity, ' ' . $uri)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Serialise a RouteLintReport to a stable string for byte-identical comparison.
+     *
+     * @param  \SineMacula\ApiToolkit\RouteLinting\RouteLintReport  $report
+     * @return string
+     */
+    private function serialiseReport(RouteLintReport $report): string
+    {
+        $lines = [];
+
+        foreach ($report->errors() as $v) {
+            $lines[] = 'E|' . $v->ruleId . '|' . $v->routeIdentity . '|' . $v->offendingSurface;
+        }
+
+        foreach ($report->warnings() as $v) {
+            $lines[] = 'W|' . $v->ruleId . '|' . $v->routeIdentity . '|' . $v->offendingSurface;
+        }
+
+        foreach ($report->staleWaivers() as $key) {
+            $lines[] = 'S|' . $key;
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/tests/Integration/RouteLinting/LintRoutesTest.php
+++ b/tests/Integration/RouteLinting/LintRoutesTest.php
@@ -319,6 +319,369 @@ class LintRoutesTest extends TestCase
     }
 
     /**
+     * Test that the observe loop runs for every descriptor so a matched-but-unused
+     * config exemption (route exists and is clean) is reported as a stale unused entry.
+     *
+     * Mutants killed: #13 (Foreach_ on observe loop), #14 (MethodCallRemoval of observe()),
+     * #16 (Foreach_ on allowlist->unused() loop).
+     *
+     * If the observe loop is skipped the entry is never marked as matched, so it
+     * appears in unmatched() instead of unused(). If the unused() loop is skipped
+     * the entry is silently dropped and no stale waiver appears at all. Asserting
+     * the specific "suppressed nothing" text distinguishes all three cases.
+     *
+     * @return void
+     */
+    public function testMatchedButUnusedConfigEntryIsReportedAsStaleUnused(): void
+    {
+        // The /users route is clean (no violations); the exemption for 'users.index'
+        // matches it via route name but suppresses nothing, because no violation fires.
+        $this->seedDefaultConfig([
+            [
+                'match'  => 'users.index',
+                'reason' => 'Pre-emptive waiver that turns out to serve no purpose.',
+            ],
+        ]);
+
+        $router = $this->getRouter();
+        $router->get('users', fn () => [])->name('users.index');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // No route violations — the route is clean
+        static::assertSame([], $report->errors(), 'Clean route must produce no errors.');
+
+        // The exemption matched a live route but suppressed nothing — must appear as a stale unused entry
+        $staleWaivers = $report->staleWaivers();
+        static::assertNotEmpty($staleWaivers, 'A matched-but-unused config entry must appear as stale.');
+
+        $staleString = implode("\n", $staleWaivers);
+        static::assertStringContainsString('users.index', $staleString, 'Stale entry must name the exemption match key.');
+        static::assertStringContainsString('suppressed nothing', $staleString, 'Stale entry must indicate nothing was suppressed.');
+        static::assertStringContainsString('Pre-emptive waiver that turns out to serve no purpose.', $staleString);
+    }
+
+    /**
+     * Test that the stale inline-suppression message uses "all rules" when the
+     * suppression covers all rules (empty rules list), not the implode of the empty array.
+     *
+     * Mutant killed: #15 (Ternary flip on rules label in stale-waiver string).
+     *
+     * Under the mutation the ternary is flipped so an empty rules list produces
+     * "rules: " (implode of []) while a non-empty list produces "rules: all rules".
+     * Asserting the exact text "rules: all rules" for a suppression with an empty
+     * rules list kills the mutant.
+     *
+     * @return void
+     */
+    public function testUnusedAllRulesInlineSuppressionReportsAllRulesLabel(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('users', fn () => [])
+            ->name('users.index')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint([], 'Blanket suppression on a clean route.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // The inline suppression fired on nothing (route is clean) → stale
+        $staleWaivers = $report->staleWaivers();
+        static::assertNotEmpty($staleWaivers, 'Unused all-rules suppression must be stale.');
+
+        $staleString = implode("\n", $staleWaivers);
+        // The label must say "all rules", not an empty string
+        static::assertStringContainsString('rules: all rules', $staleString, 'All-rules suppression must report "rules: all rules".');
+        static::assertStringContainsString('Blanket suppression on a clean route.', $staleString);
+    }
+
+    /**
+     * Test that the stale inline-suppression message lists the concrete rule IDs when
+     * the suppression has an explicit non-empty rules list.
+     *
+     * Complements testUnusedAllRulesInlineSuppressionReportsAllRulesLabel so both
+     * branches of the ternary are exercised with exact assertions.
+     *
+     * @return void
+     */
+    public function testUnusedSpecificRulesInlineSuppressionReportsRuleIds(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('users', fn () => [])
+            ->name('users.index')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1', 'R2'], 'Specific-rules suppression on a clean route.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        $staleWaivers = $report->staleWaivers();
+        static::assertNotEmpty($staleWaivers, 'Unused specific-rules suppression must be stale.');
+
+        $staleString = implode("\n", $staleWaivers);
+        // The label must enumerate the actual rule IDs, not "all rules"
+        static::assertStringContainsString('rules: R1, R2', $staleString, 'Specific-rules suppression must list rule IDs.');
+        static::assertStringContainsString('Specific-rules suppression on a clean route.', $staleString);
+    }
+
+    /**
+     * Test that a used inline suppression does NOT generate a stale entry.
+     *
+     * Mutant killed: #17 (TrueValue: $inlineUsed[...] = false).
+     *
+     * When the mutation sets the map value to false, `isset()` still returns true,
+     * which means the suppression is considered "used" and no stale entry is added.
+     * But wait — this mutant means a USED suppression does NOT get recorded as used,
+     * so the stale-detection loop at L77 fires for it. The test verifies that a
+     * suppression that actually fires on a violation produces NO stale waiver.
+     *
+     * @return void
+     */
+    public function testUsedInlineSuppressionProducesNoStaleEntry(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        // /getUsers triggers R1; inline suppression covers R1 — so suppression IS used
+        $router->get('getUsers', fn () => [])
+            ->name('get-users')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'Suppression that actually fires on R1.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R1 must be suppressed
+        $r1Violations = array_values(array_filter($report->errors(), fn ($v) => $v->ruleId === 'R1'));
+        static::assertSame([], $r1Violations, 'R1 must be suppressed by the inline suppression.');
+
+        // The suppression fired on a real violation — must NOT be stale
+        $staleString = implode("\n", $report->staleWaivers());
+        static::assertStringNotContainsString('Suppression that actually fires on R1.', $staleString, 'A used suppression must not appear as stale.');
+    }
+
+    /**
+     * Test that break (not continue) stops inline-suppression matching after the
+     * first suppression covering a violation fires.
+     *
+     * Mutant killed: #18 (Break_ → continue on the inline-suppression inner loop).
+     *
+     * With "continue" a second suppression on the same route would also be marked
+     * as used for the same violation. The fixture has two inline suppressions:
+     * the first covers R1, the second covers only R2 (which does not fire on
+     * the route). Under the mutation the "continue" causes the second suppression
+     * to also be iterated after the first fires, but since R1 is the violation and
+     * the second suppression only covers R2, it would NOT be marked used by the
+     * "continue" path either — so this specific arrangement is equivalent.
+     *
+     * Instead we need a case where the second suppression covers the SAME rule.
+     * Two suppressions both covering R1: under correct "break" only the first is
+     * marked used; under "continue" both are marked used. The second suppression
+     * would then NOT be stale under the mutation, but IS stale under correct code.
+     *
+     * @return void
+     */
+    public function testFirstMatchingInlineSuppressionBreaksAndSecondIsStale(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        // /getUsers triggers R1.
+        // Two suppressions both covering R1: the first fires, the second covers the
+        // same rule but never gets a chance to fire (break stops iteration).
+        $router->get('getUsers', fn () => [])
+            ->name('get-users')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'First suppression — fires on R1.')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'Second suppression — never fires because break exits after first.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R1 must be suppressed
+        $r1Violations = array_values(array_filter($report->errors(), fn ($v) => $v->ruleId === 'R1'));
+        static::assertSame([], $r1Violations, 'R1 must be suppressed.');
+
+        // The first suppression fired → not stale; the second did not fire → stale
+        $staleWaivers = $report->staleWaivers();
+        $staleString  = implode("\n", $staleWaivers);
+        static::assertStringContainsString(
+            'Second suppression — never fires because break exits after first.',
+            $staleString,
+            'Second suppression must be stale because break prevents it firing.',
+        );
+        static::assertStringNotContainsString(
+            'First suppression — fires on R1.',
+            $staleString,
+            'First suppression must not be stale because it fired.',
+        );
+    }
+
+    /**
+     * Test that all inline suppressions that fired are tracked when multiple
+     * suppressions on one route each cover a different rule that fires.
+     *
+     * Mutant killed: #19 (ArrayOneItem: applyViolations returns only first entry of $inlineUsed).
+     *
+     * With the mutation, only the first entry in $inlineUsed is returned, so the
+     * second suppression (which covered a different rule) is treated as unused and
+     * appears as a stale waiver even though it fired. Two suppressions on the same
+     * route, each covering a different rule that fires: both must be non-stale.
+     *
+     * @return void
+     */
+    public function testMultipleInlineSuppressionsOnSameRouteBothTrackedAsUsed(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        // /getUsers triggers R1 (verb in path) AND R2 (kebab-case).
+        // Two suppressions: first covers R1, second covers R2. Both fire.
+        $router->get('getUsers', fn () => [])
+            ->name('get-users')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R1'], 'Suppresses verb-in-path violation.')
+            // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R2'], 'Suppresses kebab-case violation.');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R1 and R2 must both be suppressed
+        $r1Violations = array_values(array_filter($report->errors(), fn ($v) => $v->ruleId === 'R1'));
+        static::assertSame([], $r1Violations, 'R1 must be suppressed by the first inline suppression.');
+
+        $r2Violations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId === 'R2',
+        ));
+        static::assertSame([], $r2Violations, 'R2 must be suppressed by the second inline suppression.');
+
+        // Neither suppression should be stale — both fired
+        $staleString = implode("\n", $report->staleWaivers());
+        static::assertStringNotContainsString('Suppresses verb-in-path violation.', $staleString, 'First suppression must not be stale.');
+        static::assertStringNotContainsString('Suppresses kebab-case violation.', $staleString, 'Second suppression must not be stale.');
+    }
+
+    /**
+     * Test that two routers with the same routes registered in opposite order produce
+     * byte-identical reports, confirming RouteLintReport provides a stable total order
+     * independent of route registration order (NFR-01).
+     *
+     * @return void
+     */
+    public function testVerdictIsIndependentOfRouteRegistrationOrder(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        $router->get('getZzz', fn () => [])->name('zzz.index');
+        $router->get('getAaa', fn () => [])->name('aaa.index');
+
+        $report1 = $this->buildUseCase($router)->lint();
+
+        // Register same routes in opposite registration order on a fresh router
+        $router2 = $this->getRouter();
+        $router2->get('getAaa', fn () => [])->name('aaa.index');
+        $router2->get('getZzz', fn () => [])->name('zzz.index');
+
+        $report2 = $this->buildUseCase($router2)->lint();
+
+        // Both runs must produce byte-identical reports regardless of registration order (NFR-01)
+        static::assertSame(
+            $this->serialiseReport($report1),
+            $this->serialiseReport($report2),
+            'RouteLintReport must return a stable total order independent of route registration order (NFR-01).',
+        );
+    }
+
+    /**
+     * Test that parameter segments are split and brace-stripped so R9 inspects the
+     * correct terminal literal.
+     *
+     * A route with two brace-wrapped parameters followed by a "create" segment is
+     * linted; R9 (apiResource alignment) must fire on the literal "create" and not
+     * on any parameter segment. This verifies that parameter segments are correctly
+     * identified and excluded from literal-segment checks.
+     *
+     * @return void
+     */
+    public function testParametersAreExtractedAndBraceStripped(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        // Route with two parameters: {organisation} and {user}
+        // The final literal segment is "create" — should trigger R9 (apiResource warning)
+        // If {organisation} and {user} are not correctly identified as parameters
+        // (e.g. trim not applied so they stay as "{organisation}") then the segment
+        // logic in other rules would be distorted.
+        $router->get('organisations/{organisation}/users/{user}/create', fn () => [])
+            ->name('organisations.users.create');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R9 fires on the "create" segment — confirms lastLiteralSegment correctly skips parameters
+        $r9Violations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId === 'R9',
+        ));
+        static::assertNotEmpty($r9Violations, 'R9 must fire: "create" is an HTML-only segment.');
+        static::assertSame('create', $r9Violations[0]->offendingSurface, 'Offending surface must be the literal "create" segment, not a parameter.');
+
+        // The plural-collections rule must NOT flag {organisation} or {user} as
+        // non-plural (they are parameters, not collection segments).
+        // This confirms parameter segments are correctly identified and skipped.
+        $r4Violations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId === 'R4' && str_contains($v->offendingSurface, '{'),
+        ));
+        static::assertSame([], $r4Violations, 'Parameter segments wrapped in braces must never be flagged by R4.');
+    }
+
+    /**
+     * Test that a route with two distinct parameters produces violations that do
+     * not reference the raw brace-wrapped parameter names, killing the trim-removal
+     * mutant and the array-slice mutant together.
+     *
+     * Mutants killed: #35 (UnwrapTrim), #36 (ArrayOneItem on extractParameters).
+     *
+     * @return void
+     */
+    public function testMultipleParametersExtractedWithoutBraces(): void
+    {
+        $this->seedDefaultConfig();
+
+        $router = $this->getRouter();
+        // Two distinct parameters: {order} and {item}
+        // Both must be extracted (kills #36) and without braces (kills #35).
+        // An AlignmentRule check via a "create" suffix confirms parameters are seen.
+        $router->get('orders/{order}/items/{item}/create', fn () => [])
+            ->name('orders.items.create');
+
+        $report = $this->buildUseCase($router)->lint();
+
+        // R9 must fire on "create" — the rule correctly skips parameter segments
+        $r9Violations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId === 'R9',
+        ));
+        static::assertNotEmpty($r9Violations, 'R9 must fire on the "create" segment.');
+
+        // Surface must be exactly "create", not a brace-wrapped param
+        static::assertSame('create', $r9Violations[0]->offendingSurface);
+
+        // No R4 violation must reference a brace-wrapped parameter segment.
+        // (R4 may fire on "create" as a singular segment, which is acceptable —
+        // what must not happen is {order} or {item} appearing as offending surfaces.)
+        $r4ParamViolations = array_values(array_filter(
+            array_merge($report->errors(), $report->warnings()),
+            fn ($v) => $v->ruleId === 'R4' && str_contains($v->offendingSurface, '{'),
+        ));
+        static::assertSame([], $r4ParamViolations, 'Parameter segments wrapped in braces must never be flagged by R4.');
+    }
+
+    /**
      * Build the LintRoutes use case with real adapters against the given router.
      *
      * Constructs the full collaborator graph directly (no container) so the test

--- a/tests/Integration/RouteLinting/RouterRouteSourceTest.php
+++ b/tests/Integration/RouteLinting/RouterRouteSourceTest.php
@@ -96,16 +96,15 @@ class RouterRouteSourceTest extends TestCase
     }
 
     /**
-     * Test that the returned app-owned route set is identical whether the
-     * route cache is warm or cold (REQ-02 cache indifference).
+     * Test that calling appRoutes() twice on the same router returns an identical set of descriptors.
      *
-     * The adapter reads `Router::getRoutes()` which returns the same table
-     * in both states after a full boot — this test proves that calling
-     * `appRoutes()` twice on the same booted router returns an identical set.
+     * Verifies that enumeration is idempotent: the URIs returned by consecutive
+     * calls are sorted-equal, confirming the adapter produces a deterministic
+     * result without requiring route-cache warming or clearing.
      *
      * @return void
      */
-    public function testRouteSetIsIdenticalWarmAndColdCache(): void
+    public function testEnumerationIsIdempotent(): void
     {
         $router = $this->getRouter();
 

--- a/tests/Integration/RouteLinting/RouterRouteSourceTest.php
+++ b/tests/Integration/RouteLinting/RouterRouteSourceTest.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteSuppression;
 use SineMacula\ApiToolkit\RouteLinting\Sources\RouterRouteSource;
 use Tests\TestCase;
 
@@ -192,6 +193,68 @@ class RouterRouteSourceTest extends TestCase
         $source = new RouterRouteSource($this->getRouter());
 
         static::assertSame([], $source->appRoutes());
+    }
+
+    /**
+     * Test that a route decorated with ignoreRouteLint() yields a descriptor
+     * whose suppressions property carries a matching RouteSuppression.
+     *
+     * @return void
+     */
+    public function testRouteWithIgnoreRouteLintYieldsSuppressionOnDescriptor(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('invoices', fn () => [])
+            ->name('invoices.index')
+            ->ignoreRouteLint(['R9'], 'Legacy naming kept for migration period.'); // @phpstan-ignore method.notFound
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('invoices.index', $byName);
+
+        $descriptor = $byName['invoices.index'];
+
+        static::assertCount(1, $descriptor->suppressions);
+        static::assertInstanceOf(RouteSuppression::class, $descriptor->suppressions[0]);
+        static::assertSame(['R9'], $descriptor->suppressions[0]->rules);
+        static::assertSame('Legacy naming kept for migration period.', $descriptor->suppressions[0]->reason);
+    }
+
+    /**
+     * Test that a route without ignoreRouteLint() yields a descriptor with an
+     * empty suppressions list.
+     *
+     * @return void
+     */
+    public function testRouteWithoutSuppressionYieldsEmptySuppressionsOnDescriptor(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('categories', fn () => [])->name('categories.index');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('categories.index', $byName);
+        static::assertSame([], $byName['categories.index']->suppressions);
     }
 
     /**

--- a/tests/Integration/RouteLinting/RouterRouteSourceTest.php
+++ b/tests/Integration/RouteLinting/RouterRouteSourceTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
 use SineMacula\ApiToolkit\RouteLinting\Dto\RouteSuppression;
 use SineMacula\ApiToolkit\RouteLinting\Sources\RouterRouteSource;
+use Tests\Fixtures\Controllers\RouteLintController;
 use Tests\TestCase;
 
 /**
@@ -255,6 +256,280 @@ class RouterRouteSourceTest extends TestCase
 
         static::assertArrayHasKey('categories.index', $byName);
         static::assertSame([], $byName['categories.index']->suppressions);
+    }
+
+    /**
+     * Test that a suppression entry with a non-array `rules` value is skipped
+     * and the valid entry alongside it is still mapped
+     * (kills LogicalAnd mutant #85: `isset($entry['rules']) || is_array(...)` vs `&&`).
+     *
+     * With `||` instead of `&&`, a missing `rules` key combined with `is_array`
+     * being false would still satisfy the condition (because `isset` is true when
+     * the key exists). Here we assert the final parsed RouteSuppression reflects
+     * only the conforming rules array.
+     *
+     * @return void
+     */
+    public function testSuppressionWithMissingRulesKeyYieldsEmptyRulesOnSuppression(): void
+    {
+        $router = $this->getRouter();
+
+        // Manually inject an action entry where 'rules' is absent
+        $route = $router->get('billing', fn () => [])->name('billing.index');
+        $route->setAction(array_merge($route->getAction(), [
+            'api-toolkit::lint-ignore' => [
+                ['reason' => 'No rules key present.'],
+            ],
+        ]));
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('billing.index', $byName);
+
+        $descriptor = $byName['billing.index'];
+
+        // The missing-rules entry still produces a RouteSuppression with empty rules
+        static::assertCount(1, $descriptor->suppressions);
+        static::assertSame([], $descriptor->suppressions[0]->rules);
+        static::assertSame('No rules key present.', $descriptor->suppressions[0]->reason);
+    }
+
+    /**
+     * Test that a suppression entry where `rules` is not an array yields empty
+     * rules on the RouteSuppression (kills LogicalAnd mutant #85 second angle).
+     *
+     * @return void
+     */
+    public function testSuppressionWithNonArrayRulesYieldsEmptyRulesOnSuppression(): void
+    {
+        $router = $this->getRouter();
+
+        $route = $router->get('analytics', fn () => [])->name('analytics.index');
+        $route->setAction(array_merge($route->getAction(), [
+            'api-toolkit::lint-ignore' => [
+                ['rules' => 'not-an-array', 'reason' => 'Non-array rules value.'],
+            ],
+        ]));
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('analytics.index', $byName);
+
+        $suppression = $byName['analytics.index']->suppressions[0];
+
+        // Non-array rules must be treated as empty
+        static::assertSame([], $suppression->rules);
+    }
+
+    /**
+     * Test that the rules list on a RouteSuppression is re-indexed (kills
+     * UnwrapArrayValues mutant #86: `array_values($entry['rules'])` vs raw value).
+     *
+     * Without `array_values`, an associative input array would be stored with
+     * string keys instead of a 0-based list.
+     *
+     * @return void
+     */
+    public function testSuppressionRulesListIsReIndexed(): void
+    {
+        $router = $this->getRouter();
+
+        $route = $router->get('reports', fn () => [])->name('reports.index');
+        $route->setAction(array_merge($route->getAction(), [
+            'api-toolkit::lint-ignore' => [
+                ['rules' => ['foo' => 'R1', 'bar' => 'R3'], 'reason' => 'Re-index test.'],
+            ],
+        ]));
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('reports.index', $byName);
+
+        $rules = $byName['reports.index']->suppressions[0]->rules;
+
+        // Must be a 0-based indexed list
+        static::assertSame([0 => 'R1', 1 => 'R3'], $rules);
+    }
+
+    /**
+     * Test that a suppression entry where `reason` is not a string defaults to
+     * an empty string (kills LogicalAnd mutant #87:
+     * `isset($entry['reason']) || is_string(...)` vs `&&`).
+     *
+     * With `||`, a non-string reason value would still satisfy the condition
+     * (because isset is true when the key exists), causing a type error when
+     * RouteSuppression stores it. With `&&` the fallback empty string is used.
+     *
+     * @return void
+     */
+    public function testSuppressionWithNonStringReasonDefaultsToEmptyString(): void
+    {
+        $router = $this->getRouter();
+
+        $route = $router->get('exports', fn () => [])->name('exports.index');
+        $route->setAction(array_merge($route->getAction(), [
+            'api-toolkit::lint-ignore' => [
+                ['rules' => ['R1'], 'reason' => 12345],
+            ],
+        ]));
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('exports.index', $byName);
+
+        $suppression = $byName['exports.index']->suppressions[0];
+
+        // Non-string reason must fall back to empty string
+        static::assertSame('', $suppression->reason);
+    }
+
+    /**
+     * Test that two valid suppression entries both survive (kills ArrayOneItem
+     * mutant #88: returns only the first suppression when count > 1).
+     *
+     * @return void
+     */
+    public function testMultipleSuppressionsAreAllMapped(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('notifications', fn () => [])
+            ->name('notifications.index')
+            ->ignoreRouteLint(['R1'], 'First suppression reason.') // @phpstan-ignore method.notFound
+            ->ignoreRouteLint(['R3'], 'Second suppression reason.') // @phpstan-ignore method.notFound
+            ->ignoreRouteLint([], 'Third suppression, all rules.'); // @phpstan-ignore method.notFound
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('notifications.index', $byName);
+
+        $suppressions = $byName['notifications.index']->suppressions;
+
+        static::assertCount(3, $suppressions);
+        static::assertSame(['R1'], $suppressions[0]->rules);
+        static::assertSame('First suppression reason.', $suppressions[0]->reason);
+        static::assertSame(['R3'], $suppressions[1]->rules);
+        static::assertSame('Second suppression reason.', $suppressions[1]->reason);
+        static::assertSame([], $suppressions[2]->rules);
+        static::assertSame('Third suppression, all rules.', $suppressions[2]->reason);
+    }
+
+    /**
+     * Test that an app-owned controller route registered as a string action
+     * appears in appRoutes() with isVendor === false.
+     *
+     * Kills the `is_string($uses) && isControllerVendor` → `||` mutant: under the
+     * mutant a string controller action is evaluated with the short-circuit OR so the
+     * vendor check fires even for non-string uses values, and conversely a string
+     * action that resolves to an app-owned file may be wrongly excluded. Registering
+     * a string controller action whose class file lives under tests/ (not vendor/)
+     * and asserting it is present with isVendor false proves the AND guard is intact.
+     *
+     * @return void
+     */
+    public function testAppOwnedControllerRouteIsNotTreatedAsVendor(): void
+    {
+        $router = $this->getRouter();
+
+        // Register using the string controller@method notation so `uses` is a string.
+        // RouteLintController lives under tests/, so ReflectionClass resolves a
+        // non-vendor file — the adapter must return it with isVendor === false.
+        $router->get('widgets', [RouteLintController::class, 'index'])->name('widgets.index');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('widgets.index', $byName, 'App-owned controller route must appear in appRoutes().');
+        static::assertFalse($byName['widgets.index']->isVendor, 'Controller whose file is under tests/ must not be flagged as vendor.');
+    }
+
+    /**
+     * Test that a route without a string `uses` action value and without a
+     * Closure is treated as app-owned (kills LogicalAnd mutant #89:
+     * `is_string($uses) || $this->isControllerVendor($route)` vs `&&`).
+     *
+     * With `||`, a non-string `uses` value would still trigger isControllerVendor
+     * (which could return true and incorrectly mark the route as vendor). The
+     * `&&` guard ensures isControllerVendor is only called for string uses values.
+     *
+     * @return void
+     */
+    public function testRouteWithNonStringUsesActionIsNotTreatedAsVendor(): void
+    {
+        $router = $this->getRouter();
+
+        // A route registered with a Closure is handled by the Closure branch
+        // (not the string branch). Register a named closure route that we own —
+        // this is the canonical non-string-uses scenario for app-owned routes.
+        $router->get('health', fn () => ['status' => 'ok'])->name('health.check');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $names = array_map(static fn (RouteDescriptor $d) => $d->name, $descriptors);
+
+        // The closure-backed app route must appear in the results
+        static::assertContains('health.check', $names);
+
+        // Confirm the returned descriptor is not flagged as vendor
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name === 'health.check') {
+                static::assertFalse($descriptor->isVendor);
+            }
+        }
     }
 
     /**

--- a/tests/Integration/RouteLinting/RouterRouteSourceTest.php
+++ b/tests/Integration/RouteLinting/RouterRouteSourceTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Integration\RouteLinting;
+
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
+use SineMacula\ApiToolkit\RouteLinting\Sources\RouterRouteSource;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the RouterRouteSource adapter.
+ *
+ * Verifies that the adapter correctly maps live router routes to
+ * RouteDescriptor DTOs, excludes vendor routes, and returns a consistent
+ * set regardless of route-cache state.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouterRouteSource::class)]
+class RouterRouteSourceTest extends TestCase
+{
+    /** @var string The vendor-segment path marker used in vendor detection. */
+    private const string VENDOR_SEGMENT = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR;
+
+    /**
+     * Test that app-owned routes are returned as RouteDescriptor instances
+     * with the correct uri, methods, and name fields.
+     *
+     * @return void
+     */
+    public function testReturnsAppOwnedRoutesAsDescriptors(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('users', fn () => [])->name('users.index');
+        $router->post('users', fn () => [])->name('users.store');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        static::assertContainsOnlyInstancesOf(RouteDescriptor::class, $descriptors);
+
+        $byName = [];
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor->name !== null) {
+                $byName[$descriptor->name] = $descriptor;
+            }
+        }
+
+        static::assertArrayHasKey('users.index', $byName);
+        static::assertArrayHasKey('users.store', $byName);
+
+        $index = $byName['users.index'];
+
+        static::assertSame('users', $index->uri);
+        static::assertContains('GET', $index->methods);
+        static::assertFalse($index->isVendor);
+
+        $store = $byName['users.store'];
+
+        static::assertSame('users', $store->uri);
+        static::assertContains('POST', $store->methods);
+        static::assertFalse($store->isVendor);
+    }
+
+    /**
+     * Test that a route whose controller class resolves to a file under the
+     * vendor directory is excluded from the returned set.
+     *
+     * @return void
+     */
+    public function testExcludesVendorRoutes(): void
+    {
+        $router = $this->getRouter();
+
+        // App-owned closure route
+        $router->get('app-route', fn () => [])->name('app.route');
+
+        // Vendor-backed controller route: the controller class file lives under vendor/
+        $router->get('vendor-route', '\Illuminate\Routing\RedirectController@__invoke')
+            ->name('vendor.route');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        $names = array_map(static fn (RouteDescriptor $d) => $d->name, $descriptors);
+
+        static::assertContains('app.route', $names);
+        static::assertNotContains('vendor.route', $names);
+    }
+
+    /**
+     * Test that the returned app-owned route set is identical whether the
+     * route cache is warm or cold (REQ-02 cache indifference).
+     *
+     * The adapter reads `Router::getRoutes()` which returns the same table
+     * in both states after a full boot — this test proves that calling
+     * `appRoutes()` twice on the same booted router returns an identical set.
+     *
+     * @return void
+     */
+    public function testRouteSetIsIdenticalWarmAndColdCache(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('orders', fn () => [])->name('orders.index');
+        $router->delete('orders/{order}', fn () => [])->name('orders.destroy');
+
+        $source = new RouterRouteSource($router);
+
+        // First call simulates a cold-cache environment
+        $firstPass = $source->appRoutes();
+
+        // Second call simulates a warm-cache environment
+        $secondPass = $source->appRoutes();
+
+        static::assertCount(count($firstPass), $secondPass);
+
+        $firstUris  = array_map(static fn (RouteDescriptor $d) => $d->uri, $firstPass);
+        $secondUris = array_map(static fn (RouteDescriptor $d) => $d->uri, $secondPass);
+
+        sort($firstUris);
+        sort($secondUris);
+
+        static::assertSame($firstUris, $secondUris);
+    }
+
+    /**
+     * Test that the count of app-owned routes returned by the adapter matches
+     * the count of non-vendor routes in the live router (census parity with
+     * what route:list --except-vendor would report).
+     *
+     * @return void
+     */
+    public function testAppOwnedCountMatchesRouteList(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('products', fn () => [])->name('products.index');
+        $router->get('products/{product}', fn () => [])->name('products.show');
+        $router->get('vendor-redirect', '\Illuminate\Routing\RedirectController@__invoke');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        // Build a reference count using the same vendor-detection heuristic
+        // as the adapter, so the test does not depend on CLI output format
+        $expectedCount = 0;
+
+        foreach ($router->getRoutes()->getRoutes() as $route) {
+            if (!$this->isVendorRoute($route)) {
+                $expectedCount++;
+            }
+        }
+
+        static::assertCount($expectedCount, $descriptors);
+    }
+
+    /**
+     * Test that no Illuminate\Routing\Route instance is returned by the
+     * adapter — only RouteDescriptor DTOs cross the boundary.
+     *
+     * @return void
+     */
+    public function testNoFrameworkRouteLeaksPastTheAdapter(): void
+    {
+        $router = $this->getRouter();
+
+        $router->get('items', fn () => [])->name('items.index');
+
+        $source      = new RouterRouteSource($router);
+        $descriptors = $source->appRoutes();
+
+        foreach ($descriptors as $descriptor) {
+            static::assertInstanceOf(RouteDescriptor::class, $descriptor);
+            static::assertNotInstanceOf(Route::class, $descriptor);
+        }
+    }
+
+    /**
+     * Test that an app with no registered routes returns an empty array.
+     *
+     * @return void
+     */
+    public function testEmptyRouterReturnsEmptyArray(): void
+    {
+        $source = new RouterRouteSource($this->getRouter());
+
+        static::assertSame([], $source->appRoutes());
+    }
+
+    /**
+     * Get a fresh router instance for the test.
+     *
+     * Returns the container-bound router so routes are registered against the
+     * same instance the adapter consumes.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    private function getRouter(): Router
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Routing\Router */
+        return $this->app->make('router');
+    }
+
+    /**
+     * Reference implementation of vendor-route detection used by the census
+     * parity test to build an independent expected count.
+     *
+     * Mirrors the same heuristic as the adapter: closure -> reflect file;
+     * string -> reflect controller class file; default -> app-owned.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     */
+    private function isVendorRoute(Route $route): bool
+    {
+        $uses = $route->getAction('uses');
+
+        if ($uses instanceof \Closure) {
+            try {
+                $file = (new \ReflectionFunction($uses))->getFileName();
+            } catch (\ReflectionException) {
+                return false;
+            }
+
+            return is_string($file) && str_contains($file, self::VENDOR_SEGMENT);
+        }
+
+        if (!is_string($uses)) {
+            return false;
+        }
+
+        $controllerClass = $route->getControllerClass();
+
+        if ($controllerClass === null) {
+            return false;
+        }
+
+        try {
+            $file = (new \ReflectionClass($controllerClass))->getFileName();
+        } catch (\ReflectionException) {
+            return false;
+        }
+
+        return is_string($file) && str_contains($file, self::VENDOR_SEGMENT);
+    }
+}

--- a/tests/Unit/RouteLinting/Configuration/ConfigRuleConfigurationTest.php
+++ b/tests/Unit/RouteLinting/Configuration/ConfigRuleConfigurationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Configuration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Configuration\ConfigRuleConfiguration;
+use SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException;
+use Tests\TestCase;
+
+/**
+ * Tests for ConfigRuleConfiguration.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ConfigRuleConfiguration::class)]
+class ConfigRuleConfigurationTest extends TestCase
+{
+    /**
+     * Test that load() returns an empty exemptions array when no app overrides
+     * are present (the shipped-default zero-exemption state).
+     *
+     * @return void
+     */
+    public function testDefaultExemptionsAreEmpty(): void
+    {
+        $adapter = new ConfigRuleConfiguration;
+        $config  = $adapter->load();
+
+        static::assertSame([], $config->exemptions);
+    }
+
+    /**
+     * Test that load() reads the three separate config surfaces independently
+     * and assembles them into a RuleConfig with matching values.
+     *
+     * @return void
+     */
+    public function testReadsThreeSeparateSurfaces(): void
+    {
+        config()->set('api-toolkit.route_linting.verb_denylist', ['get', 'fetch']);
+        config()->set('api-toolkit.route_linting.remediation_hints', ['get' => 'Use a noun resource instead.']);
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'users.store', 'reason' => 'Legacy endpoint kept for backward compatibility.'],
+        ]);
+        config()->set('api-toolkit.route_linting.uncountables', ['media', 'data']);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertSame(['get', 'fetch'], $result->verbDenylist);
+        static::assertSame(['get' => 'Use a noun resource instead.'], $result->remediationHints);
+        static::assertCount(1, $result->exemptions);
+        static::assertSame('users.store', $result->exemptions[0]->match);
+        static::assertSame('Legacy endpoint kept for backward compatibility.', $result->exemptions[0]->reason);
+        static::assertSame(['media', 'data'], $result->uncountables);
+    }
+
+    /**
+     * Test that load() throws StaleWaiverException when an exemption entry has
+     * no reason, enforcing the required-reason invariant.
+     *
+     * @return void
+     */
+    public function testExemptionWithoutReasonIsRejected(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'users.store'],
+        ]);
+
+        $this->expectException(StaleWaiverException::class);
+        $this->expectExceptionMessage('Allowlist entry "users.store" is missing a required reason.');
+
+        $adapter = new ConfigRuleConfiguration;
+        $adapter->load();
+    }
+
+    /**
+     * Test that load() throws StaleWaiverException when an exemption entry has
+     * an empty (whitespace-only) reason.
+     *
+     * @return void
+     */
+    public function testExemptionWithEmptyReasonIsRejected(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'users.store', 'reason' => '   '],
+        ]);
+
+        $this->expectException(StaleWaiverException::class);
+        $this->expectExceptionMessage('Allowlist entry "users.store" is missing a required reason.');
+
+        $adapter = new ConfigRuleConfiguration;
+        $adapter->load();
+    }
+
+    /**
+     * Test that load() returns empty arrays for all surfaces when config keys
+     * are entirely absent.
+     *
+     * @return void
+     */
+    public function testMissingConfigKeysDefaultToEmptyArrays(): void
+    {
+        config()->set('api-toolkit.route_linting', null);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertSame([], $result->verbDenylist);
+        static::assertSame([], $result->remediationHints);
+        static::assertSame([], $result->exemptions);
+        static::assertSame([], $result->uncountables);
+    }
+}

--- a/tests/Unit/RouteLinting/Configuration/ConfigRuleConfigurationTest.php
+++ b/tests/Unit/RouteLinting/Configuration/ConfigRuleConfigurationTest.php
@@ -183,4 +183,131 @@ class ConfigRuleConfigurationTest extends TestCase
         static::assertCount(1, $result->exemptions);
         static::assertSame([], $result->exemptions[0]->rules);
     }
+
+    /**
+     * Test that load() throws StaleWaiverException when an exemption entry is a
+     * non-array scalar (kills LogicalOr mutant #1: `!is_array($item) && ...`).
+     *
+     * The original guard `!is_array($item) || !isset($item['match']) || ...`
+     * must throw when the item is a plain string — a non-array value can never
+     * have a `match` key but the mutant changes `||` to `&&` before the second
+     * clause, allowing a non-array to pass silently.
+     *
+     * @return void
+     */
+    public function testNonArrayExemptionItemThrowsStaleWaiverException(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            'this-is-a-string-not-an-array',
+        ]);
+
+        $this->expectException(StaleWaiverException::class);
+        $this->expectExceptionMessage('Allowlist entry is missing a required match key.');
+
+        $adapter = new ConfigRuleConfiguration;
+        $adapter->load();
+    }
+
+    /**
+     * Test that an array exemption item with no 'match' key throws
+     * StaleWaiverException (kills LogicalOr mutant #2: `... && !is_string($item['match'])`).
+     *
+     * The original guard requires `isset($item['match'])` as well as
+     * `is_string($item['match'])`. The mutant changes the second `||` to `&&`,
+     * which lets a missing-match entry through when `is_string` is also false.
+     *
+     * @return void
+     */
+    public function testArrayExemptionItemWithoutMatchKeyThrowsStaleWaiverException(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['reason' => 'Has a reason but no match key.'],
+        ]);
+
+        $this->expectException(StaleWaiverException::class);
+        $this->expectExceptionMessage('Allowlist entry is missing a required match key.');
+
+        $adapter = new ConfigRuleConfiguration;
+        $adapter->load();
+    }
+
+    /**
+     * Test that a `rules` list containing non-string values has those values
+     * filtered out, keeping only string entries (kills UnwrapArrayFilter mutant).
+     *
+     * `array_filter($rawRules, 'is_string')` must remove the integer; without the
+     * filter the mutant returns the integer entry inside `AllowlistEntry::$rules`.
+     *
+     * @return void
+     */
+    public function testNonStringRuleValuesAreFilteredOut(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'orders.store', 'reason' => 'Mixed rules.', 'rules' => ['R1', 42, 'R3', null]],
+        ]);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertCount(1, $result->exemptions);
+
+        $rules = $result->exemptions[0]->rules;
+
+        // Only the two string values should survive
+        static::assertSame(['R1', 'R3'], $rules);
+    }
+
+    /**
+     * Test that the filtered rules list is re-indexed from zero (kills
+     * UnwrapArrayValues mutant: `array_values(array_filter(...))` vs just the filter).
+     *
+     * After filtering, `array_values` guarantees integer keys 0, 1, 2... even
+     * when the source array had gaps. Without `array_values` the mutant returns a
+     * non-contiguous array that fails an assertSame against [0 => 'R1', 1 => 'R3'].
+     *
+     * @return void
+     */
+    public function testFilteredRulesListIsReIndexed(): void
+    {
+        // Place a non-string at index 0 so after filtering index 1 would remain 1
+        // without array_values — with array_values it becomes index 0.
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'users.index', 'reason' => 'Reindex test.', 'rules' => [0 => 99, 1 => 'R1', 2 => 'R3']],
+        ]);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertCount(1, $result->exemptions);
+
+        $rules = $result->exemptions[0]->rules;
+
+        // Must be a contiguous 0-based list
+        static::assertSame([0 => 'R1', 1 => 'R3'], $rules);
+    }
+
+    /**
+     * Test that two valid exemption entries both survive (kills ArrayOneItem mutant).
+     *
+     * The ArrayOneItem mutant returns `array_slice($entries, 0, 1)` when count > 1,
+     * truncating to the first entry only.
+     *
+     * @return void
+     */
+    public function testMultipleExemptionEntriesAreAllReturned(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'users.index', 'reason' => 'First waiver.'],
+            ['match' => 'orders.index', 'reason' => 'Second waiver.'],
+            ['match' => 'products.index', 'reason' => 'Third waiver.'],
+        ]);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertCount(3, $result->exemptions);
+        static::assertSame('users.index', $result->exemptions[0]->match);
+        static::assertSame('orders.index', $result->exemptions[1]->match);
+        static::assertSame('products.index', $result->exemptions[2]->match);
+    }
 }

--- a/tests/Unit/RouteLinting/Configuration/ConfigRuleConfigurationTest.php
+++ b/tests/Unit/RouteLinting/Configuration/ConfigRuleConfigurationTest.php
@@ -114,4 +114,73 @@ class ConfigRuleConfigurationTest extends TestCase
         static::assertSame([], $result->exemptions);
         static::assertSame([], $result->uncountables);
     }
+
+    /**
+     * Test that an exemption entry with a `rules` key produces an AllowlistEntry
+     * whose covers() is scoped to those rule IDs only.
+     *
+     * @return void
+     */
+    public function testExemptionWithRulesKeyProducesScopedEntry(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'users.store', 'reason' => 'Scoped waiver.', 'rules' => ['R9', 'R3']],
+        ]);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertCount(1, $result->exemptions);
+
+        $entry = $result->exemptions[0];
+
+        static::assertSame(['R9', 'R3'], $entry->rules);
+        static::assertTrue($entry->covers('R9'));
+        static::assertTrue($entry->covers('R3'));
+        static::assertFalse($entry->covers('R1'));
+    }
+
+    /**
+     * Test that an exemption entry without a `rules` key produces an
+     * AllowlistEntry that covers all rules (backward-compatible default).
+     *
+     * @return void
+     */
+    public function testExemptionWithoutRulesKeyCoversAllRules(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'orders.index', 'reason' => 'All-rules waiver.'],
+        ]);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertCount(1, $result->exemptions);
+
+        $entry = $result->exemptions[0];
+
+        static::assertSame([], $entry->rules);
+        static::assertTrue($entry->covers('R9'));
+        static::assertTrue($entry->covers('R1'));
+    }
+
+    /**
+     * Test that a non-array `rules` value in an exemption config entry is
+     * treated as empty (all rules covered), so a corrupt config key does not
+     * crash the adapter.
+     *
+     * @return void
+     */
+    public function testNonArrayRulesValueDefaultsToEmpty(): void
+    {
+        config()->set('api-toolkit.route_linting.exemptions', [
+            ['match' => 'reports.index', 'reason' => 'Fallback waiver.', 'rules' => 'not-an-array'],
+        ]);
+
+        $adapter = new ConfigRuleConfiguration;
+        $result  = $adapter->load();
+
+        static::assertCount(1, $result->exemptions);
+        static::assertSame([], $result->exemptions[0]->rules);
+    }
 }

--- a/tests/Unit/RouteLinting/Dto/AllowlistEntryTest.php
+++ b/tests/Unit/RouteLinting/Dto/AllowlistEntryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Dto;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry;
+use Tests\TestCase;
+
+/**
+ * Tests for the AllowlistEntry DTO.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(AllowlistEntry::class)]
+class AllowlistEntryTest extends TestCase
+{
+    /**
+     * Test that covers() returns true for any rule ID when the rules list
+     * defaults to empty, i.e. the entry covers all rules.
+     *
+     * @return void
+     */
+    public function testCoversAllRulesWhenRulesListIsEmpty(): void
+    {
+        $entry = new AllowlistEntry('users.store', 'Legacy endpoint.');
+
+        static::assertTrue($entry->covers('R1'));
+        static::assertTrue($entry->covers('R9'));
+        static::assertTrue($entry->covers('PLURAL_COLLECTIONS'));
+    }
+
+    /**
+     * Test that covers() returns true when the given rule ID is explicitly
+     * present in a non-empty rules list.
+     *
+     * @return void
+     */
+    public function testCoversReturnsTrueForExplicitlyListedRule(): void
+    {
+        $entry = new AllowlistEntry('users.store', 'Scoped waiver.', ['R9', 'R3']);
+
+        static::assertTrue($entry->covers('R9'));
+        static::assertTrue($entry->covers('R3'));
+    }
+
+    /**
+     * Test that covers() returns false when the given rule ID is absent from
+     * a non-empty rules list.
+     *
+     * @return void
+     */
+    public function testCoversReturnsFalseForRuleNotInList(): void
+    {
+        $entry = new AllowlistEntry('users.store', 'Scoped waiver.', ['R9']);
+
+        static::assertFalse($entry->covers('R1'));
+        static::assertFalse($entry->covers('PLURAL_COLLECTIONS'));
+    }
+
+    /**
+     * Test that all three properties round-trip correctly and that the default
+     * rules value is an empty array.
+     *
+     * @return void
+     */
+    public function testExposesMatchReasonAndRulesWithCorrectDefaults(): void
+    {
+        $defaultEntry = new AllowlistEntry('api/*', 'All API routes waived.');
+
+        static::assertSame('api/*', $defaultEntry->match);
+        static::assertSame('All API routes waived.', $defaultEntry->reason);
+        static::assertSame([], $defaultEntry->rules);
+
+        $scopedEntry = new AllowlistEntry('orders.index', 'Scoped.', ['R9']);
+
+        static::assertSame(['R9'], $scopedEntry->rules);
+    }
+}

--- a/tests/Unit/RouteLinting/Dto/RouteDescriptorTest.php
+++ b/tests/Unit/RouteLinting/Dto/RouteDescriptorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Dto;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteDescriptor;
+use Tests\TestCase;
+
+/**
+ * Tests for the RouteDescriptor DTO.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouteDescriptor::class)]
+class RouteDescriptorTest extends TestCase
+{
+    /**
+     * Test that all four properties round-trip correctly, including isVendor
+     * for both true and false, and that name may be null.
+     *
+     * @return void
+     */
+    public function testExposesUriMethodsNameAndVendorFlag(): void
+    {
+        // Arrange & Act — named route, non-vendor
+        $named = new RouteDescriptor(
+            uri: 'users/{user}',
+            methods: ['GET', 'HEAD'],
+            name: 'users.show',
+            isVendor: false,
+        );
+
+        // Assert
+        static::assertSame('users/{user}', $named->uri);
+        static::assertSame(['GET', 'HEAD'], $named->methods);
+        static::assertSame('users.show', $named->name);
+        static::assertFalse($named->isVendor);
+
+        // Arrange & Act — unnamed vendor route
+        $vendor = new RouteDescriptor(
+            uri: 'vendor/package/resource',
+            methods: ['POST'],
+            name: null,
+            isVendor: true,
+        );
+
+        // Assert
+        static::assertSame('vendor/package/resource', $vendor->uri);
+        static::assertSame(['POST'], $vendor->methods);
+        static::assertNull($vendor->name);
+        static::assertTrue($vendor->isVendor);
+    }
+}

--- a/tests/Unit/RouteLinting/Dto/RouteSuppressionTest.php
+++ b/tests/Unit/RouteLinting/Dto/RouteSuppressionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Dto;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RouteSuppression;
+use Tests\TestCase;
+
+/**
+ * Tests for the RouteSuppression DTO.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouteSuppression::class)]
+class RouteSuppressionTest extends TestCase
+{
+    /**
+     * Test that covers() returns true for any rule ID when the rules list is
+     * empty, i.e. the suppression targets all rules.
+     *
+     * @return void
+     */
+    public function testCoversReturnsTrueForAnyRuleWhenRulesListIsEmpty(): void
+    {
+        $suppression = new RouteSuppression([], 'Suppresses all rules.');
+
+        static::assertTrue($suppression->covers('R1'));
+        static::assertTrue($suppression->covers('R9'));
+        static::assertTrue($suppression->covers('PLURAL_COLLECTIONS'));
+    }
+
+    /**
+     * Test that covers() returns true when the given rule ID is explicitly
+     * present in the suppression's rules list.
+     *
+     * @return void
+     */
+    public function testCoversReturnsTrueForExplicitlyListedRule(): void
+    {
+        $suppression = new RouteSuppression(['R9', 'R3'], 'Specific rules suppressed.');
+
+        static::assertTrue($suppression->covers('R9'));
+        static::assertTrue($suppression->covers('R3'));
+    }
+
+    /**
+     * Test that covers() returns false when the given rule ID is not in the
+     * suppression's non-empty rules list.
+     *
+     * @return void
+     */
+    public function testCoversReturnsFalseForRuleNotInList(): void
+    {
+        $suppression = new RouteSuppression(['R9'], 'Only R9 suppressed.');
+
+        static::assertFalse($suppression->covers('R1'));
+        static::assertFalse($suppression->covers('PLURAL_COLLECTIONS'));
+    }
+
+    /**
+     * Test that the constructor correctly exposes rules and reason as public
+     * properties.
+     *
+     * @return void
+     */
+    public function testExposesRulesAndReason(): void
+    {
+        $suppression = new RouteSuppression(['R9', 'R3'], 'Legacy route.');
+
+        static::assertSame(['R9', 'R3'], $suppression->rules);
+        static::assertSame('Legacy route.', $suppression->reason);
+    }
+}

--- a/tests/Unit/RouteLinting/Dto/RuleConfigTest.php
+++ b/tests/Unit/RouteLinting/Dto/RuleConfigTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Dto;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use Tests\TestCase;
+
+/**
+ * Tests for the RuleConfig DTO.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RuleConfig::class)]
+class RuleConfigTest extends TestCase
+{
+    /**
+     * Test that all four surfaces are stored independently and round-trip
+     * correctly, including the AllowlistEntry objects within exemptions.
+     *
+     * @return void
+     */
+    public function testHoldsThreeSeparateSurfacesAndHints(): void
+    {
+        // Arrange
+        $denylist     = ['get', 'list', 'create'];
+        $hints        = ['get' => 'Use GET /resources', 'list' => 'Use GET /resources'];
+        $exemption    = new AllowlistEntry(match: 'users.legacy', reason: 'Pre-REST route kept for backward compat');
+        $uncountables = ['data', 'media'];
+
+        // Act
+        $config = new RuleConfig(
+            verbDenylist: $denylist,
+            remediationHints: $hints,
+            exemptions: [$exemption],
+            uncountables: $uncountables,
+        );
+
+        // Assert — each surface is exactly the value passed in
+        static::assertSame($denylist, $config->verbDenylist);
+        static::assertSame($hints, $config->remediationHints);
+        static::assertCount(1, $config->exemptions);
+        static::assertSame($exemption, $config->exemptions[0]);
+        static::assertSame($uncountables, $config->uncountables);
+
+        // Assert AllowlistEntry properties round-trip through exemptions
+        static::assertSame('users.legacy', $config->exemptions[0]->match);
+        static::assertSame('Pre-REST route kept for backward compat', $config->exemptions[0]->reason);
+    }
+
+    /**
+     * Test that a RuleConfig with an empty exemptions array is valid and
+     * exemptions returns an empty array.
+     *
+     * @return void
+     */
+    public function testExemptionsDefaultEmptyIsRepresentable(): void
+    {
+        // Arrange & Act
+        $config = new RuleConfig(
+            verbDenylist: ['get'],
+            remediationHints: [],
+            exemptions: [],
+            uncountables: [],
+        );
+
+        // Assert
+        static::assertSame([], $config->exemptions);
+    }
+}

--- a/tests/Unit/RouteLinting/ExemptionAllowlistTest.php
+++ b/tests/Unit/RouteLinting/ExemptionAllowlistTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Unit\RouteLinting;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\AllowlistEntry;
+use SineMacula\ApiToolkit\RouteLinting\ExemptionAllowlist;
+use Tests\TestCase;
+
+/**
+ * Tests for the ExemptionAllowlist domain service.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ExemptionAllowlist::class)]
+class ExemptionAllowlistTest extends TestCase
+{
+    /**
+     * Test that an empty allowlist never exempts any route and reports no
+     * unmatched entries.
+     *
+     * @return void
+     */
+    public function testEmptyAllowlistExemptsNothing(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([]);
+
+        // Act & Assert
+        static::assertFalse($allowlist->isExempt('users.index', 'users'));
+        static::assertFalse($allowlist->isExempt(null, 'users'));
+        static::assertSame([], $allowlist->unmatched());
+    }
+
+    /**
+     * Test that an entry matching a route by its exact name exempts that route.
+     *
+     * @return void
+     */
+    public function testMatchesByExactRouteName(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.store', 'Legacy store endpoint kept for backward compat.'),
+        ]);
+
+        // Act & Assert — exact name match exempts
+        static::assertTrue($allowlist->isExempt('users.store', 'users'));
+
+        // A different name does not match even when the URI would
+        static::assertFalse($allowlist->isExempt('users.index', 'users'));
+    }
+
+    /**
+     * Test that an entry with a URI wildcard pattern exempts routes whose URI
+     * matches the pattern via fnmatch() shell-wildcard semantics.
+     *
+     * @return void
+     */
+    public function testMatchesByUriWildcardPattern(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users/*', 'All user sub-routes are exempted for migration.'),
+        ]);
+
+        // Act & Assert — wildcard matches the URI
+        static::assertTrue($allowlist->isExempt(null, 'users/create'));
+        static::assertTrue($allowlist->isExempt(null, 'users/profile'));
+
+        // A URI that does not match the pattern is not exempt
+        static::assertFalse($allowlist->isExempt(null, 'articles/create'));
+    }
+
+    /**
+     * Test that an entry that matched no live route appears in unmatched(), and
+     * that an entry that was matched at least once does not.
+     *
+     * @return void
+     */
+    public function testUnmatchedEntryIsReportedStale(): void
+    {
+        // Arrange — two entries; only the first will be matched
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.store', 'Legacy store endpoint.'),
+            new AllowlistEntry('articles.old', 'Deprecated article route.'),
+        ]);
+
+        // Act — match the first entry once
+        $allowlist->isExempt('users.store', 'users');
+
+        // Assert — only the unmatched second entry is stale
+        static::assertSame(['articles.old'], $allowlist->unmatched());
+    }
+
+    /**
+     * Test that unmatched() returns stale match keys sorted ascending
+     * regardless of the order they appear in the entry list.
+     *
+     * @return void
+     */
+    public function testUnmatchedIsSorted(): void
+    {
+        // Arrange — three entries, none matched
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users/*', 'User sub-routes.'),
+            new AllowlistEntry('articles.old', 'Old article route.'),
+            new AllowlistEntry('beta/feature', 'Beta feature.'),
+        ]);
+
+        // Act — no calls to isExempt(), so all entries are stale
+
+        // Assert — keys returned in ascending lexicographic order
+        static::assertSame(
+            ['articles.old', 'beta/feature', 'users/*'],
+            $allowlist->unmatched(),
+        );
+    }
+}

--- a/tests/Unit/RouteLinting/ExemptionAllowlistTest.php
+++ b/tests/Unit/RouteLinting/ExemptionAllowlistTest.php
@@ -19,48 +19,87 @@ use Tests\TestCase;
 class ExemptionAllowlistTest extends TestCase
 {
     /**
-     * Test that an empty allowlist never exempts any route and reports no
-     * unmatched entries.
+     * Test that an empty allowlist never suppresses any violation and reports no
+     * unmatched or unused entries.
      *
      * @return void
      */
-    public function testEmptyAllowlistExemptsNothing(): void
+    public function testEmptyAllowlistSuppressesNothing(): void
     {
         // Arrange
         $allowlist = new ExemptionAllowlist([]);
 
-        // Act & Assert
-        static::assertFalse($allowlist->isExempt('users.index', 'users'));
-        static::assertFalse($allowlist->isExempt(null, 'users'));
+        // Act
+        $allowlist->observe('users.index', 'users');
+
+        // Assert
+        static::assertFalse($allowlist->suppresses('users.index', 'users', 'R1'));
         static::assertSame([], $allowlist->unmatched());
+        static::assertSame([], $allowlist->unused());
     }
 
     /**
-     * Test that an entry matching a route by its exact name exempts that route.
+     * Test that an entry without a rules list suppresses any rule on a matching
+     * route (backward-compatibility: omitting rules means all rules).
      *
      * @return void
      */
-    public function testMatchesByExactRouteName(): void
+    public function testEntryWithoutRulesSuppressesAnyRule(): void
     {
-        // Arrange
+        // Arrange — entry with empty rules list (default)
         $allowlist = new ExemptionAllowlist([
             new AllowlistEntry('users.store', 'Legacy store endpoint kept for backward compat.'),
         ]);
 
-        // Act & Assert — exact name match exempts
-        static::assertTrue($allowlist->isExempt('users.store', 'users'));
-
-        // A different name does not match even when the URI would
-        static::assertFalse($allowlist->isExempt('users.index', 'users'));
+        // Act & Assert — suppresses any rule ID on the matching route
+        static::assertTrue($allowlist->suppresses('users.store', 'users', 'R1'));
+        static::assertTrue($allowlist->suppresses('users.store', 'users', 'R9'));
+        static::assertTrue($allowlist->suppresses('users.store', 'users', 'R99'));
     }
 
     /**
-     * Test that an entry with a URI wildcard pattern exempts routes whose URI
-     * matches the pattern via fnmatch() shell-wildcard semantics.
+     * Test that an entry with an explicit rules list suppresses only the listed
+     * rules and leaves other rules unsuppressed on the same route.
      *
      * @return void
      */
-    public function testMatchesByUriWildcardPattern(): void
+    public function testEntryWithRulesSuppressesOnlyListedRules(): void
+    {
+        // Arrange — entry covering only R1
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('login', 'Legacy auth endpoint.', ['R1']),
+        ]);
+
+        // Act & Assert — R1 is suppressed; R2 is not
+        static::assertTrue($allowlist->suppresses(null, 'login', 'R1'));
+        static::assertFalse($allowlist->suppresses(null, 'login', 'R2'));
+    }
+
+    /**
+     * Test that suppresses() matches by exact route name.
+     *
+     * @return void
+     */
+    public function testSuppressesByExactRouteName(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.store', 'Legacy store endpoint.'),
+        ]);
+
+        // Act & Assert — exact name match suppresses
+        static::assertTrue($allowlist->suppresses('users.store', 'users', 'R1'));
+
+        // A different name is not suppressed even if the URI matches
+        static::assertFalse($allowlist->suppresses('users.index', 'users', 'R1'));
+    }
+
+    /**
+     * Test that suppresses() matches by URI wildcard pattern via fnmatch().
+     *
+     * @return void
+     */
+    public function testSuppressesByUriWildcardPattern(): void
     {
         // Arrange
         $allowlist = new ExemptionAllowlist([
@@ -68,29 +107,29 @@ class ExemptionAllowlistTest extends TestCase
         ]);
 
         // Act & Assert — wildcard matches the URI
-        static::assertTrue($allowlist->isExempt(null, 'users/create'));
-        static::assertTrue($allowlist->isExempt(null, 'users/profile'));
+        static::assertTrue($allowlist->suppresses(null, 'users/create', 'R1'));
+        static::assertTrue($allowlist->suppresses(null, 'users/profile', 'R2'));
 
-        // A URI that does not match the pattern is not exempt
-        static::assertFalse($allowlist->isExempt(null, 'articles/create'));
+        // A URI that does not match the pattern is not suppressed
+        static::assertFalse($allowlist->suppresses(null, 'articles/create', 'R1'));
     }
 
     /**
-     * Test that an entry that matched no live route appears in unmatched(), and
-     * that an entry that was matched at least once does not.
+     * Test that observe() drives unmatched() — an entry whose pattern never
+     * matches any observed route appears in unmatched().
      *
      * @return void
      */
-    public function testUnmatchedEntryIsReportedStale(): void
+    public function testObserveAndUnmatched(): void
     {
-        // Arrange — two entries; only the first will be matched
+        // Arrange — two entries; only the first will be observed
         $allowlist = new ExemptionAllowlist([
             new AllowlistEntry('users.store', 'Legacy store endpoint.'),
             new AllowlistEntry('articles.old', 'Deprecated article route.'),
         ]);
 
-        // Act — match the first entry once
-        $allowlist->isExempt('users.store', 'users');
+        // Act — observe only the route matching the first entry
+        $allowlist->observe('users.store', 'users');
 
         // Assert — only the unmatched second entry is stale
         static::assertSame(['articles.old'], $allowlist->unmatched());
@@ -104,19 +143,90 @@ class ExemptionAllowlistTest extends TestCase
      */
     public function testUnmatchedIsSorted(): void
     {
-        // Arrange — three entries, none matched
+        // Arrange — three entries, none observed
         $allowlist = new ExemptionAllowlist([
             new AllowlistEntry('users/*', 'User sub-routes.'),
             new AllowlistEntry('articles.old', 'Old article route.'),
             new AllowlistEntry('beta/feature', 'Beta feature.'),
         ]);
 
-        // Act — no calls to isExempt(), so all entries are stale
+        // Act — no observe() calls, so all entries are unmatched
 
         // Assert — keys returned in ascending lexicographic order
         static::assertSame(
             ['articles.old', 'beta/feature', 'users/*'],
             $allowlist->unmatched(),
         );
+    }
+
+    /**
+     * Test that an entry that matched a live route but suppressed no violation
+     * appears in unused() with a descriptive string.
+     *
+     * @return void
+     */
+    public function testUnusedEntryMatchedRouteButSuppressedNothing(): void
+    {
+        // Arrange — entry covering R1 only; the route has no R1 violation
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.index', 'Waived for migration.', ['R1']),
+        ]);
+
+        // Act — observe the route (it is live), but never call suppresses()
+        // because no violation fires on it
+        $allowlist->observe('users.index', 'users');
+
+        // Assert — entry appears in unused() but not unmatched()
+        static::assertSame([], $allowlist->unmatched());
+        static::assertCount(1, $allowlist->unused());
+        static::assertStringContainsString('users.index', $allowlist->unused()[0]);
+        static::assertStringContainsString('suppressed nothing', $allowlist->unused()[0]);
+        static::assertStringContainsString('Waived for migration.', $allowlist->unused()[0]);
+    }
+
+    /**
+     * Test that an entry that actually suppresses a violation does NOT appear
+     * in unused().
+     *
+     * @return void
+     */
+    public function testUsedEntryDoesNotAppearInUnused(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('login', 'Legacy auth endpoint.', ['R1']),
+        ]);
+
+        // Act — observe and then suppress a violation
+        $allowlist->observe(null, 'login');
+        $allowlist->suppresses(null, 'login', 'R1');
+
+        // Assert — entry was used; it appears in neither unused() nor unmatched()
+        static::assertSame([], $allowlist->unmatched());
+        static::assertSame([], $allowlist->unused());
+    }
+
+    /**
+     * Test that unused() returns entries sorted ascending for determinism.
+     *
+     * @return void
+     */
+    public function testUnusedIsSorted(): void
+    {
+        // Arrange — two entries that both match a live route but suppress nothing
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('z-route', 'Last alphabetically.', ['R9']),
+            new AllowlistEntry('a-route', 'First alphabetically.', ['R9']),
+        ]);
+
+        // Act — observe both routes but never suppress
+        $allowlist->observe('z-route', 'z-route');
+        $allowlist->observe('a-route', 'a-route');
+
+        // Assert — sorted ascending
+        $unused = $allowlist->unused();
+        static::assertCount(2, $unused);
+        static::assertStringContainsString('a-route', $unused[0]);
+        static::assertStringContainsString('z-route', $unused[1]);
     }
 }

--- a/tests/Unit/RouteLinting/ExemptionAllowlistTest.php
+++ b/tests/Unit/RouteLinting/ExemptionAllowlistTest.php
@@ -229,4 +229,119 @@ class ExemptionAllowlistTest extends TestCase
         static::assertStringContainsString('a-route', $unused[0]);
         static::assertStringContainsString('z-route', $unused[1]);
     }
+
+    /**
+     * Test that observe() records a match so the entry does NOT appear in
+     * unmatched() (kills TrueValue mutant #6: `$this->matched[$index] = false`).
+     *
+     * If `matched[$index]` is stored as false instead of true, the entry would
+     * appear in unmatched() even though observe() was called for a matching route.
+     *
+     * @return void
+     */
+    public function testObserveMarksEntryAsMatchedSoItDoesNotAppearInUnmatched(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.index', 'Should be matched.'),
+        ]);
+
+        // Act — observe the matching route
+        $allowlist->observe('users.index', 'users');
+
+        // Assert — entry must NOT appear in unmatched()
+        static::assertSame([], $allowlist->unmatched());
+    }
+
+    /**
+     * Test that suppresses() iterates all entries, not just the first matching one
+     * (kills Continue_→break mutant #7).
+     *
+     * With `break` instead of `continue`, iteration stops on the first
+     * non-matching entry, leaving subsequent matching entries unchecked.
+     *
+     * @return void
+     */
+    public function testSuppressesChecksAllEntriesNotJustFirst(): void
+    {
+        // Arrange — first entry does NOT match; second entry DOES match
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('orders.index', 'First entry, non-matching.', ['R1']),
+            new AllowlistEntry('users.store', 'Second entry, matching.', ['R1']),
+        ]);
+
+        // Act & Assert — the matching second entry must suppress the violation
+        static::assertTrue($allowlist->suppresses('users.store', 'users', 'R1'));
+    }
+
+    /**
+     * Test that suppresses() marks a matched entry so it does NOT appear in
+     * unmatched() (kills TrueValue mutant #8: `$this->matched[$index] = false`).
+     *
+     * The suppresses() method also records match state. If it stores false, the
+     * entry would appear in unmatched() even when suppresses() was called for a
+     * matching route.
+     *
+     * @return void
+     */
+    public function testSuppressesMarksEntryAsMatchedSoItDoesNotAppearInUnmatched(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.store', 'Legacy endpoint.', ['R1']),
+        ]);
+
+        // Act — call suppresses() (not observe()) for a matching route
+        $allowlist->suppresses('users.store', 'users', 'R1');
+
+        // Assert — entry was matched via suppresses(), must not appear in unmatched()
+        static::assertSame([], $allowlist->unmatched());
+    }
+
+    /**
+     * Test that suppresses() marks an entry as used so it does NOT appear in
+     * unused() (kills TrueValue mutant #9: `$this->used[$index] = false`).
+     *
+     * If `used[$index]` is stored as false instead of true, the entry would
+     * appear in unused() even after it has suppressed a violation.
+     *
+     * @return void
+     */
+    public function testSuppressesMarksEntryAsUsedSoItDoesNotAppearInUnused(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('users.store', 'Legacy endpoint.', ['R1']),
+        ]);
+
+        // Act — call suppresses() so the entry covers the violation
+        $result = $allowlist->suppresses('users.store', 'users', 'R1');
+
+        // Assert — suppresses() returned true and entry is not in unused()
+        static::assertTrue($result);
+        static::assertSame([], $allowlist->unused());
+    }
+
+    /**
+     * Test the exact descriptive format of an unused() string entry.
+     *
+     * The format must be: "<match> (suppressed nothing): <reason>".
+     * This pins the sprintf template against simple substring checks.
+     *
+     * @return void
+     */
+    public function testUnusedEntryHasExactFormat(): void
+    {
+        // Arrange
+        $allowlist = new ExemptionAllowlist([
+            new AllowlistEntry('legacy.route', 'Migration period waiver.', ['R5']),
+        ]);
+
+        $allowlist->observe('legacy.route', 'legacy/route');
+
+        // Assert exact string format
+        $unused = $allowlist->unused();
+        static::assertCount(1, $unused);
+        static::assertSame('legacy.route (suppressed nothing): Migration period waiver.', $unused[0]);
+    }
 }

--- a/tests/Unit/RouteLinting/Inflection/FrameworkInflectorTest.php
+++ b/tests/Unit/RouteLinting/Inflection/FrameworkInflectorTest.php
@@ -82,4 +82,47 @@ class FrameworkInflectorTest extends TestCase
         static::assertSame('Media', $inflector->singular('Media'));
         static::assertTrue($inflector->isPlural('MEDIA'));
     }
+
+    /**
+     * Test that an uncountable word where Str::singular() returns the same
+     * value is still reported as plural-safe by isPlural().
+     *
+     * Targets ReturnRemoval on the uncountable `return true` in isPlural():
+     * without that return, 'data' would fall through to
+     * `Str::singular($word) !== $word`, which evaluates to 'data' !== 'data'
+     * = false, incorrectly reporting 'data' as not plural.
+     *
+     * @return void
+     */
+    public function testUncountableWhoseSingularFormMatchesItselfIsPlural(): void
+    {
+        // `Str::singular('data')` returns 'data' (unchanged), so without the
+        // early return the result would be false.
+        $inflector = new FrameworkInflector(['data']);
+
+        static::assertTrue($inflector->isPlural('data'));
+    }
+
+    /**
+     * Test that isPlural() is case-insensitive for uncountable matching —
+     * 'DATA' (uppercase) must be treated as plural-safe when 'data' is configured.
+     *
+     * Targets UnwrapStrToLower on the uncountable in_array check in isPlural():
+     * without strtolower(), in_array('DATA', ['data']) returns false; the
+     * method then delegates to Str::singular('DATA') which returns 'DATA'
+     * (unchanged), so Str::singular != word evaluates false — isPlural returns
+     * false instead of the expected true.
+     *
+     * @return void
+     */
+    public function testUncountableMatchingIsCaseInsensitiveForWordsThatDoNotChangeSingular(): void
+    {
+        // 'data' is an uncountable whose Str::singular() == itself.
+        // Without strtolower(), 'DATA' would not be found in ['data'] and
+        // Str::singular('DATA') === 'DATA' would make isPlural return false.
+        $inflector = new FrameworkInflector(['data']);
+
+        static::assertTrue($inflector->isPlural('DATA'));
+        static::assertTrue($inflector->isPlural('Data'));
+    }
 }

--- a/tests/Unit/RouteLinting/Inflection/FrameworkInflectorTest.php
+++ b/tests/Unit/RouteLinting/Inflection/FrameworkInflectorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Inflection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Inflection\FrameworkInflector;
+use Tests\TestCase;
+
+/**
+ * Tests for FrameworkInflector.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(FrameworkInflector::class)]
+class FrameworkInflectorTest extends TestCase
+{
+    /**
+     * Test that singular() returns the singular form of a regular plural word.
+     *
+     * @return void
+     */
+    public function testSingularisesAPlural(): void
+    {
+        $inflector = new FrameworkInflector;
+
+        static::assertSame('user', $inflector->singular('users'));
+    }
+
+    /**
+     * Test that a configured uncountable is returned unchanged by singular() and
+     * is reported as plural-safe by isPlural().
+     *
+     * @return void
+     */
+    public function testUncountableIsReturnedUnchangedAndPluralSafe(): void
+    {
+        $inflector = new FrameworkInflector(['media']);
+
+        static::assertSame('media', $inflector->singular('media'));
+        static::assertTrue($inflector->isPlural('media'));
+    }
+
+    /**
+     * Test that isPlural() correctly identifies plural and singular words.
+     *
+     * @return void
+     */
+    public function testIsPluralDetectsPlurality(): void
+    {
+        $inflector = new FrameworkInflector;
+
+        static::assertTrue($inflector->isPlural('users'));
+        static::assertFalse($inflector->isPlural('user'));
+    }
+
+    /**
+     * Test that an empty string is returned unchanged by singular() and
+     * isPlural() returns false for an empty string.
+     *
+     * @return void
+     */
+    public function testEmptyStringEdgeCases(): void
+    {
+        $inflector = new FrameworkInflector;
+
+        static::assertSame('', $inflector->singular(''));
+        static::assertFalse($inflector->isPlural(''));
+    }
+
+    /**
+     * Test that uncountable matching is case-insensitive.
+     *
+     * @return void
+     */
+    public function testUncountableMatchingIsCaseInsensitive(): void
+    {
+        $inflector = new FrameworkInflector(['media']);
+
+        static::assertSame('Media', $inflector->singular('Media'));
+        static::assertTrue($inflector->isPlural('MEDIA'));
+    }
+}

--- a/tests/Unit/RouteLinting/NormalisedRouteTest.php
+++ b/tests/Unit/RouteLinting/NormalisedRouteTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit\RouteLinting;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use Tests\TestCase;
+
+/**
+ * Tests for NormalisedRoute::identity().
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(NormalisedRoute::class)]
+class NormalisedRouteTest extends TestCase
+{
+    /**
+     * Test that methods are sorted ascending regardless of construction order.
+     *
+     * @return void
+     */
+    public function testMethodsAreSortedDeterministically(): void
+    {
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['POST', 'GET'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        static::assertStringStartsWith('GET,POST ', $route->identity());
+    }
+
+    /**
+     * Test that the URI is included in the identity string.
+     *
+     * @return void
+     */
+    public function testUriIsIncludedInIdentity(): void
+    {
+        $route = new NormalisedRoute(
+            uri: 'users/{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '{user}'],
+            parameters: ['user'],
+        );
+
+        static::assertSame('GET users/{user}', $route->identity());
+    }
+
+    /**
+     * Test that a named route appends the name after the URI.
+     *
+     * @return void
+     */
+    public function testNamedRouteAppendsNameToIdentity(): void
+    {
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['HEAD', 'GET'],
+            name: 'users.index',
+            segments: ['users'],
+            parameters: [],
+        );
+
+        static::assertSame('GET,HEAD users users.index', $route->identity());
+    }
+
+    /**
+     * Test that an unnamed route omits the name from the identity.
+     *
+     * @return void
+     */
+    public function testUnnamedRouteOmitsNameFromIdentity(): void
+    {
+        $route = new NormalisedRoute(
+            uri: 'orders',
+            methods: ['GET'],
+            name: null,
+            segments: ['orders'],
+            parameters: [],
+        );
+
+        static::assertSame('GET orders', $route->identity());
+    }
+}

--- a/tests/Unit/RouteLinting/Output/ConsoleLintReporterTest.php
+++ b/tests/Unit/RouteLinting/Output/ConsoleLintReporterTest.php
@@ -73,6 +73,8 @@ class ConsoleLintReporterTest extends TestCase
         static::assertStringContainsString('GET /get-users', $output);
         static::assertStringContainsString('get', $output);
         static::assertStringContainsString('use a noun-based path instead', $output);
+        // Hint segment must use the exact label
+        static::assertStringContainsString('Hint: use a noun-based path instead', $output);
     }
 
     /**
@@ -204,5 +206,180 @@ class ConsoleLintReporterTest extends TestCase
         static::assertStringContainsString('Route linting warnings', $output);
         static::assertStringNotContainsString('Route linting errors', $output);
         static::assertStringNotContainsString('Stale waivers / unused suppressions', $output);
+    }
+
+    /**
+     * Test that a clean report does NOT render error/warning/stale sections
+     * (kills ReturnRemoval mutant #37: early return omitted in the clean-report branch).
+     *
+     * Without the early return the reporter would fall through to
+     * renderErrors/renderWarnings/renderStaleWaivers even on a clean report.
+     * Those inner methods have their own empty-array guards and would emit
+     * nothing extra — but we confirm the success line is the ONLY output and
+     * none of the section headers bleed through.
+     *
+     * @return void
+     */
+    public function testCleanReportOutputContainsOnlySuccessLine(): void
+    {
+        // Arrange — completely empty report
+        $report = new RouteLintReport;
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — success line is present
+        static::assertStringContainsString('All routes conform to the RESTful conventions.', $output);
+
+        // Assert — none of the section headers are present (early-return guard)
+        static::assertStringNotContainsString('Route linting errors', $output);
+        static::assertStringNotContainsString('Route linting warnings', $output);
+        static::assertStringNotContainsString('Stale waivers', $output);
+    }
+
+    /**
+     * Test that a report with only warnings does NOT render the success line
+     * (kills ReturnRemoval mutant #37 from another angle).
+     *
+     * If the early return is removed, a clean-report check passes through and
+     * the success line would appear even alongside finding sections. This test
+     * confirms the two branches are mutually exclusive.
+     *
+     * @return void
+     */
+    public function testReportWithWarningsDoesNotRenderSuccessLine(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+        $report->addViolation(new Violation(
+            ruleId: 'R8',
+            severity: Severity::WARNING,
+            routeIdentity: 'GET users',
+            offendingSurface: 'users',
+            remediationHint: null,
+        ));
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — success line must NOT appear when there are warnings
+        static::assertStringNotContainsString('All routes conform to the RESTful conventions.', $output);
+        static::assertStringContainsString('Route linting warnings', $output);
+    }
+
+    /**
+     * Test that an empty warnings list does not render the warnings section header
+     * (kills ReturnRemoval mutant #38: early return in renderWarnings omitted).
+     *
+     * Without the early return in renderWarnings(), an empty array still causes
+     * the warning header and foreach (which emits nothing) to execute.
+     * Specifically, the warning header "Route linting warnings:" would appear
+     * in the output even with an empty warnings list when the report has errors.
+     *
+     * @return void
+     */
+    public function testEmptyWarningsSectionIsNotRendered(): void
+    {
+        // Arrange — error only; warnings list is empty
+        $report = new RouteLintReport;
+        $report->addViolation(new Violation(
+            ruleId: 'R1',
+            severity: Severity::ERROR,
+            routeIdentity: 'GET getUsers',
+            offendingSurface: 'getUsers',
+            remediationHint: null,
+        ));
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — errors section is rendered; warnings section is NOT
+        static::assertStringContainsString('Route linting errors', $output);
+        static::assertStringNotContainsString('Route linting warnings', $output);
+    }
+
+    /**
+     * Test the exact rendered format of a violation line with a hint.
+     *
+     * Pins the sprintf template: "  [<ruleId>] <routeIdentity> (<offendingSurface>) -- Hint: <hint>".
+     *
+     * @return void
+     */
+    public function testViolationLineExactFormatWithHint(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+        $report->addViolation(new Violation(
+            ruleId: 'R5',
+            severity: Severity::ERROR,
+            routeIdentity: 'GET /fetch-items',
+            offendingSurface: 'fetch',
+            remediationHint: 'rename to /items',
+        ));
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert exact line content
+        static::assertStringContainsString(
+            '  [R5] GET /fetch-items (fetch) -- Hint: rename to /items',
+            $output,
+        );
+    }
+
+    /**
+     * Test the exact rendered format of a violation line without a hint.
+     *
+     * Pins the sprintf template: "  [<ruleId>] <routeIdentity> (<offendingSurface>)" — no hint segment.
+     *
+     * @return void
+     */
+    public function testViolationLineExactFormatWithoutHint(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+        $report->addViolation(new Violation(
+            ruleId: 'R3',
+            severity: Severity::ERROR,
+            routeIdentity: 'POST UserItems',
+            offendingSurface: 'UserItems',
+            remediationHint: null,
+        ));
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert exact line content — no " -- Hint:" suffix
+        static::assertStringContainsString('  [R3] POST UserItems (UserItems)', $output);
+        static::assertStringNotContainsString('Hint:', $output);
+    }
+
+    /**
+     * Test the exact rendered format of a stale-waiver line.
+     *
+     * Pins the sprintf template: "  - <entry>".
+     *
+     * @return void
+     */
+    public function testStaleWaiverLineExactFormat(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+        $report->addStaleWaiver('orders.legacy (suppressed nothing): Old migration waiver.');
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert exact line content
+        static::assertStringContainsString(
+            '  - orders.legacy (suppressed nothing): Old migration waiver.',
+            $output,
+        );
     }
 }

--- a/tests/Unit/RouteLinting/Output/ConsoleLintReporterTest.php
+++ b/tests/Unit/RouteLinting/Output/ConsoleLintReporterTest.php
@@ -123,7 +123,7 @@ class ConsoleLintReporterTest extends TestCase
         $output = $this->buffer->fetch();
 
         // Assert — stale-waivers header and entry key are present
-        static::assertStringContainsString('Stale allowlist entries', $output);
+        static::assertStringContainsString('Stale waivers / unused suppressions', $output);
         static::assertStringContainsString('users.legacy', $output);
     }
 
@@ -146,7 +146,7 @@ class ConsoleLintReporterTest extends TestCase
         static::assertStringContainsString('All routes conform to the RESTful conventions.', $output);
         static::assertStringNotContainsString('Route linting errors', $output);
         static::assertStringNotContainsString('Route linting warnings', $output);
-        static::assertStringNotContainsString('Stale allowlist entries', $output);
+        static::assertStringNotContainsString('Stale waivers / unused suppressions', $output);
     }
 
     /**
@@ -203,6 +203,6 @@ class ConsoleLintReporterTest extends TestCase
         // Assert — only the warning section header appears
         static::assertStringContainsString('Route linting warnings', $output);
         static::assertStringNotContainsString('Route linting errors', $output);
-        static::assertStringNotContainsString('Stale allowlist entries', $output);
+        static::assertStringNotContainsString('Stale waivers / unused suppressions', $output);
     }
 }

--- a/tests/Unit/RouteLinting/Output/ConsoleLintReporterTest.php
+++ b/tests/Unit/RouteLinting/Output/ConsoleLintReporterTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Output;
+
+use Illuminate\Console\OutputStyle;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Output\ConsoleLintReporter;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintReport;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+/**
+ * Tests for the ConsoleLintReporter adapter.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ConsoleLintReporter::class)]
+class ConsoleLintReporterTest extends TestCase
+{
+    /** @var \Symfony\Component\Console\Output\BufferedOutput */
+    private BufferedOutput $buffer;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Output\ConsoleLintReporter */
+    private ConsoleLintReporter $reporter;
+
+    /**
+     * Set up a buffered output sink and a fresh reporter for each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buffer   = new BufferedOutput;
+        $this->reporter = new ConsoleLintReporter(
+            new OutputStyle(new ArrayInput([]), $this->buffer),
+        );
+    }
+
+    /**
+     * Test that an error violation with a remediation hint renders a line
+     * containing the rule id, route identity, offending surface, and hint.
+     *
+     * @return void
+     */
+    public function testRendersErrorFindingsWithHint(): void
+    {
+        // Arrange
+        $report    = new RouteLintReport;
+        $violation = new Violation(
+            ruleId: 'R1',
+            severity: Severity::ERROR,
+            routeIdentity: 'GET /get-users',
+            offendingSurface: 'get',
+            remediationHint: 'use a noun-based path instead',
+        );
+        $report->addViolation($violation);
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — error header and violation line are present
+        static::assertStringContainsString('Route linting errors', $output);
+        static::assertStringContainsString('[R1]', $output);
+        static::assertStringContainsString('GET /get-users', $output);
+        static::assertStringContainsString('get', $output);
+        static::assertStringContainsString('use a noun-based path instead', $output);
+    }
+
+    /**
+     * Test that a warning violation renders a line under the warning header
+     * containing the rule id and route identity.
+     *
+     * @return void
+     */
+    public function testRendersWarningFindings(): void
+    {
+        // Arrange
+        $report    = new RouteLintReport;
+        $violation = new Violation(
+            ruleId: 'R8',
+            severity: Severity::WARNING,
+            routeIdentity: 'GET users',
+            offendingSurface: 'users.getAll',
+            remediationHint: null,
+        );
+        $report->addViolation($violation);
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — warning header and violation line are present; no error header
+        static::assertStringContainsString('Route linting warnings', $output);
+        static::assertStringContainsString('[R8]', $output);
+        static::assertStringContainsString('GET users', $output);
+        static::assertStringContainsString('users.getAll', $output);
+        static::assertStringNotContainsString('Route linting errors', $output);
+    }
+
+    /**
+     * Test that a stale-waiver entry renders a line naming the allowlist key
+     * under the stale-waivers header.
+     *
+     * @return void
+     */
+    public function testRendersStaleWaivers(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+        $report->addStaleWaiver('users.legacy');
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — stale-waivers header and entry key are present
+        static::assertStringContainsString('Stale allowlist entries', $output);
+        static::assertStringContainsString('users.legacy', $output);
+    }
+
+    /**
+     * Test that a report with no errors, warnings, or stale waivers renders
+     * a success line and no finding headers.
+     *
+     * @return void
+     */
+    public function testCleanReportRendersSuccessLine(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — success message present; no finding headers
+        static::assertStringContainsString('All routes conform to the RESTful conventions.', $output);
+        static::assertStringNotContainsString('Route linting errors', $output);
+        static::assertStringNotContainsString('Route linting warnings', $output);
+        static::assertStringNotContainsString('Stale allowlist entries', $output);
+    }
+
+    /**
+     * Test that an error violation with no remediation hint renders a line
+     * without the hint segment.
+     *
+     * @return void
+     */
+    public function testRendersErrorFindingsWithoutHint(): void
+    {
+        // Arrange
+        $report    = new RouteLintReport;
+        $violation = new Violation(
+            ruleId: 'R2',
+            severity: Severity::ERROR,
+            routeIdentity: 'GET userProfiles',
+            offendingSurface: 'userProfiles',
+            remediationHint: null,
+        );
+        $report->addViolation($violation);
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — violation line is present without a hint segment
+        static::assertStringContainsString('[R2]', $output);
+        static::assertStringContainsString('userProfiles', $output);
+        static::assertStringNotContainsString('Hint:', $output);
+    }
+
+    /**
+     * Test that empty error and stale sections are skipped when only warnings exist.
+     *
+     * @return void
+     */
+    public function testSkipsEmptySections(): void
+    {
+        // Arrange — warning only; no errors and no stale waivers
+        $report    = new RouteLintReport;
+        $violation = new Violation(
+            ruleId: 'R11',
+            severity: Severity::WARNING,
+            routeIdentity: 'GET a/b/c/d',
+            offendingSurface: 'a/b/c/d',
+            remediationHint: null,
+        );
+        $report->addViolation($violation);
+
+        // Act
+        $this->reporter->report($report);
+        $output = $this->buffer->fetch();
+
+        // Assert — only the warning section header appears
+        static::assertStringContainsString('Route linting warnings', $output);
+        static::assertStringNotContainsString('Route linting errors', $output);
+        static::assertStringNotContainsString('Stale allowlist entries', $output);
+    }
+}

--- a/tests/Unit/RouteLinting/RouteLintEngineTest.php
+++ b/tests/Unit/RouteLinting/RouteLintEngineTest.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace Tests\Unit\RouteLinting;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Rule;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintEngine;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+use Tests\TestCase;
+
+/**
+ * Tests for the RouteLintEngine pure orchestrator.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouteLintEngine::class)]
+class RouteLintEngineTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute */
+    private NormalisedRoute $route;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: 'users.index',
+            segments: ['users'],
+            parameters: [],
+        );
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that the engine runs all supplied rules in their constructor-supplied
+     * order and returns both violations in that order.
+     *
+     * @return void
+     */
+    public function testRunsAllRulesInSuppliedOrder(): void
+    {
+        // Arrange — two stub rules each emitting a canned violation
+        $firstViolation  = new Violation('R1', Severity::ERROR, 'GET users users.index', 'getUsers', null);
+        $secondViolation = new Violation('R2', Severity::ERROR, 'GET users users.index', 'UserProfiles', null);
+
+        $firstRule = new class ($firstViolation) implements Rule {
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation
+             */
+            public function __construct(private readonly Violation $violation) {}
+
+            /**
+             * @return string
+             */
+            #[\Override]
+            public function id(): string
+            {
+                return 'R1';
+            }
+
+            /**
+             * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+             */
+            #[\Override]
+            public function severity(): Severity
+            {
+                return Severity::ERROR;
+            }
+
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+             * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+             */
+            #[\Override]
+            public function inspect(NormalisedRoute $route, RuleConfig $config): array
+            {
+                return [$this->violation];
+            }
+        };
+
+        $secondRule = new class ($secondViolation) implements Rule {
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation
+             */
+            public function __construct(private readonly Violation $violation) {}
+
+            /**
+             * @return string
+             */
+            #[\Override]
+            public function id(): string
+            {
+                return 'R2';
+            }
+
+            /**
+             * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+             */
+            #[\Override]
+            public function severity(): Severity
+            {
+                return Severity::ERROR;
+            }
+
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+             * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+             */
+            #[\Override]
+            public function inspect(NormalisedRoute $route, RuleConfig $config): array
+            {
+                return [$this->violation];
+            }
+        };
+
+        $engine = new RouteLintEngine($firstRule, $secondRule);
+
+        // Act
+        $violations = $engine->inspect($this->route, $this->config);
+
+        // Assert — both violations present in supplied rule order
+        static::assertCount(2, $violations);
+        static::assertSame('R1', $violations[0]->ruleId);
+        static::assertSame('R2', $violations[1]->ruleId);
+    }
+
+    /**
+     * Test that violations from multiple rules with different yield counts are
+     * flattened into a single array of the expected total size.
+     *
+     * Rule A emits 0, Rule B emits 1, Rule C emits 2 — total must be 3.
+     *
+     * @return void
+     */
+    public function testAggregatesViolationsAcrossRules(): void
+    {
+        // Arrange
+        $violationB  = new Violation('R2', Severity::ERROR, 'GET users users.index', 'UserProfiles', null);
+        $violationC1 = new Violation('R3', Severity::ERROR, 'GET users users.index', 'Users', null);
+        $violationC2 = new Violation('R3', Severity::ERROR, 'GET users users.index', 'USERS', null);
+
+        $ruleA = new class implements Rule {
+            /**
+             * @return string
+             */
+            #[\Override]
+            public function id(): string
+            {
+                return 'R1';
+            }
+
+            /**
+             * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+             */
+            #[\Override]
+            public function severity(): Severity
+            {
+                return Severity::ERROR;
+            }
+
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+             * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+             */
+            #[\Override]
+            public function inspect(NormalisedRoute $route, RuleConfig $config): array
+            {
+                return [];
+            }
+        };
+
+        $ruleB = new class ($violationB) implements Rule {
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation
+             */
+            public function __construct(private readonly Violation $violation) {}
+
+            /**
+             * @return string
+             */
+            #[\Override]
+            public function id(): string
+            {
+                return 'R2';
+            }
+
+            /**
+             * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+             */
+            #[\Override]
+            public function severity(): Severity
+            {
+                return Severity::ERROR;
+            }
+
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+             * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+             */
+            #[\Override]
+            public function inspect(NormalisedRoute $route, RuleConfig $config): array
+            {
+                return [$this->violation];
+            }
+        };
+
+        $ruleC = new class ($violationC1, $violationC2) implements Rule {
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation1
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation2
+             */
+            public function __construct(
+                private readonly Violation $violation1,
+                private readonly Violation $violation2,
+            ) {}
+
+            /**
+             * @return string
+             */
+            #[\Override]
+            public function id(): string
+            {
+                return 'R3';
+            }
+
+            /**
+             * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+             */
+            #[\Override]
+            public function severity(): Severity
+            {
+                return Severity::ERROR;
+            }
+
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+             * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+             */
+            #[\Override]
+            public function inspect(NormalisedRoute $route, RuleConfig $config): array
+            {
+                return [$this->violation1, $this->violation2];
+            }
+        };
+
+        $engine = new RouteLintEngine($ruleA, $ruleB, $ruleC);
+
+        // Act
+        $violations = $engine->inspect($this->route, $this->config);
+
+        // Assert — 0 + 1 + 2 = 3 violations in a flat array
+        static::assertCount(3, $violations);
+        static::assertSame('R2', $violations[0]->ruleId);
+        static::assertSame('R3', $violations[1]->ruleId);
+        static::assertSame('R3', $violations[2]->ruleId);
+    }
+
+    /**
+     * Test that an engine constructed with no rules returns an empty array.
+     *
+     * @return void
+     */
+    public function testNoRulesReturnsEmpty(): void
+    {
+        // Arrange
+        $engine = new RouteLintEngine;
+
+        // Act
+        $violations = $engine->inspect($this->route, $this->config);
+
+        // Assert
+        static::assertSame([], $violations);
+    }
+
+    /**
+     * Test that calling inspect() twice with the same route and config produces
+     * byte-identical arrays (NFR-01 repeatability / determinism).
+     *
+     * @return void
+     */
+    public function testRepeatableOutputAcrossTwoRuns(): void
+    {
+        // Arrange — a single stub rule emitting two canned violations
+        $violation1 = new Violation('R1', Severity::ERROR, 'GET users users.index', 'getUsers', null);
+        $violation2 = new Violation('R1', Severity::ERROR, 'GET users users.index', 'listUsers', null);
+
+        $rule = new class ($violation1, $violation2) implements Rule {
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation1
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Violation  $violation2
+             */
+            public function __construct(
+                private readonly Violation $violation1,
+                private readonly Violation $violation2,
+            ) {}
+
+            /**
+             * @return string
+             */
+            #[\Override]
+            public function id(): string
+            {
+                return 'R1';
+            }
+
+            /**
+             * @return \SineMacula\ApiToolkit\RouteLinting\Severity
+             */
+            #[\Override]
+            public function severity(): Severity
+            {
+                return Severity::ERROR;
+            }
+
+            /**
+             * @param  \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute  $route
+             * @param  \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig  $config
+             * @return array<int, \SineMacula\ApiToolkit\RouteLinting\Violation>
+             */
+            #[\Override]
+            public function inspect(NormalisedRoute $route, RuleConfig $config): array
+            {
+                return [$this->violation1, $this->violation2];
+            }
+        };
+
+        $engine = new RouteLintEngine($rule);
+
+        // Act — two separate calls with identical inputs
+        $firstRun  = $engine->inspect($this->route, $this->config);
+        $secondRun = $engine->inspect($this->route, $this->config);
+
+        // Assert — identical count, identical element identity per position
+        static::assertCount(2, $firstRun);
+        static::assertCount(2, $secondRun);
+
+        foreach ($firstRun as $index => $violation) {
+            static::assertSame($violation->ruleId, $secondRun[$index]->ruleId);
+            static::assertSame($violation->routeIdentity, $secondRun[$index]->routeIdentity);
+            static::assertSame($violation->offendingSurface, $secondRun[$index]->offendingSurface);
+            static::assertSame($violation->severity, $secondRun[$index]->severity);
+        }
+    }
+}

--- a/tests/Unit/RouteLinting/RouteLintReportTest.php
+++ b/tests/Unit/RouteLinting/RouteLintReportTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Unit\RouteLinting;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\RouteLintReport;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+use Tests\TestCase;
+
+/**
+ * Tests for the RouteLintReport verdict aggregate.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouteLintReport::class)]
+class RouteLintReportTest extends TestCase
+{
+    /**
+     * Test that errors() returns only ERROR-severity violations and warnings()
+     * returns only WARNING-severity violations.
+     *
+     * @return void
+     */
+    public function testErrorsReturnsOnlyErrorSeverityViolations(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+
+        $error   = new Violation('R1', Severity::ERROR, 'GET users', 'getUsers', null);
+        $warning = new Violation('R8', Severity::WARNING, 'GET users', 'users.getAll', null);
+
+        $report->addViolation($error);
+        $report->addViolation($warning);
+
+        // Act
+        $errors   = $report->errors();
+        $warnings = $report->warnings();
+
+        // Assert
+        static::assertCount(1, $errors);
+        static::assertSame(Severity::ERROR, $errors[0]->severity);
+        static::assertSame('R1', $errors[0]->ruleId);
+
+        static::assertCount(1, $warnings);
+        static::assertSame(Severity::WARNING, $warnings[0]->severity);
+        static::assertSame('R8', $warnings[0]->ruleId);
+    }
+
+    /**
+     * Test that findings are returned in a deterministic total order regardless
+     * of insertion order (NFR-01).
+     *
+     * Two report instances seeded with the same violations in different orders
+     * must produce byte-identical sorted arrays.
+     *
+     * @return void
+     */
+    public function testFindingsAreDeterministicallyOrdered(): void
+    {
+        // Arrange — three violations that differ on all three sort keys
+        $alpha = new Violation('R1', Severity::ERROR, 'GET,HEAD users', 'getUsers', null);
+        $beta  = new Violation('R2', Severity::ERROR, 'GET,HEAD users', 'UserProfiles', null);
+        $gamma = new Violation('R1', Severity::ERROR, 'GET articles', 'getArticles', null);
+
+        // Report A: inserted in alpha, beta, gamma order
+        $reportA = new RouteLintReport;
+        $reportA->addViolation($alpha);
+        $reportA->addViolation($beta);
+        $reportA->addViolation($gamma);
+
+        // Report B: inserted in shuffled gamma, alpha, beta order
+        $reportB = new RouteLintReport;
+        $reportB->addViolation($gamma);
+        $reportB->addViolation($alpha);
+        $reportB->addViolation($beta);
+
+        // Act
+        $errorsA = $reportA->errors();
+        $errorsB = $reportB->errors();
+
+        // Assert — identical count and identical identity/ruleId/surface per position
+        static::assertCount(3, $errorsA);
+        static::assertCount(3, $errorsB);
+
+        foreach ($errorsA as $index => $violation) {
+            static::assertSame($violation->routeIdentity, $errorsB[$index]->routeIdentity);
+            static::assertSame($violation->ruleId, $errorsB[$index]->ruleId);
+            static::assertSame($violation->offendingSurface, $errorsB[$index]->offendingSurface);
+        }
+
+        // Assert the concrete order: gamma sorts before alpha/beta (route identity 'GET articles' < 'GET,HEAD users')
+        static::assertSame('GET articles', $errorsA[0]->routeIdentity);
+        // Within 'GET,HEAD users': R1 before R2
+        static::assertSame('R1', $errorsA[1]->ruleId);
+        static::assertSame('R2', $errorsA[2]->ruleId);
+    }
+
+    /**
+     * Test that a report containing only warnings and stale waivers returns
+     * hasErrors() === false.
+     *
+     * @return void
+     */
+    public function testHasErrorsIsFalseForWarningOnlyReport(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+
+        $report->addViolation(new Violation('R8', Severity::WARNING, 'GET users', 'users.getAll', null));
+        $report->addViolation(new Violation('R11', Severity::WARNING, 'GET a/b/c/d', 'a/b/c/d', null));
+        $report->addStaleWaiver('users.legacy');
+
+        // Act & Assert
+        static::assertFalse($report->hasErrors());
+        static::assertCount(2, $report->warnings());
+        static::assertEmpty($report->errors());
+    }
+
+    /**
+     * Test that staleWaivers() returns stale entries sorted ascending regardless
+     * of insertion order.
+     *
+     * @return void
+     */
+    public function testStaleWaiversAreSorted(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+
+        $report->addStaleWaiver('users.legacy');
+        $report->addStaleWaiver('articles.old');
+        $report->addStaleWaiver('beta.route');
+
+        // Act
+        $stale = $report->staleWaivers();
+
+        // Assert
+        static::assertSame(['articles.old', 'beta.route', 'users.legacy'], $stale);
+    }
+
+    /**
+     * Test that a freshly constructed report has no errors, no warnings, no
+     * stale waivers, and hasErrors() returns false.
+     *
+     * @return void
+     */
+    public function testEmptyReportHasNoErrors(): void
+    {
+        // Arrange
+        $report = new RouteLintReport;
+
+        // Act & Assert
+        static::assertFalse($report->hasErrors());
+        static::assertSame([], $report->errors());
+        static::assertSame([], $report->warnings());
+        static::assertSame([], $report->staleWaivers());
+    }
+}

--- a/tests/Unit/RouteLinting/RouteLintReportTest.php
+++ b/tests/Unit/RouteLinting/RouteLintReportTest.php
@@ -159,4 +159,63 @@ class RouteLintReportTest extends TestCase
         static::assertSame([], $report->warnings());
         static::assertSame([], $report->staleWaivers());
     }
+
+    /**
+     * Test the third sort key (offendingSurface ASC) in the deterministic order
+     * (kills Spaceship mutant #39: `$a->offendingSurface <=> $b->offendingSurface`
+     * reversed to `$b->offendingSurface <=> $a->offendingSurface`).
+     *
+     * Two violations share the same routeIdentity AND the same ruleId; the only
+     * distinguishing key is offendingSurface. The mutant reverses this comparison,
+     * producing descending order instead of ascending.
+     *
+     * @return void
+     */
+    public function testThirdSortKeyIsOffendingSurfaceAscending(): void
+    {
+        // Arrange — same routeIdentity and ruleId, different offendingSurface
+        $report = new RouteLintReport;
+
+        $report->addViolation(new Violation('R1', Severity::ERROR, 'GET users', 'zebra', null));
+        $report->addViolation(new Violation('R1', Severity::ERROR, 'GET users', 'apple', null));
+        $report->addViolation(new Violation('R1', Severity::ERROR, 'GET users', 'mango', null));
+
+        // Act
+        $errors = $report->errors();
+
+        // Assert — must be ascending by offendingSurface
+        static::assertCount(3, $errors);
+        static::assertSame('apple', $errors[0]->offendingSurface);
+        static::assertSame('mango', $errors[1]->offendingSurface);
+        static::assertSame('zebra', $errors[2]->offendingSurface);
+    }
+
+    /**
+     * Test that violations inserted in reverse offendingSurface order still sort
+     * ascending (complements the spaceship test with reversed insertion order).
+     *
+     * @return void
+     */
+    public function testOffendingSurfaceSortIsStableAcrossInsertionOrders(): void
+    {
+        // Report A: inserted ascending
+        $reportA = new RouteLintReport;
+        $reportA->addViolation(new Violation('R2', Severity::ERROR, 'POST orders', 'alpha-surface', null));
+        $reportA->addViolation(new Violation('R2', Severity::ERROR, 'POST orders', 'omega-surface', null));
+
+        // Report B: inserted descending
+        $reportB = new RouteLintReport;
+        $reportB->addViolation(new Violation('R2', Severity::ERROR, 'POST orders', 'omega-surface', null));
+        $reportB->addViolation(new Violation('R2', Severity::ERROR, 'POST orders', 'alpha-surface', null));
+
+        // Act
+        $errorsA = $reportA->errors();
+        $errorsB = $reportB->errors();
+
+        // Assert — both produce the same ascending order
+        static::assertSame('alpha-surface', $errorsA[0]->offendingSurface);
+        static::assertSame('omega-surface', $errorsA[1]->offendingSurface);
+        static::assertSame('alpha-surface', $errorsB[0]->offendingSurface);
+        static::assertSame('omega-surface', $errorsB[1]->offendingSurface);
+    }
 }

--- a/tests/Unit/RouteLinting/Rules/ApiResourceAlignmentRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/ApiResourceAlignmentRuleTest.php
@@ -144,6 +144,99 @@ class ApiResourceAlignmentRuleTest extends TestCase
     }
 
     /**
+     * Test that 'edit' followed by a route parameter is still flagged as the final literal segment.
+     *
+     * Kills the Continue_->break mutant (#41): without continue the loop would stop on the
+     * first parameter segment encountered in reverse order, returning null instead of
+     * scanning back to find 'edit'. The violation must still be produced.
+     *
+     * @return void
+     */
+    public function testEditBeforeTrailingParamIsFlagged(): void
+    {
+        // Arrange — GET /users/edit/{user}; reversed segments are ['{user}', 'edit', 'users']
+        // The param '{user}' must be skipped (continue) to reach 'edit' as the last literal
+        $route = new NormalisedRoute(
+            uri: 'users/edit/{user}',
+            methods: ['GET'],
+            name: 'users.edit',
+            segments: ['users', 'edit', '{user}'],
+            parameters: ['user'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'edit' is the final literal segment and must be flagged
+        static::assertCount(1, $violations);
+        static::assertSame('R9', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('edit', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that 'create' followed by a route parameter is still flagged as the final literal segment.
+     *
+     * Provides additional coverage for the Continue_->break mutant (#41) and
+     * also kills the LogicalOr->LogicalAnd mutant (#40) on the skip condition:
+     * if the condition were 'empty AND param', the empty segment would not be skipped
+     * and would be returned instead of 'create'.
+     *
+     * @return void
+     */
+    public function testCreateBeforeTrailingParamIsFlagged(): void
+    {
+        // Arrange — GET /photos/create/{photo}; reversed: ['{photo}', 'create', 'photos']
+        $route = new NormalisedRoute(
+            uri: 'photos/create/{photo}',
+            methods: ['GET'],
+            name: 'photos.create',
+            segments: ['photos', 'create', '{photo}'],
+            parameters: ['photo'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'create' is the final literal segment and must be flagged
+        static::assertCount(1, $violations);
+        static::assertSame('R9', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('create', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a trailing empty segment does not prevent detection of a preceding 'create'.
+     *
+     * Kills the LogicalOr->LogicalAnd mutant (#40) on the skip condition: if the condition
+     * were '$segment === "" && str_starts_with($segment, "{")' (impossible to satisfy), the
+     * empty segment would not be skipped and would be returned as the last literal, masking
+     * the 'create' violation.
+     *
+     * @return void
+     */
+    public function testTrailingEmptySegmentDoesNotMaskCreateViolation(): void
+    {
+        // Arrange — trailing slash produces an empty segment after 'create';
+        // reversed: ['', 'create', 'photos'] — empty must be skipped to reach 'create'
+        $route = new NormalisedRoute(
+            uri: 'photos/create/',
+            methods: ['GET'],
+            name: 'photos.create',
+            segments: ['photos', 'create', ''],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'create' is still the final meaningful literal
+        static::assertCount(1, $violations);
+        static::assertSame('R9', $violations[0]->ruleId);
+        static::assertSame('create', $violations[0]->offendingSurface);
+    }
+
+    /**
      * Test that rule id() returns 'R9' and severity() returns Severity::WARNING.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/ApiResourceAlignmentRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/ApiResourceAlignmentRuleTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\ApiResourceAlignmentRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the ApiResourceAlignmentRule (R9) warning rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiResourceAlignmentRule::class)]
+class ApiResourceAlignmentRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\ApiResourceAlignmentRule */
+    private ApiResourceAlignmentRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new ApiResourceAlignmentRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a route whose final segment is 'edit' produces one R9 warning violation.
+     *
+     * @return void
+     */
+    public function testEditActionIsFlagged(): void
+    {
+        // Arrange — GET /photos/{photo}/edit; 'edit' is the final literal segment
+        $route = new NormalisedRoute(
+            uri: 'photos/{photo}/edit',
+            methods: ['GET'],
+            name: 'photos.edit',
+            segments: ['photos', '{photo}', 'edit'],
+            parameters: ['photo'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R9', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('edit', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a route whose final segment is 'create' produces one R9 warning violation.
+     *
+     * @return void
+     */
+    public function testCreateActionIsFlagged(): void
+    {
+        // Arrange — GET /photos/create; 'create' is the final literal segment
+        $route = new NormalisedRoute(
+            uri: 'photos/create',
+            methods: ['GET'],
+            name: 'photos.create',
+            segments: ['photos', 'create'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R9', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('create', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that the canonical show route GET /photos/{photo} produces no R9 violation.
+     *
+     * The final segment is the route parameter `{photo}`, not a literal 'create' or 'edit'.
+     *
+     * @return void
+     */
+    public function testCanonicalShowIsNotFlagged(): void
+    {
+        // Arrange — GET /photos/{photo}; final segment is a parameter
+        $route = new NormalisedRoute(
+            uri: 'photos/{photo}',
+            methods: ['GET'],
+            name: 'photos.show',
+            segments: ['photos', '{photo}'],
+            parameters: ['photo'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a literal 'create' in a non-terminal position does not produce a violation.
+     *
+     * Only the final literal segment is checked to keep precision high.
+     *
+     * @return void
+     */
+    public function testNonFinalCreateSegmentIsNotFlagged(): void
+    {
+        // Arrange — 'create' is not the last literal; 'items' follows it
+        $route = new NormalisedRoute(
+            uri: 'create/items',
+            methods: ['GET'],
+            name: null,
+            segments: ['create', 'items'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that rule id() returns 'R9' and severity() returns Severity::WARNING.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R9', $this->rule->id());
+        static::assertSame(Severity::WARNING, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/KebabCaseRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/KebabCaseRuleTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\KebabCaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the KebabCaseRule (R2) error rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(KebabCaseRule::class)]
+class KebabCaseRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\KebabCaseRule */
+    private KebabCaseRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new KebabCaseRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a camelCase segment produces one R2 error violation.
+     *
+     * @return void
+     */
+    public function testCamelCaseSegmentIsFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'userProfiles',
+            methods: ['GET'],
+            name: null,
+            segments: ['userProfiles'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R2', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('userProfiles', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a valid kebab-case segment produces no R2 violation.
+     *
+     * @return void
+     */
+    public function testKebabSegmentIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'user-profiles',
+            methods: ['GET'],
+            name: null,
+            segments: ['user-profiles'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that route-parameter segments wrapped in braces are ignored.
+     *
+     * @return void
+     */
+    public function testParameterSegmentsAreIgnored(): void
+    {
+        // Arrange — the sole segment is a route parameter
+        $route = new NormalisedRoute(
+            uri: '{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['{user}'],
+            parameters: ['user'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a plain lowercase alphanumeric segment produces no violation.
+     *
+     * @return void
+     */
+    public function testPlainLowercaseSegmentIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that empty segments (from trailing or duplicate slashes) are ignored.
+     *
+     * @return void
+     */
+    public function testEmptySegmentsAreIgnored(): void
+    {
+        // Arrange — trailing slash produces an empty trailing segment
+        $route = new NormalisedRoute(
+            uri: 'users/',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', ''],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'users' is valid kebab; '' is skipped; no violations
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that rule id() returns 'R2' and severity() returns Severity::ERROR.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R2', $this->rule->id());
+        static::assertSame(Severity::ERROR, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/KebabCaseRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/KebabCaseRuleTest.php
@@ -159,6 +159,68 @@ class KebabCaseRuleTest extends TestCase
     }
 
     /**
+     * Test that a non-kebab literal following a route-parameter segment is still flagged.
+     *
+     * Kills the Continue_->break mutant (#42): if the loop breaks on a param/empty segment
+     * instead of continuing, any literal that follows it is never inspected. With a param
+     * first then a camelCase literal, the original produces a violation while the mutant
+     * produces none.
+     *
+     * @return void
+     */
+    public function testNonKebabSegmentAfterParameterIsFlagged(): void
+    {
+        // Arrange — '{user}' is first; 'userProfiles' follows and must still be inspected
+        $route = new NormalisedRoute(
+            uri: '{user}/userProfiles',
+            methods: ['GET'],
+            name: null,
+            segments: ['{user}', 'userProfiles'],
+            parameters: ['user'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'userProfiles' violates kebab-case despite the leading param
+        static::assertCount(1, $violations);
+        static::assertSame('R2', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('userProfiles', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that two non-kebab segments each produce their own R2 violation.
+     *
+     * Kills the ArrayOneItem mutant (#43): when more than one violation is produced, the
+     * mutant returns only the first element. Asserting count = 2 and both offendingSurface
+     * values ensures the complete violations array is returned.
+     *
+     * @return void
+     */
+    public function testTwoNonKebabSegmentsProduceTwoViolations(): void
+    {
+        // Arrange — both 'userProfiles' and 'some_other_stuff' violate kebab-case
+        $route = new NormalisedRoute(
+            uri: 'userProfiles/some_other_stuff',
+            methods: ['GET'],
+            name: null,
+            segments: ['userProfiles', 'some_other_stuff'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — two violations, one per offending segment, in segment order
+        static::assertCount(2, $violations);
+        static::assertSame('R2', $violations[0]->ruleId);
+        static::assertSame('userProfiles', $violations[0]->offendingSurface);
+        static::assertSame('R2', $violations[1]->ruleId);
+        static::assertSame('some_other_stuff', $violations[1]->offendingSurface);
+    }
+
+    /**
      * Test that rule id() returns 'R2' and severity() returns Severity::ERROR.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/LowercaseRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/LowercaseRuleTest.php
@@ -161,6 +161,67 @@ class LowercaseRuleTest extends TestCase
     }
 
     /**
+     * Test that a route-parameter segment preceding an uppercase literal still produces a violation.
+     *
+     * Kills the Continue_->break mutant (#44): if the loop breaks instead of continuing on a
+     * param/empty segment, any literal that follows is never reached. With a param first
+     * then an uppercase literal, the original produces a violation while the mutant produces none.
+     *
+     * @return void
+     */
+    public function testUppercaseSegmentAfterParameterIsFlagged(): void
+    {
+        // Arrange — '{user}' is first; 'Users' follows and must still be inspected
+        $route = new NormalisedRoute(
+            uri: '{user}/Users',
+            methods: ['GET'],
+            name: null,
+            segments: ['{user}', 'Users'],
+            parameters: ['user'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'Users' is uppercase and must be flagged despite the leading param
+        static::assertCount(1, $violations);
+        static::assertSame('R3', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('Users', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that two uppercase segments each produce their own R3 violation.
+     *
+     * Kills the ArrayOneItem mutant (#45): when more than one violation is produced, the mutant
+     * returns only the first element. Asserting count = 2 and both offendingSurface values
+     * ensures the complete violations array is returned.
+     *
+     * @return void
+     */
+    public function testTwoUppercaseSegmentsProduceTwoViolations(): void
+    {
+        // Arrange — both 'Users' and 'Posts' contain uppercase letters
+        $route = new NormalisedRoute(
+            uri: 'Users/Posts',
+            methods: ['GET'],
+            name: null,
+            segments: ['Users', 'Posts'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — two violations, one per offending segment, in segment order
+        static::assertCount(2, $violations);
+        static::assertSame('R3', $violations[0]->ruleId);
+        static::assertSame('Users', $violations[0]->offendingSurface);
+        static::assertSame('R3', $violations[1]->ruleId);
+        static::assertSame('Posts', $violations[1]->offendingSurface);
+    }
+
+    /**
      * Test that rule id() returns 'R3' and severity() returns Severity::ERROR.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/LowercaseRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/LowercaseRuleTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\LowercaseRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the LowercaseRule (R3) error rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(LowercaseRule::class)]
+class LowercaseRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\LowercaseRule */
+    private LowercaseRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new LowercaseRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a segment containing an uppercase letter produces one R3 error violation.
+     *
+     * @return void
+     */
+    public function testUppercaseSegmentIsFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'Users',
+            methods: ['GET'],
+            name: null,
+            segments: ['Users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R3', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('Users', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that an all-lowercase segment produces no R3 violation.
+     *
+     * @return void
+     */
+    public function testLowercaseSegmentIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that route-parameter segments wrapped in braces are ignored.
+     *
+     * @return void
+     */
+    public function testParameterSegmentsAreIgnored(): void
+    {
+        // Arrange — the sole segment is a route parameter
+        $route = new NormalisedRoute(
+            uri: '{User}',
+            methods: ['GET'],
+            name: null,
+            segments: ['{User}'],
+            parameters: ['User'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a camelCase segment (mixed case) is flagged as a violation.
+     *
+     * @return void
+     */
+    public function testCamelCaseSegmentIsFlagged(): void
+    {
+        // Arrange — userProfiles contains uppercase letters; both R2 and R3 fire independently
+        $route = new NormalisedRoute(
+            uri: 'userProfiles',
+            methods: ['GET'],
+            name: null,
+            segments: ['userProfiles'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — R3 produces one violation for the mixed-case segment
+        static::assertCount(1, $violations);
+        static::assertSame('R3', $violations[0]->ruleId);
+        static::assertSame('userProfiles', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that empty segments are ignored and do not produce violations.
+     *
+     * @return void
+     */
+    public function testEmptySegmentsAreIgnored(): void
+    {
+        // Arrange — trailing slash produces an empty trailing segment
+        $route = new NormalisedRoute(
+            uri: 'users/',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', ''],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that rule id() returns 'R3' and severity() returns Severity::ERROR.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R3', $this->rule->id());
+        static::assertSame(Severity::ERROR, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/NestingDepthRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/NestingDepthRuleTest.php
@@ -140,6 +140,155 @@ class NestingDepthRuleTest extends TestCase
     }
 
     /**
+     * Test that a route with four literals but fewer route parameters is correctly flagged.
+     *
+     * This kills the LogicalOrNegation mutant (#46) that inverts the segment-skip condition
+     * so that literals are skipped and parameters are counted instead. With only two
+     * parameters but four literal segments, the original produces a violation while
+     * the mutant (counting params, not literals) produces none.
+     *
+     * @return void
+     */
+    public function testFourLiteralsWithFewerParamsIsFlagged(): void
+    {
+        // Arrange — four literal segments (users, posts, comments, tags) and two params
+        $uri   = 'users/{user}/posts/comments/tags';
+        $route = new NormalisedRoute(
+            uri: $uri,
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '{user}', 'posts', 'comments', 'tags'],
+            parameters: ['user'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — four literal segments exceeds the threshold of three
+        static::assertCount(1, $violations);
+        static::assertSame('R11', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame($uri, $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that route-parameter segments are not counted toward nesting depth.
+     *
+     * This kills the LogicalOrSingleSubExprNegation mutant (#47) that changes the
+     * condition so non-parameter segments (literals) are skipped and parameters
+     * are counted. Four parameters with only three literal segments: original
+     * counts three (no violation), mutant counts four (violation).
+     *
+     * @return void
+     */
+    public function testParameterSegmentsAreNotCountedTowardDepth(): void
+    {
+        // Arrange — three literal segments (users, posts, comments) and four params
+        $route = new NormalisedRoute(
+            uri: '{a}/{b}/users/{c}/posts/comments/{d}',
+            methods: ['GET'],
+            name: null,
+            segments: ['{a}', '{b}', 'users', '{c}', 'posts', 'comments', '{d}'],
+            parameters: ['a', 'b', 'c', 'd'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — only three literal segments; must not trigger R11
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a segment containing 'v2' in a non-prefix position is counted in the depth.
+     *
+     * Kills PregMatchRemoveCaret mutant (#48): without the leading anchor the regex
+     * '/v\d+$/i' would also match 'xv2', causing that segment to be skipped. With the
+     * correct anchored regex '/^v\d+$/i' only pure version tokens are excluded.
+     *
+     * @return void
+     */
+    public function testSegmentContainingVersionStringIsCountedAsLiteral(): void
+    {
+        // Arrange — 'xv2' looks version-like but is not a pure version token;
+        // four literals including 'xv2' must all be counted to trigger R11
+        $uri   = 'users/posts/comments/xv2';
+        $route = new NormalisedRoute(
+            uri: $uri,
+            methods: ['GET'],
+            name: null,
+            segments: ['users', 'posts', 'comments', 'xv2'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — all four segments are literal, depth = 4 > 3
+        static::assertCount(1, $violations);
+        static::assertSame('R11', $violations[0]->ruleId);
+        static::assertSame($uri, $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a segment beginning with a version token but having a suffix is counted as a literal.
+     *
+     * Kills PregMatchRemoveDollar mutant (#49): without the trailing anchor the regex
+     * '/^v\d+/i' would match 'v2extra', skipping that segment. With the correct
+     * fully-anchored regex '/^v\d+$/i', 'v2extra' is not a version prefix and is counted.
+     *
+     * @return void
+     */
+    public function testVersionPrefixWithSuffixIsCountedAsLiteral(): void
+    {
+        // Arrange — 'v2extra' starts with a version-like token but is not a pure version;
+        // four literals including 'v2extra' must all be counted to trigger R11
+        $uri   = 'users/posts/comments/v2extra';
+        $route = new NormalisedRoute(
+            uri: $uri,
+            methods: ['GET'],
+            name: null,
+            segments: ['users', 'posts', 'comments', 'v2extra'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — depth = 4 > 3; 'v2extra' must not be excluded
+        static::assertCount(1, $violations);
+        static::assertSame($uri, $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that an uppercase version token (e.g. 'V2') is excluded from the depth count.
+     *
+     * Kills PregMatchRemoveFlags mutant (#50): without the 'i' flag, the regex
+     * '/^v\d+$/' would not match 'V2', causing it to be counted as a literal segment.
+     * With the case-insensitive flag, 'V2' is a valid version prefix and is excluded.
+     *
+     * @return void
+     */
+    public function testUppercaseVersionTokenIsExcludedFromDepth(): void
+    {
+        // Arrange — three literal resource segments plus uppercase 'V2' prefix;
+        // 'V2' must be excluded so depth = 3, which is exactly the threshold (no violation)
+        $route = new NormalisedRoute(
+            uri: 'V2/users/posts/comments',
+            methods: ['GET'],
+            name: null,
+            segments: ['V2', 'users', 'posts', 'comments'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — 'V2' excluded; depth = 3; must not produce a violation
+        static::assertEmpty($violations);
+    }
+
+    /**
      * Test that rule id() returns 'R11' and severity() returns Severity::WARNING.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/NestingDepthRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/NestingDepthRuleTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\NestingDepthRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the NestingDepthRule (R11) warning rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(NestingDepthRule::class)]
+class NestingDepthRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\NestingDepthRule */
+    private NestingDepthRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new NestingDepthRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a four-collection-level route produces one R11 warning violation.
+     *
+     * users/{user}/posts/{post}/comments/{comment}/likes/{like} has four literal
+     * resource segments: users, posts, comments, likes.
+     *
+     * @return void
+     */
+    public function testFourLevelRouteIsFlagged(): void
+    {
+        // Arrange
+        $uri   = 'users/{user}/posts/{post}/comments/{comment}/likes/{like}';
+        $route = new NormalisedRoute(
+            uri: $uri,
+            methods: ['GET'],
+            name: 'users.posts.comments.likes.index',
+            segments: ['users', '{user}', 'posts', '{post}', 'comments', '{comment}', 'likes', '{like}'],
+            parameters: ['user', 'post', 'comment', 'like'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R11', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame($uri, $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a three-collection-level route produces no R11 violation.
+     *
+     * users/{user}/posts/{post}/comments/{comment} has three literal resource
+     * segments: users, posts, comments — exactly at the threshold, so no warning.
+     *
+     * @return void
+     */
+    public function testThreeLevelRouteIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users/{user}/posts/{post}/comments/{comment}',
+            methods: ['GET'],
+            name: 'users.posts.comments.index',
+            segments: ['users', '{user}', 'posts', '{post}', 'comments', '{comment}'],
+            parameters: ['user', 'post', 'comment'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that 'api' and version prefix segments are excluded from the depth count.
+     *
+     * api/v1/users/{user}/posts/{post}/comments/{comment}/likes/{like} has four
+     * resource literals after excluding 'api' and 'v1', so it is flagged.
+     * Conversely api/v1/users/{user}/posts/{post}/comments/{comment} has three
+     * and must not be flagged.
+     *
+     * @return void
+     */
+    public function testApiVersionPrefixExcludedFromDepth(): void
+    {
+        // Arrange — four resource levels with api/v1 prefix (flagged)
+        $fourLevelUri   = 'api/v1/users/{user}/posts/{post}/comments/{comment}/likes/{like}';
+        $fourLevelRoute = new NormalisedRoute(
+            uri: $fourLevelUri,
+            methods: ['GET'],
+            name: null,
+            segments: ['api', 'v1', 'users', '{user}', 'posts', '{post}', 'comments', '{comment}', 'likes', '{like}'],
+            parameters: ['user', 'post', 'comment', 'like'],
+        );
+
+        // Arrange — three resource levels with api/v1 prefix (clean)
+        $threeLevelRoute = new NormalisedRoute(
+            uri: 'api/v1/users/{user}/posts/{post}/comments/{comment}',
+            methods: ['GET'],
+            name: null,
+            segments: ['api', 'v1', 'users', '{user}', 'posts', '{post}', 'comments', '{comment}'],
+            parameters: ['user', 'post', 'comment'],
+        );
+
+        // Act
+        $flaggedViolations = $this->rule->inspect($fourLevelRoute, $this->config);
+        $cleanViolations   = $this->rule->inspect($threeLevelRoute, $this->config);
+
+        // Assert — four levels after prefix exclusion triggers warning
+        static::assertCount(1, $flaggedViolations);
+        static::assertSame($fourLevelUri, $flaggedViolations[0]->offendingSurface);
+
+        // Assert — three levels after prefix exclusion is clean
+        static::assertEmpty($cleanViolations);
+    }
+
+    /**
+     * Test that rule id() returns 'R11' and severity() returns Severity::WARNING.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R11', $this->rule->id());
+        static::assertSame(Severity::WARNING, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/PluralCollectionsRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/PluralCollectionsRuleTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\PluralCollectionsRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the PluralCollectionsRule (R4) error rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(PluralCollectionsRule::class)]
+class PluralCollectionsRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\PluralCollectionsRule */
+    private PluralCollectionsRule $rule;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule = new PluralCollectionsRule($this->makeInflector());
+    }
+
+    /**
+     * Test that a singular collection segment preceding a parameter is flagged.
+     *
+     * @return void
+     */
+    public function testSingularCollectionIsFlagged(): void
+    {
+        // Arrange — `user` precedes `{user}` so it is a collection segment
+        $route = new NormalisedRoute(
+            uri: 'user/{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['user', '{user}'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R4', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('user', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a plural collection segment preceding a parameter is not flagged.
+     *
+     * @return void
+     */
+    public function testPluralCollectionIsNotFlagged(): void
+    {
+        // Arrange — `users` is already plural
+        $route = new NormalisedRoute(
+            uri: 'users/{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '{user}'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a configured uncountable segment is never flagged even when singular.
+     *
+     * @return void
+     */
+    public function testUncountableSegmentIsNotFlagged(): void
+    {
+        // Arrange — `media` is in the uncountables list; the fake inflector
+        // would return false for isPlural('media'), but uncountable bypass fires first
+        $route = new NormalisedRoute(
+            uri: 'media/{item}',
+            methods: ['GET'],
+            name: null,
+            segments: ['media', '{item}'],
+            parameters: ['item'],
+        );
+
+        $config = new RuleConfig([], [], [], ['media']);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a standalone top-level singular segment (no following param) is flagged.
+     *
+     * @return void
+     */
+    public function testTopLevelSingularCollectionIsFlagged(): void
+    {
+        // Arrange — `user` is the final literal segment with no following param
+        $route = new NormalisedRoute(
+            uri: 'user',
+            methods: ['GET'],
+            name: null,
+            segments: ['user'],
+            parameters: [],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('user', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a standalone top-level plural segment produces no violation.
+     *
+     * @return void
+     */
+    public function testTopLevelPluralCollectionIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that route parameter segments are never evaluated as collection segments.
+     *
+     * @return void
+     */
+    public function testParameterSegmentsAreIgnored(): void
+    {
+        // Arrange — a lone parameter with no preceding literal
+        $route = new NormalisedRoute(
+            uri: '{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['{user}'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that rule id() returns 'R4' and severity() returns Severity::ERROR.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R4', $this->rule->id());
+        static::assertSame(Severity::ERROR, $this->rule->severity());
+    }
+
+    /**
+     * Build a fake Inflector that treats words ending in 's' as plural and
+     * everything else as singular. This is sufficient for fixture segments.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector
+     */
+    private function makeInflector(): Inflector
+    {
+        return new class implements Inflector {
+            /**
+             * Return the singular form of a value.
+             *
+             * @param  string  $value
+             * @return string
+             */
+            public function singular(string $value): string
+            {
+                return rtrim($value, 's');
+            }
+
+            /**
+             * Determine whether the value is plural.
+             *
+             * @param  string  $value
+             * @return bool
+             */
+            public function isPlural(string $value): bool
+            {
+                return str_ends_with($value, 's');
+            }
+        };
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/PluralCollectionsRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/PluralCollectionsRuleTest.php
@@ -193,6 +193,283 @@ class PluralCollectionsRuleTest extends TestCase
     }
 
     /**
+     * Test that an empty segment before a singular collection is skipped (not
+     * breaking the loop) so the singular collection still produces a violation.
+     *
+     * @return void
+     */
+    public function testEmptySegmentBeforeCollectionDoesNotBreakLoop(): void
+    {
+        // Arrange — leading empty string from a double-slash URI; `user` must still be detected
+        $route = new NormalisedRoute(
+            uri: '/user/{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['', 'user', '{user}'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — empty segment at index 0 must be skipped, not break the loop
+        static::assertCount(1, $violations);
+        static::assertSame('user', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that an uncountable collection segment before a singular one does
+     * not break the loop — the singular segment after must still be flagged.
+     *
+     * @return void
+     */
+    public function testUncountableCollectionBeforeSingularCollectionDoesNotBreakLoop(): void
+    {
+        // Arrange — `media` is uncountable (at index 0, followed by `{item}` so it IS a collection),
+        // `user` is the final literal segment after `{item}` and is singular
+        $route = new NormalisedRoute(
+            uri: 'media/{item}/user',
+            methods: ['GET'],
+            name: null,
+            segments: ['media', '{item}', 'user'],
+            parameters: ['item'],
+        );
+
+        $config = new RuleConfig([], [], [], ['media']);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — `media` is skipped via uncountable bypass (not broken out of loop),
+        // `user` is the remaining singular collection and must be flagged
+        static::assertCount(1, $violations);
+        static::assertSame('user', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a plural collection segment before a singular one does not
+     * break the loop — the singular segment after must still be flagged.
+     *
+     * @return void
+     */
+    public function testPluralCollectionBeforeSingularCollectionDoesNotBreakLoop(): void
+    {
+        // Arrange — `users` is plural (skipped), `comment` is a singular final literal
+        $route = new NormalisedRoute(
+            uri: 'users/{user}/comment',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '{user}', 'comment'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — `users` plural short-circuit must continue, not break; `comment` is flagged
+        static::assertCount(1, $violations);
+        static::assertSame('comment', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that multiple singular collection segments each produce a violation
+     * so the full array is returned (not truncated to the first entry).
+     *
+     * @return void
+     */
+    public function testMultipleSingularCollectionsEachProduceViolation(): void
+    {
+        // Arrange — `user` precedes `{user}`, `comment` precedes `{comment}`; both are singular
+        $route = new NormalisedRoute(
+            uri: 'user/{user}/comment/{comment}',
+            methods: ['GET'],
+            name: null,
+            segments: ['user', '{user}', 'comment', '{comment}'],
+            parameters: ['user', 'comment'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — both collections must be reported; verifies the full array is returned
+        static::assertCount(2, $violations);
+
+        $surfaces = array_map(fn ($v) => $v->offendingSurface, $violations);
+
+        static::assertContains('user', $surfaces);
+        static::assertContains('comment', $surfaces);
+    }
+
+    /**
+     * Test that a non-collection literal segment followed by another literal
+     * segment is not misidentified as a collection when using index arithmetic.
+     *
+     * Targets the isCollectionSegment() index + 1 calculation: with +0 the
+     * segment at 'user' in ['user', '{user}', 'comment'] would lose its
+     * collection status because it would look at itself instead of '{user}'.
+     *
+     * @return void
+     */
+    public function testCollectionDetectionUsesNextSegmentIndex(): void
+    {
+        // Arrange — `user` is a collection (next is `{user}`); `comment` is the final literal
+        $route = new NormalisedRoute(
+            uri: 'user/{user}/comment',
+            methods: ['GET'],
+            name: null,
+            segments: ['user', '{user}', 'comment'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — both `user` (next is param) and `comment` (final literal) must be violations
+        static::assertCount(2, $violations);
+
+        $surfaces = array_map(fn ($v) => $v->offendingSurface, $violations);
+
+        static::assertContains('user', $surfaces);
+        static::assertContains('comment', $surfaces);
+    }
+
+    /**
+     * Test that a non-terminal literal segment that has another literal after it
+     * is NOT treated as a collection — targeting the for-loop range check.
+     *
+     * @return void
+     */
+    public function testNonTerminalLiteralWithLiteralAfterIsNotCollection(): void
+    {
+        // Arrange — `user` has `page` as the next segment (literal, not param),
+        // then `{user}` follows; `user` must NOT be detected as a collection
+        $route = new NormalisedRoute(
+            uri: 'user/page/{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['user', 'page', '{user}'],
+            parameters: ['user'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — only `page` (immediately before `{user}`) is a collection and is flagged;
+        // `user` must not be flagged (it has a literal between itself and the parameter)
+        static::assertCount(1, $violations);
+        static::assertSame('page', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a literal segment preceded by a route parameter is not
+     * misidentified as a collection via backward index arithmetic.
+     *
+     * Specifically: with index - 1 instead of index + 1 as the "next" lookup,
+     * a segment at index 1 preceded by a route parameter at index 0 would
+     * incorrectly be flagged as a collection.
+     *
+     * @return void
+     */
+    public function testSegmentPrecededByParameterIsNotCollection(): void
+    {
+        // Arrange — `{id}` at index 0, `user` at index 1, `extra` at index 2
+        // `user` has a literal after it so it must NOT be a collection
+        $route = new NormalisedRoute(
+            uri: '{id}/user/extra',
+            methods: ['GET'],
+            name: null,
+            segments: ['{id}', 'user', 'extra'],
+            parameters: ['id'],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — neither `user` nor `extra` is a collection (both have literals following them
+        // or `extra` is the last literal after `user`, meaning `extra` IS the last literal,
+        // `user` is NOT since `extra` follows it)
+        // Actually `extra` is the final literal → IS a collection, singular → violation
+        // `user` has `extra` (literal) after → NOT a collection
+        static::assertCount(1, $violations);
+        static::assertSame('extra', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a literal segment followed only by another literal (not a
+     * parameter) does not become a collection via short-circuit on `!== null`.
+     *
+     * @return void
+     */
+    public function testLiteralFollowedByLiteralIsNotCollection(): void
+    {
+        // Arrange — `user` at index 0, `users` at index 1; neither is followed by a param
+        // `user` (index 0) has `users` (literal) after it → for-loop finds literal → NOT collection
+        // `users` (index 1) is the final literal → IS a collection but is plural → no violation
+        $route = new NormalisedRoute(
+            uri: 'user/users',
+            methods: ['GET'],
+            name: null,
+            segments: ['user', 'users'],
+            parameters: [],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — `user` must not be misidentified as a collection just because next is !== null
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a singular final-literal segment followed only by an empty segment
+     * (trailing slash) is still flagged.
+     *
+     * Kills the `&&` → `||` mutant in the final-literal-segment loop: under the
+     * mutant the loop returns early when the trailing empty segment satisfies the
+     * OR branch, so no violation is emitted. Under correct code both conditions
+     * (`=== ''` and `str_starts_with('{')`) must hold for the loop to continue,
+     * and the singular `comment` is correctly flagged.
+     *
+     * @return void
+     */
+    public function testSingularFinalLiteralBeforeTrailingSlashIsFlagged(): void
+    {
+        // Arrange — URI `comment/` produces segments ['comment', '']; the fake
+        // inflector treats `comment` as singular (does not end with 's')
+        $route = new NormalisedRoute(
+            uri: 'comment/',
+            methods: ['GET'],
+            name: null,
+            segments: ['comment', ''],
+            parameters: [],
+        );
+
+        $config = new RuleConfig([], [], [], []);
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — exactly one R4 violation for the singular segment 'comment'
+        static::assertCount(1, $violations);
+        static::assertSame('R4', $violations[0]->ruleId);
+        static::assertSame('comment', $violations[0]->offendingSurface);
+    }
+
+    /**
      * Test that rule id() returns 'R4' and severity() returns Severity::ERROR.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/RouteNameRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/RouteNameRuleTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\RouteNameRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the RouteNameRule (R8) warning rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouteNameRule::class)]
+class RouteNameRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\RouteNameRule */
+    private RouteNameRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new RouteNameRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a named route not matching {resource}.{action} produces one R8 warning violation.
+     *
+     * @return void
+     */
+    public function testNonConventionalNameIsFlagged(): void
+    {
+        // Arrange — 'getAll' is not in the allowed actions set
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: 'users.getAll',
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R8', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('users.getAll', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a route named with a conventional {resource}.{action} produces no R8 violation.
+     *
+     * @return void
+     */
+    public function testConventionalNameIsNotFlagged(): void
+    {
+        // Arrange — 'index' is an allowed action
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: 'users.index',
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that an unnamed route produces no R8 violation.
+     *
+     * @return void
+     */
+    public function testUnnamedRouteIsSkipped(): void
+    {
+        // Arrange — name is null; rule must skip without flagging
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a nested resource name with a valid action produces no R8 violation.
+     *
+     * @return void
+     */
+    public function testNestedResourceNameIsNotFlagged(): void
+    {
+        // Arrange — 'users.posts.show': resource='users.posts', action='show'
+        $route = new NormalisedRoute(
+            uri: 'users/{user}/posts/{post}',
+            methods: ['GET'],
+            name: 'users.posts.show',
+            segments: ['users', '{user}', 'posts', '{post}'],
+            parameters: ['user', 'post'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that a name with no dot separator is flagged as a violation.
+     *
+     * @return void
+     */
+    public function testNameWithoutDotIsFlagged(): void
+    {
+        // Arrange — 'login' has no dot; no resource.action structure
+        $route = new NormalisedRoute(
+            uri: 'login',
+            methods: ['GET'],
+            name: 'login',
+            segments: ['login'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R8', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('login', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that rule id() returns 'R8' and severity() returns Severity::WARNING.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R8', $this->rule->id());
+        static::assertSame(Severity::WARNING, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/RouteNameRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/RouteNameRuleTest.php
@@ -162,6 +162,92 @@ class RouteNameRuleTest extends TestCase
     }
 
     /**
+     * Test that a name whose only dot is at position zero (empty resource part) is flagged.
+     *
+     * A name such as '.index' has $lastDot === 0, making the resource part empty; the rule
+     * must flag it. This pins the $lastDot === 0 boundary and the consequent return false.
+     *
+     * @return void
+     */
+    public function testNameWithLeadingDotIsFlagged(): void
+    {
+        // Arrange — '.index' has the dot at position 0; resource would be empty
+        $route = new NormalisedRoute(
+            uri: 'index',
+            methods: ['GET'],
+            name: '.index',
+            segments: ['index'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — the name must be flagged: offendingSurface is the full name
+        static::assertCount(1, $violations);
+        static::assertSame('R8', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('.index', $violations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that every canonical REST action is accepted without an R8 violation.
+     *
+     * Pins each element of the ALLOWED_ACTIONS set so that mutations swapping or
+     * extending the set are caught by at least one assertion.
+     *
+     * @return void
+     */
+    public function testAllAllowedActionsAreAccepted(): void
+    {
+        // Arrange — the seven canonical actions
+        $allowedActions = ['index', 'show', 'store', 'update', 'destroy', 'create', 'edit'];
+
+        foreach ($allowedActions as $action) {
+            $route = new NormalisedRoute(
+                uri: 'resources',
+                methods: ['GET'],
+                name: 'resources.' . $action,
+                segments: ['resources'],
+                parameters: [],
+            );
+
+            $violations = $this->rule->inspect($route, $this->config);
+
+            static::assertEmpty($violations, "Action '{$action}' should be accepted but produced a violation.");
+        }
+    }
+
+    /**
+     * Test that a disallowed action produces an R8 violation with the full name as the offending surface.
+     *
+     * Pins the in_array(action, ALLOWED_ACTIONS) check. Using a single-segment resource
+     * ('a') ensures the resource part is non-empty after any plausible substr variant.
+     *
+     * @return void
+     */
+    public function testDisallowedActionOnShortResourceIsFlagged(): void
+    {
+        // Arrange — 'a.list': resource='a' (one char), action='list' (not allowed)
+        $route = new NormalisedRoute(
+            uri: 'a',
+            methods: ['GET'],
+            name: 'a.list',
+            segments: ['a'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R8', $violations[0]->ruleId);
+        static::assertSame(Severity::WARNING, $violations[0]->severity);
+        static::assertSame('a.list', $violations[0]->offendingSurface);
+    }
+
+    /**
      * Test that rule id() returns 'R8' and severity() returns Severity::WARNING.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/SlashSanityRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/SlashSanityRuleTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\SlashSanityRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the SlashSanityRule (R5) error rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(SlashSanityRule::class)]
+class SlashSanityRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\SlashSanityRule */
+    private SlashSanityRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new SlashSanityRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a URI with a trailing slash produces one R5 error violation.
+     *
+     * @return void
+     */
+    public function testTrailingSlashIsFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users/',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', ''],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R5', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('users/', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a URI with a duplicate slash produces one R5 error violation.
+     *
+     * @return void
+     */
+    public function testDuplicateSlashIsFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users//posts',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '', 'posts'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R5', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('users//posts', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a URI with both a duplicate and a trailing slash emits only one violation.
+     *
+     * @return void
+     */
+    public function testBothDefectsEmitOneViolation(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users//posts/',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '', 'posts', ''],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — one violation regardless of defect count
+        static::assertCount(1, $violations);
+    }
+
+    /**
+     * Test that a clean URI produces no R5 violation.
+     *
+     * @return void
+     */
+    public function testCleanUriIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: 'users/{user}',
+            methods: ['GET'],
+            name: null,
+            segments: ['users', '{user}'],
+            parameters: ['user'],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that the root path produces no R5 violation.
+     *
+     * @return void
+     */
+    public function testRootPathIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: '/',
+            methods: ['GET'],
+            name: null,
+            segments: ['', ''],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that an empty URI produces no R5 violation.
+     *
+     * @return void
+     */
+    public function testEmptyUriIsNotFlagged(): void
+    {
+        // Arrange
+        $route = new NormalisedRoute(
+            uri: '',
+            methods: ['GET'],
+            name: null,
+            segments: [],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that rule id() returns 'R5' and severity() returns Severity::ERROR.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R5', $this->rule->id());
+        static::assertSame(Severity::ERROR, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/StandardMethodsRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/StandardMethodsRuleTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\StandardMethodsRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use Tests\TestCase;
+
+/**
+ * Tests for the StandardMethodsRule (R7) error rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(StandardMethodsRule::class)]
+class StandardMethodsRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\StandardMethodsRule */
+    private StandardMethodsRule $rule;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig */
+    private RuleConfig $config;
+
+    /**
+     * Set up shared fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule   = new StandardMethodsRule;
+        $this->config = new RuleConfig([], [], [], []);
+    }
+
+    /**
+     * Test that a route whose methods include a non-standard verb produces one R7 error violation.
+     *
+     * @return void
+     */
+    public function testNonStandardMethodIsFlagged(): void
+    {
+        // Arrange — PURGE is not in the standard set
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['PURGE'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame('R7', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('PURGE', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a route with only standard methods produces no R7 violation.
+     *
+     * @return void
+     */
+    public function testStandardMethodsAreNotFlagged(): void
+    {
+        // Arrange — GET and HEAD are both in the standard set
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET', 'HEAD'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert
+        static::assertEmpty($violations);
+    }
+
+    /**
+     * Test that rule id() returns 'R7' and severity() returns Severity::ERROR.
+     *
+     * @return void
+     */
+    public function testRuleMetadata(): void
+    {
+        static::assertSame('R7', $this->rule->id());
+        static::assertSame(Severity::ERROR, $this->rule->severity());
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/StandardMethodsRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/StandardMethodsRuleTest.php
@@ -90,6 +90,68 @@ class StandardMethodsRuleTest extends TestCase
     }
 
     /**
+     * Test that multiple non-standard methods produce a single R7 violation whose offending
+     * surface is the methods sorted alphabetically and joined by ', '.
+     *
+     * Kills the FunctionCallRemoval mutant (#72) that removes the sort() call: without
+     * sorting the non-standard methods are joined in input order, so the offendingSurface
+     * would be 'ZZZ, AAA' instead of the expected 'AAA, ZZZ'.
+     *
+     * @return void
+     */
+    public function testMultipleNonStandardMethodsAreSortedInOffendingSurface(): void
+    {
+        // Arrange — ZZZ and AAA are both non-standard; input order is ZZZ first
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['ZZZ', 'GET', 'AAA'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — one violation; non-standard methods must appear sorted
+        static::assertCount(1, $violations);
+        static::assertSame('R7', $violations[0]->ruleId);
+        static::assertSame(Severity::ERROR, $violations[0]->severity);
+        static::assertSame('AAA, ZZZ', $violations[0]->offendingSurface);
+        static::assertNull($violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a route with a non-standard method mixed in with standard ones is flagged,
+     * and that only the non-standard method appears in the offending surface.
+     *
+     * Kills the UnwrapArrayValues mutant (#71) by asserting the exact offendingSurface
+     * string — if array_values were removed the key ordering could differ under sort(),
+     * but since sort() re-indexes anyway the observable difference is confirmed absent,
+     * making this an equivalent mutant (see note below).
+     *
+     * @return void
+     */
+    public function testOnlyNonStandardMethodAppearsInOffendingSurface(): void
+    {
+        // Arrange — only FOO is non-standard; GET is standard and must be excluded
+        $route = new NormalisedRoute(
+            uri: 'users',
+            methods: ['GET', 'FOO'],
+            name: null,
+            segments: ['users'],
+            parameters: [],
+        );
+
+        // Act
+        $violations = $this->rule->inspect($route, $this->config);
+
+        // Assert — exactly one non-standard method; offendingSurface is 'FOO' alone
+        static::assertCount(1, $violations);
+        static::assertSame('FOO', $violations[0]->offendingSurface);
+    }
+
+    /**
      * Test that rule id() returns 'R7' and severity() returns Severity::ERROR.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Rules/Support/SegmentNormaliserTest.php
+++ b/tests/Unit/RouteLinting/Rules/Support/SegmentNormaliserTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules\Support;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser;
+use Tests\TestCase;
+
+/**
+ * Tests for the SegmentNormaliser 6-step pipeline.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(SegmentNormaliser::class)]
+class SegmentNormaliserTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector */
+    private Inflector $inflector;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser */
+    private SegmentNormaliser $normaliser;
+
+    /**
+     * Set up a stub inflector and normaliser before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Stub inflector: singularises by stripping a trailing 's', otherwise returns the word as-is
+        $this->inflector = new class implements Inflector {
+            /**
+             * @param  string  $value
+             * @return string
+             */
+            public function singular(string $value): string
+            {
+                return str_ends_with($value, 's') ? substr($value, 0, -1) : $value;
+            }
+
+            /**
+             * @param  string  $value
+             * @return bool
+             */
+            public function isPlural(string $value): bool
+            {
+                return str_ends_with($value, 's');
+            }
+        };
+
+        $this->normaliser = new SegmentNormaliser($this->inflector);
+    }
+
+    /**
+     * Test that api prefix, version segments, and route parameters are all dropped
+     * so only meaningful resource words survive.
+     *
+     * @return void
+     */
+    public function testDropsParametersAndVersionAndApiPrefix(): void
+    {
+        // Arrange
+        $uri = 'api/v1/{user}/getUsers';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — 'api', 'v1', '{user}' are dropped; 'getUsers' decomposes to 'get' + 'users' -> 'get' + 'user'
+        static::assertSame(['get', 'user'], $words);
+    }
+
+    /**
+     * Test that compound segments decompose correctly across camelCase, kebab, and snake boundaries.
+     *
+     * @return void
+     */
+    public function testDecomposesCompoundCamelKebabSnake(): void
+    {
+        // Arrange — three separate URIs each with a different delimiter style
+        $camel = 'getUsers';
+        $kebab = 'user-profiles';
+        $snake = 'get_users';
+
+        // Act
+        $camelWords = $this->normaliser->normalise($camel, []);
+        $kebabWords = $this->normaliser->normalise($kebab, []);
+        $snakeWords = $this->normaliser->normalise($snake, []);
+
+        // Assert — each decomposes into its constituent words (singularised by the stub)
+        static::assertSame(['get', 'user'], $camelWords);
+        static::assertSame(['user', 'profile'], $kebabWords);
+        static::assertSame(['get', 'user'], $snakeWords);
+    }
+
+    /**
+     * Test that words are lowercased and singularised via the injected inflector.
+     *
+     * @return void
+     */
+    public function testLowercasesAndSingularises(): void
+    {
+        // Arrange
+        $uri = 'getUsers';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — 'getUsers' -> decomposed ['get', 'Users'] -> lowercased ['get', 'users'] -> singularised ['get', 'user']
+        static::assertSame(['get', 'user'], $words);
+    }
+
+    /**
+     * Test that a URI consisting only of parameters, version, and api segments yields an empty result.
+     *
+     * @return void
+     */
+    public function testOnlyParametersYieldsEmpty(): void
+    {
+        // Arrange
+        $uri = 'api/v1/{user}';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert
+        static::assertSame([], $words);
+    }
+
+    /**
+     * Test that an empty URI yields an empty result.
+     *
+     * @return void
+     */
+    public function testEmptyUriYieldsEmpty(): void
+    {
+        // Act
+        $words = $this->normaliser->normalise('', []);
+
+        // Assert
+        static::assertSame([], $words);
+    }
+
+    /**
+     * Test that a segment with mixed delimiters decomposes across all boundaries.
+     *
+     * @return void
+     */
+    public function testMixedDelimitersDecomposeAcrossAllBoundaries(): void
+    {
+        // Arrange — 'get_userProfiles' has both snake and camelCase boundaries
+        $uri = 'get_userProfiles';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — decomposed to 'get', 'user', 'Profiles' -> lowercased -> singularised
+        static::assertSame(['get', 'user', 'profile'], $words);
+    }
+
+    /**
+     * Test that words present in the uncountables list bypass singularisation.
+     *
+     * @return void
+     */
+    public function testUncountableWordsBypassSingularisation(): void
+    {
+        // Arrange — 'media' ends in 's' so the stub would singularise it to 'medi',
+        // but declaring it uncountable must prevent that
+        $uri          = 'medias';
+        $uncountables = ['medias'];
+
+        // Act
+        $words = $this->normaliser->normalise($uri, $uncountables);
+
+        // Assert — 'medias' is returned as-is, not stripped to 'media' by the stub
+        static::assertSame(['medias'], $words);
+    }
+
+    /**
+     * Test that optional route parameters (with trailing ?) are dropped.
+     *
+     * @return void
+     */
+    public function testOptionalRouteParametersAreDropped(): void
+    {
+        // Arrange
+        $uri = 'users/{user?}/posts';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — '{user?}' is a route parameter and must be discarded
+        static::assertSame(['user', 'post'], $words);
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/Support/SegmentNormaliserTest.php
+++ b/tests/Unit/RouteLinting/Rules/Support/SegmentNormaliserTest.php
@@ -198,4 +198,118 @@ class SegmentNormaliserTest extends TestCase
         // Assert — '{user?}' is a route parameter and must be discarded
         static::assertSame(['user', 'post'], $words);
     }
+
+    /**
+     * Test that a segment containing '{' but not ending at '}' is kept as a
+     * literal — step 2 regex requires the segment to end exactly at '}'.
+     *
+     * Targets PregMatchRemoveDollar on the step-2 pattern: without '$' the
+     * mutant would drop '{id}extra' (it starts with '{' and contains '}'),
+     * but the original keeps it because '{}' is not at the end of the string.
+     *
+     * @return void
+     */
+    public function testSegmentWithBraceSuffixIsNotDroppedAsParameter(): void
+    {
+        // Arrange — '{id}extra' starts with '{' and contains '}' but is not a pure
+        // route parameter; step 2 must keep it; `posts` is a normal resource segment
+        $uri = '{id}extra/posts';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — '{id}extra' survives step 2 and passes through as a word;
+        // step 4 treats it as a single segment (no camelCase/kebab/snake boundary),
+        // step 5 lowercases it, step 6 singularises it (no trailing 's' so unchanged);
+        // 'posts' → 'post' via stub singulariser
+        static::assertSame(['{id}extra', 'post'], $words);
+    }
+
+    /**
+     * Test that version-like prefix strings that contain digits but do not
+     * start with 'v' are not dropped — step 3 regex requires the '^' anchor.
+     *
+     * Targets PregMatchRemoveCaret on the step-3 pattern: without '^' the
+     * mutant matches any segment ending in 'v<digits>', dropping 'av2' even
+     * though it is not a version prefix.
+     *
+     * @return void
+     */
+    public function testSegmentContainingVersionPatternMidstringIsKept(): void
+    {
+        // Arrange — 'av2' contains 'v2' but does not start with 'v', so it is
+        // a real resource segment and must survive step 3
+        $uri = 'av2/users';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — 'av2' is kept; 'users' singularises to 'user'
+        static::assertSame(['av2', 'user'], $words);
+    }
+
+    /**
+     * Test that a version segment with trailing literal characters is not dropped
+     * — step 3 regex requires the '$' anchor so only pure version tokens are removed.
+     *
+     * Targets PregMatchRemoveDollar on the step-3 pattern: without '$' the
+     * mutant matches 'v1more' (starts with 'v' followed by digits), dropping it
+     * even though it is not a pure version prefix.
+     *
+     * @return void
+     */
+    public function testSegmentStartingWithVersionPatternButHasSuffixIsKept(): void
+    {
+        // Arrange — 'v1more' starts with 'v1' but has extra text, so it is not a
+        // pure version segment and must survive step 3
+        $uri = 'v1more/users';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — 'v1more' is kept; 'users' singularises to 'user'
+        static::assertSame(['v1more', 'user'], $words);
+    }
+
+    /**
+     * Test that version segments in uppercase are still dropped — step 3 uses
+     * the 'i' flag for case-insensitive matching.
+     *
+     * Targets PregMatchRemoveFlags on the step-3 pattern: without 'i' the mutant
+     * keeps 'V1' because the pattern '/^v\d+$/' does not match an uppercase 'V'.
+     *
+     * @return void
+     */
+    public function testUppercaseVersionSegmentIsDropped(): void
+    {
+        // Arrange — 'V1' is a version prefix in uppercase; must be dropped
+        $uri = 'V1/users';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — 'V1' is dropped; only 'users' → 'user' survives
+        static::assertSame(['user'], $words);
+    }
+
+    /**
+     * Test that the 'api' prefix is dropped case-insensitively — step 3
+     * applies strtolower() before comparing to 'api'.
+     *
+     * Targets UnwrapStrToLower on the step-3 strtolower(): without lowercasing,
+     * 'API' would not equal 'api' and would be kept as a segment.
+     *
+     * @return void
+     */
+    public function testUppercaseApiPrefixIsDropped(): void
+    {
+        // Arrange — 'API' in uppercase must be treated as the API prefix and dropped
+        $uri = 'API/users';
+
+        // Act
+        $words = $this->normaliser->normalise($uri, []);
+
+        // Assert — 'API' is dropped case-insensitively; only 'users' → 'user' survives
+        static::assertSame(['user'], $words);
+    }
 }

--- a/tests/Unit/RouteLinting/Rules/Support/VerbDenylistTest.php
+++ b/tests/Unit/RouteLinting/Rules/Support/VerbDenylistTest.php
@@ -132,4 +132,28 @@ class VerbDenylistTest extends TestCase
         static::assertNull($denylist->hint('fetch'));
         static::assertNull($denylist->hint('unknown'));
     }
+
+    /**
+     * Test that hint() is case-insensitive — the lookup applies strtolower() so
+     * that 'LOGIN' resolves to the same hint as 'login'.
+     *
+     * Targets UnwrapStrToLower on hint(): without lowercasing, 'LOGIN' would not
+     * match the 'login' key in the hints array and would return null instead of
+     * the configured hint string.
+     *
+     * @return void
+     */
+    public function testHintIsCaseInsensitive(): void
+    {
+        // Arrange
+        $denylist = new VerbDenylist(
+            ['login'],
+            ['login' => 'Use POST /sessions instead.'],
+        );
+
+        // Act & Assert — uppercase lookup must resolve the same hint as lowercase
+        static::assertSame('Use POST /sessions instead.', $denylist->hint('LOGIN'));
+        static::assertSame('Use POST /sessions instead.', $denylist->hint('Login'));
+        static::assertSame('Use POST /sessions instead.', $denylist->hint('login'));
+    }
 }

--- a/tests/Unit/RouteLinting/Rules/Support/VerbDenylistTest.php
+++ b/tests/Unit/RouteLinting/Rules/Support/VerbDenylistTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules\Support;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist;
+use Tests\TestCase;
+
+/**
+ * Tests for the VerbDenylist membership oracle.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(VerbDenylist::class)]
+class VerbDenylistTest extends TestCase
+{
+    /**
+     * Test that contains() returns true for a word that is in the denylist.
+     *
+     * @return void
+     */
+    public function testContainsDenylistedVerb(): void
+    {
+        // Arrange
+        $denylist = new VerbDenylist(['get', 'post', 'delete'], []);
+
+        // Act & Assert
+        static::assertTrue($denylist->contains('get'));
+        static::assertTrue($denylist->contains('post'));
+        static::assertTrue($denylist->contains('delete'));
+    }
+
+    /**
+     * Test that contains() returns false for a word not in the denylist.
+     *
+     * @return void
+     */
+    public function testDoesNotContainAbsentVerb(): void
+    {
+        // Arrange
+        $denylist = new VerbDenylist(['get', 'post'], []);
+
+        // Act & Assert
+        static::assertFalse($denylist->contains('users'));
+        static::assertFalse($denylist->contains('transfer'));
+    }
+
+    /**
+     * Test that constructing without a verb makes contains() return false for it
+     * (homograph removal — removing from denylist is the tuning surface).
+     *
+     * @return void
+     */
+    public function testRemovingWordMakesContainsFalse(): void
+    {
+        // Arrange — denylist constructed without 'transfer'
+        $denylist = new VerbDenylist(['get', 'post', 'delete'], []);
+
+        // Act & Assert — 'transfer' was never added, so it must not be present
+        static::assertFalse($denylist->contains('transfer'));
+    }
+
+    /**
+     * Test that contains() is case-insensitive, normalising both sides to lowercase.
+     *
+     * @return void
+     */
+    public function testContainsIsCaseInsensitive(): void
+    {
+        // Arrange
+        $denylist = new VerbDenylist(['GET', 'Post'], []);
+
+        // Act & Assert
+        static::assertTrue($denylist->contains('get'));
+        static::assertTrue($denylist->contains('GET'));
+        static::assertTrue($denylist->contains('post'));
+        static::assertTrue($denylist->contains('POST'));
+    }
+
+    /**
+     * Test that hint() returns the configured remediation hint for a known verb.
+     *
+     * @return void
+     */
+    public function testHintReturnsConfiguredHintOrNull(): void
+    {
+        // Arrange
+        $denylist = new VerbDenylist(
+            ['login', 'logout'],
+            ['login' => 'Use POST /sessions instead.', 'logout' => 'Use DELETE /sessions/{session} instead.'],
+        );
+
+        // Act & Assert — mapped verbs return their hint
+        static::assertSame('Use POST /sessions instead.', $denylist->hint('login'));
+        static::assertSame('Use DELETE /sessions/{session} instead.', $denylist->hint('logout'));
+
+        // A verb in the denylist but absent from hints returns null
+        $denylistWithoutHint = new VerbDenylist(['get'], []);
+        static::assertNull($denylistWithoutHint->hint('get'));
+    }
+
+    /**
+     * Test that an empty denylist means contains() always returns false.
+     *
+     * @return void
+     */
+    public function testEmptyDenylistAlwaysReturnsFalse(): void
+    {
+        // Arrange
+        $denylist = new VerbDenylist([], []);
+
+        // Act & Assert
+        static::assertFalse($denylist->contains('get'));
+        static::assertFalse($denylist->contains('post'));
+        static::assertFalse($denylist->contains(''));
+    }
+
+    /**
+     * Test that hint() returns null for an unmapped verb regardless of denylist membership.
+     *
+     * @return void
+     */
+    public function testHintReturnsNullForUnmappedVerb(): void
+    {
+        // Arrange — verb is in denylist but has no hint entry
+        $denylist = new VerbDenylist(['fetch'], []);
+
+        // Act & Assert
+        static::assertNull($denylist->hint('fetch'));
+        static::assertNull($denylist->hint('unknown'));
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/VerbInPathRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/VerbInPathRuleTest.php
@@ -45,21 +45,21 @@ class VerbInPathRuleTest extends TestCase
         // Stub inflector: strips a trailing 's' to singularise, returns word unchanged otherwise
         $inflector = new class implements Inflector {
             /**
-             * @param  string  $value
+             * @param  string  $word
              * @return string
              */
-            public function singular(string $value): string
+            public function singular(string $word): string
             {
-                return str_ends_with($value, 's') ? substr($value, 0, -1) : $value;
+                return str_ends_with($word, 's') ? substr($word, 0, -1) : $word;
             }
 
             /**
-             * @param  string  $value
+             * @param  string  $word
              * @return bool
              */
-            public function isPlural(string $value): bool
+            public function isPlural(string $word): bool
             {
-                return str_ends_with($value, 's');
+                return str_ends_with($word, 's');
             }
         };
 
@@ -236,7 +236,7 @@ class VerbInPathRuleTest extends TestCase
 
         // Assert
         static::assertCount(1, $violations);
-        static::assertSame($route->identity(), $violations[0]->routeIdentity);
+        static::assertSame('GET login', $violations[0]->routeIdentity);
     }
 
     /**

--- a/tests/Unit/RouteLinting/Rules/VerbInPathRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/VerbInPathRuleTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Contracts\Inflector;
+use SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig;
+use SineMacula\ApiToolkit\RouteLinting\NormalisedRoute;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser;
+use SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist;
+use SineMacula\ApiToolkit\RouteLinting\Rules\VerbInPathRule;
+use SineMacula\ApiToolkit\RouteLinting\Severity;
+use SineMacula\ApiToolkit\RouteLinting\Violation;
+use Tests\TestCase;
+
+/**
+ * Tests for VerbInPathRule (R1).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(VerbInPathRule::class)]
+class VerbInPathRuleTest extends TestCase
+{
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\Support\SegmentNormaliser */
+    private SegmentNormaliser $normaliser;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\Support\VerbDenylist */
+    private VerbDenylist $denylist;
+
+    /** @var \SineMacula\ApiToolkit\RouteLinting\Rules\VerbInPathRule */
+    private VerbInPathRule $rule;
+
+    /**
+     * Set up a stub inflector, normaliser, denylist, and rule before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Stub inflector: strips a trailing 's' to singularise, returns word unchanged otherwise
+        $inflector = new class implements Inflector {
+            /**
+             * @param  string  $value
+             * @return string
+             */
+            public function singular(string $value): string
+            {
+                return str_ends_with($value, 's') ? substr($value, 0, -1) : $value;
+            }
+
+            /**
+             * @param  string  $value
+             * @return bool
+             */
+            public function isPlural(string $value): bool
+            {
+                return str_ends_with($value, 's');
+            }
+        };
+
+        $this->normaliser = new SegmentNormaliser($inflector);
+
+        $this->denylist = new VerbDenylist(
+            ['get', 'create', 'cancel', 'login', 'logout', 'delete', 'fetch'],
+            [
+                'get'    => 'Use GET /resources instead.',
+                'create' => 'Use POST /resources instead.',
+                'cancel' => 'Use DELETE /resources/{id} instead.',
+                'login'  => 'Use POST /auth instead.',
+                'logout' => 'Use DELETE /auth/session instead.',
+                'delete' => 'Use DELETE /resources/{id} instead.',
+                'fetch'  => 'Use GET /resources instead.',
+            ],
+        );
+
+        $this->rule = new VerbInPathRule($this->normaliser, $this->denylist);
+    }
+
+    /**
+     * Test that id() returns 'R1' and severity() returns Severity::ERROR.
+     *
+     * @return void
+     */
+    public function testIdAndSeverity(): void
+    {
+        static::assertSame('R1', $this->rule->id());
+        static::assertSame(Severity::ERROR, $this->rule->severity());
+    }
+
+    /**
+     * Test that /getUsers produces one R1 error violation naming 'get' with a non-null remediation hint.
+     *
+     * @return void
+     */
+    public function testFlagsGetUsersWithRemediationHint(): void
+    {
+        // Arrange
+        $route  = $this->makeRoute('getUsers');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — one violation for the verb 'get'; 'user' is not a verb
+        static::assertCount(1, $violations);
+
+        $violation = $violations[0];
+
+        static::assertInstanceOf(Violation::class, $violation);
+        static::assertSame('R1', $violation->ruleId);
+        static::assertSame(Severity::ERROR, $violation->severity);
+        static::assertSame('get', $violation->offendingSurface);
+        static::assertNotNull($violation->remediationHint);
+    }
+
+    /**
+     * Test that /users/create, /order/{id}/cancel, and /login each produce an R1 violation naming the offending verb.
+     *
+     * @return void
+     */
+    public function testFlagsCreateCancelAndLogin(): void
+    {
+        // Arrange
+        $config = $this->makeConfig();
+
+        // Act & Assert — /users/create
+        $createViolations = $this->rule->inspect($this->makeRoute('users/create'), $config);
+        static::assertCount(1, $createViolations);
+        static::assertSame('create', $createViolations[0]->offendingSurface);
+        static::assertSame('R1', $createViolations[0]->ruleId);
+
+        // Act & Assert — /order/{id}/cancel
+        $cancelViolations = $this->rule->inspect($this->makeRoute('order/{id}/cancel'), $config);
+        static::assertCount(1, $cancelViolations);
+        static::assertSame('cancel', $cancelViolations[0]->offendingSurface);
+
+        // Act & Assert — /login
+        $loginViolations = $this->rule->inspect($this->makeRoute('login'), $config);
+        static::assertCount(1, $loginViolations);
+        static::assertSame('login', $loginViolations[0]->offendingSurface);
+    }
+
+    /**
+     * Test that a clean plural collection /users produces no R1 violation.
+     *
+     * @return void
+     */
+    public function testCleanPluralCollectionNotFlagged(): void
+    {
+        // Arrange — /users normalises to 'user', which is not a verb
+        $route  = $this->makeRoute('users');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertSame([], $violations);
+    }
+
+    /**
+     * Test that the emitted violation's remediationHint is non-null for a denylisted verb with a configured hint.
+     *
+     * @return void
+     */
+    public function testRemediationHintIsPresentForDenylistedVerb(): void
+    {
+        // Arrange
+        $route  = $this->makeRoute('login');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertNotNull($violations[0]->remediationHint);
+        static::assertSame('Use POST /auth instead.', $violations[0]->remediationHint);
+    }
+
+    /**
+     * Test that a route with the same verb appearing in two segments emits a single R1 violation for it.
+     *
+     * @return void
+     */
+    public function testDuplicateVerbEmittedOncePerRoute(): void
+    {
+        // Arrange — 'getItems/getDetails' would normalise 'get' twice
+        $route  = $this->makeRoute('getItems/getDetails');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — 'get' appears in both segments but must be emitted once only
+        $offendingSurfaces = array_map(fn (Violation $v): string => $v->offendingSurface, $violations);
+        static::assertCount(1, array_filter($offendingSurfaces, fn (string $s): bool => $s === 'get'));
+    }
+
+    /**
+     * Test that a route consisting only of parameters normalises to empty and produces no violations.
+     *
+     * @return void
+     */
+    public function testParameterOnlyRouteProducesNoViolations(): void
+    {
+        // Arrange
+        $route  = $this->makeRoute('{user}');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertSame([], $violations);
+    }
+
+    /**
+     * Test that the routeIdentity on the emitted violation matches the route's identity() value.
+     *
+     * @return void
+     */
+    public function testViolationCarriesCorrectRouteIdentity(): void
+    {
+        // Arrange
+        $route  = $this->makeRoute('login');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert
+        static::assertCount(1, $violations);
+        static::assertSame($route->identity(), $violations[0]->routeIdentity);
+    }
+
+    /**
+     * Build a minimal NormalisedRoute for the given URI.
+     *
+     * @param  string  $uri
+     * @return \SineMacula\ApiToolkit\RouteLinting\NormalisedRoute
+     */
+    private function makeRoute(string $uri): NormalisedRoute
+    {
+        return new NormalisedRoute(
+            uri: $uri,
+            methods: ['GET'],
+            name: null,
+            segments: explode('/', $uri),
+            parameters: [],
+        );
+    }
+
+    /**
+     * Build a minimal RuleConfig with empty uncountables.
+     *
+     * @return \SineMacula\ApiToolkit\RouteLinting\Dto\RuleConfig
+     */
+    private function makeConfig(): RuleConfig
+    {
+        return new RuleConfig(
+            verbDenylist: [],
+            remediationHints: [],
+            exemptions: [],
+            uncountables: [],
+        );
+    }
+}

--- a/tests/Unit/RouteLinting/Rules/VerbInPathRuleTest.php
+++ b/tests/Unit/RouteLinting/Rules/VerbInPathRuleTest.php
@@ -203,6 +203,66 @@ class VerbInPathRuleTest extends TestCase
     }
 
     /**
+     * Test that a denylisted verb appearing in two separate segments produces exactly one R1 violation.
+     *
+     * Kills the `$seen[$word] = true` → `false` dedup mutant: under the mutant the
+     * seen-flag is stored as false so the guard `$seen[$word] ?? false` always reads
+     * false, allowing the same verb to be emitted once per segment it appears in.
+     * Asserting `assertCount(1, $violations)` on a route where `get` normalises from
+     * two distinct segments catches the double-emission introduced by the mutant.
+     *
+     * @return void
+     */
+    public function testSameVerbInTwoSegmentsProducesExactlyOneViolation(): void
+    {
+        // Arrange — 'get-users/get-items' decomposes to words [get, user, get, item];
+        // 'get' appears twice but must produce exactly one R1 violation
+        $route  = $this->makeRoute('get-users/get-items');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — total violation count must be exactly 1 (deduplicated)
+        static::assertCount(1, $violations);
+        static::assertSame('get', $violations[0]->offendingSurface);
+        static::assertSame('R1', $violations[0]->ruleId);
+    }
+
+    /**
+     * Test that two distinct denylisted verbs in the same route each produce their own R1 violation.
+     *
+     * Kills the ArrayOneItem mutant (#84): when a route produces two or more violations,
+     * the mutant returns only the first element. Asserting both violations by count and
+     * by their exact offendingSurface values forces the full array to be present.
+     *
+     * @return void
+     */
+    public function testTwoDistinctVerbsProduceTwoViolations(): void
+    {
+        // Arrange — 'getUsers/deleteItems' normalises to words including 'get' and 'delete',
+        // both of which are in the denylist
+        $route  = $this->makeRoute('getUsers/deleteItems');
+        $config = $this->makeConfig();
+
+        // Act
+        $violations = $this->rule->inspect($route, $config);
+
+        // Assert — exactly two violations, one per distinct verb
+        static::assertCount(2, $violations);
+
+        $surfaces = array_map(fn (Violation $v): string => $v->offendingSurface, $violations);
+        static::assertContains('get', $surfaces);
+        static::assertContains('delete', $surfaces);
+
+        // Both must carry R1 ERROR severity
+        foreach ($violations as $violation) {
+            static::assertSame('R1', $violation->ruleId);
+            static::assertSame(Severity::ERROR, $violation->severity);
+        }
+    }
+
+    /**
      * Test that a route consisting only of parameters normalises to empty and produces no violations.
      *
      * @return void

--- a/tests/Unit/RouteLinting/Support/RouteLintMacrosTest.php
+++ b/tests/Unit/RouteLinting/Support/RouteLintMacrosTest.php
@@ -47,6 +47,36 @@ class RouteLintMacrosTest extends TestCase
     }
 
     /**
+     * Test that calling register() a second time when the macro already exists
+     * does NOT re-register a new closure (kills ReturnRemoval mutant #90).
+     *
+     * Without the early return the macro would be re-registered on each call.
+     * We verify idempotency by checking that a second call leaves the route
+     * action produced by the macro intact — the macro still works and was not
+     * double-appended by the re-registration attempt.
+     *
+     * @return void
+     */
+    public function testSecondRegisterCallDoesNotReplaceExistingMacro(): void
+    {
+        // Macro is already registered by the service provider boot.
+        // Register again and confirm the macro still functions correctly.
+        RouteLintMacros::register();
+
+        $router = $this->getRouter();
+        $route  = $router->get('idempotent-test', fn () => []);
+
+        $route->ignoreRouteLint(['R1'], 'Still works after second register.'); // @phpstan-ignore method.notFound
+
+        $action = $route->getAction('api-toolkit::lint-ignore');
+
+        static::assertIsArray($action);
+        static::assertCount(1, $action);
+        static::assertSame(['R1'], $action[0]['rules']);
+        static::assertSame('Still works after second register.', $action[0]['reason']);
+    }
+
+    /**
      * Test that calling ignoreRouteLint() appends an entry to the
      * `api-toolkit::lint-ignore` action key with the correct rules and reason.
      *
@@ -141,6 +171,36 @@ class RouteLintMacrosTest extends TestCase
 
         static::assertIsArray($action);
         static::assertSame([], $action[0]['rules']);
+    }
+
+    /**
+     * Test that the stored rules list is a re-indexed (0-based) array
+     * (kills UnwrapArrayValues mutant #91: `$ruleIds` stored directly vs
+     * `array_values($ruleIds)`).
+     *
+     * If `array_values` is removed, an associative input like `['foo' => 'R1']`
+     * would be stored with string keys. With `array_values` the result is always
+     * a 0-indexed list regardless of input key type.
+     *
+     * @return void
+     */
+    public function testStoredRulesListIsAlwaysReIndexed(): void
+    {
+        $router = $this->getRouter();
+        $route  = $router->get('assets', fn () => []);
+
+        // Pass an array with non-sequential / string keys
+        $route->ignoreRouteLint(['foo' => 'R1', 'bar' => 'R3'], 'Non-sequential keys.'); // @phpstan-ignore method.notFound
+
+        $action = $route->getAction('api-toolkit::lint-ignore');
+
+        static::assertIsArray($action);
+        static::assertCount(1, $action);
+
+        $rules = $action[0]['rules'];
+
+        // Must be a 0-based indexed list, not the original associative array
+        static::assertSame([0 => 'R1', 1 => 'R3'], $rules);
     }
 
     /**

--- a/tests/Unit/RouteLinting/Support/RouteLintMacrosTest.php
+++ b/tests/Unit/RouteLinting/Support/RouteLintMacrosTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit\RouteLinting\Support;
+
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\RouteLinting\Exceptions\StaleWaiverException;
+use SineMacula\ApiToolkit\RouteLinting\Support\RouteLintMacros;
+use Tests\TestCase;
+
+/**
+ * Tests for the RouteLintMacros registrar.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RouteLintMacros::class)]
+class RouteLintMacrosTest extends TestCase
+{
+    /**
+     * Test that the ignoreRouteLint macro is registered after calling register().
+     *
+     * @return void
+     */
+    public function testMacroIsRegisteredAfterRegisterCall(): void
+    {
+        // The ApiServiceProvider already calls RouteLintMacros::register() during
+        // test bootstrap via getPackageProviders(); confirm the macro exists.
+        static::assertTrue(Route::hasMacro('ignoreRouteLint'));
+    }
+
+    /**
+     * Test that calling register() more than once does not cause an error and
+     * leaves the macro functional (idempotent registration guard).
+     *
+     * @return void
+     */
+    public function testRegistrationIsIdempotent(): void
+    {
+        RouteLintMacros::register();
+        RouteLintMacros::register();
+
+        static::assertTrue(Route::hasMacro('ignoreRouteLint'));
+    }
+
+    /**
+     * Test that calling ignoreRouteLint() appends an entry to the
+     * `api-toolkit::lint-ignore` action key with the correct rules and reason.
+     *
+     * @return void
+     */
+    public function testMacroAppendsEntryToActionKey(): void
+    {
+        $router = $this->getRouter();
+        $route  = $router->get('users', fn () => [])->name('users.index');
+
+        $result = $route->ignoreRouteLint(['R9'], 'Legacy naming kept for backward compatibility.'); // @phpstan-ignore method.notFound
+
+        $action = $route->getAction('api-toolkit::lint-ignore');
+
+        static::assertIsArray($action);
+        static::assertCount(1, $action);
+        static::assertSame(['R9'], $action[0]['rules']);
+        static::assertSame('Legacy naming kept for backward compatibility.', $action[0]['reason']);
+
+        // Return value must be the route itself for fluent chaining
+        static::assertSame($route, $result);
+    }
+
+    /**
+     * Test that multiple ignoreRouteLint() calls accumulate independent entries
+     * in the action array rather than overwriting.
+     *
+     * @return void
+     */
+    public function testMultipleCallsAccumulateEntries(): void
+    {
+        $router = $this->getRouter();
+        $route  = $router->get('orders', fn () => []);
+
+        $route->ignoreRouteLint(['R9'], 'First suppression.'); // @phpstan-ignore method.notFound
+        $route->ignoreRouteLint([], 'Second suppression, all rules.'); // @phpstan-ignore method.notFound
+
+        $action = $route->getAction('api-toolkit::lint-ignore');
+
+        static::assertIsArray($action);
+        static::assertCount(2, $action);
+        static::assertSame(['R9'], $action[0]['rules']);
+        static::assertSame('First suppression.', $action[0]['reason']);
+        static::assertSame([], $action[1]['rules']);
+        static::assertSame('Second suppression, all rules.', $action[1]['reason']);
+    }
+
+    /**
+     * Test that an empty reason string throws a StaleWaiverException.
+     *
+     * @return void
+     */
+    public function testEmptyReasonThrowsStaleWaiverException(): void
+    {
+        $router = $this->getRouter();
+        $route  = $router->get('items', fn () => []);
+
+        $this->expectException(StaleWaiverException::class);
+
+        $route->ignoreRouteLint(['R9'], ''); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that a whitespace-only reason string throws a StaleWaiverException.
+     *
+     * @return void
+     */
+    public function testWhitespaceOnlyReasonThrowsStaleWaiverException(): void
+    {
+        $router = $this->getRouter();
+        $route  = $router->get('products', fn () => []);
+
+        $this->expectException(StaleWaiverException::class);
+
+        $route->ignoreRouteLint([], '   '); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that passing an empty rules array stores an empty list, representing
+     * the "suppress all rules" intent.
+     *
+     * @return void
+     */
+    public function testEmptyRulesArrayMeansSuppressAll(): void
+    {
+        $router = $this->getRouter();
+        $route  = $router->get('resources', fn () => []);
+
+        $route->ignoreRouteLint([], 'Suppress all rules for this route.'); // @phpstan-ignore method.notFound
+
+        $action = $route->getAction('api-toolkit::lint-ignore');
+
+        static::assertIsArray($action);
+        static::assertSame([], $action[0]['rules']);
+    }
+
+    /**
+     * Get a fresh router instance for the test.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    private function getRouter(): Router
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Routing\Router */
+        return $this->app->make('router');
+    }
+}


### PR DESCRIPTION
## Summary
Adds `api-toolkit:lint-routes` — a deterministic, opt-in artisan command that lints the live Laravel route table against a fixed catalogue of RESTful URL conventions and exits non-zero on error-severity violations, so CI can gate on it. Mirrors the existing `ValidateSchemasCommand`/`SchemaValidator` engine/command split.

## What's included
- **New `src/RouteLinting/` bounded context** (hexagonal): ports in `Contracts/`, framework-free domain VOs + `LintRoutes` use case, framework adapters in `Sources/` (router), `Configuration/` (config), `Inflection/` (inflector), `Output/` (console reporter).
- **9 convention rules** — error: verb-in-path (R1), kebab-case (R2), lowercase (R3), plural-collections (R4), slash-sanity (R5), standard-methods (R7); warning: route-name (R8), apiResource-alignment (R9), nesting-depth (R11).
- **Verb detection** via a curated, tunable denylist applied after a normalisation pipeline (split → drop params/version segments → decompose compounds → lowercase → singularise), not probabilistic tagging.
- **Three separate config surfaces** under a new `route_linting` section: verb denylist (ships defaults), exemption allowlist (**ships empty**, each waiver requires a written reason), inflector uncountables. Stale (unmatched) waivers are surfaced.

## Wiring (additive — NFR-02)
New config section + command registration + `registerRouteLinter()` bindings. The 3 modified files changed **+146 / −0** — no existing runtime line altered.

## Verification
- `composer test`: **1989 tests / 4346 assertions / 0 failures**
- 12/12 acceptance criteria proven by automated oracles; 22/22 interface contracts conform
- `composer check`: route-linter contribution qlty-clean (PHPStan L8)

## Not in scope (deferred)
R6/R10/R12 rules, the PHPUnit/Pest assertion wrapper (REQ-13), and reusable cross-repo CI packaging.
