### PR TITLE
fix(exceptions): guard getCustomDetail against missing translation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,9 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
+
+### Fixed
+
+- `ApiException::getCustomDetail()` now returns an empty detail instead of leaking the raw
+  translation key when no `detail` translation is registered, matching the existing
+  `getCustomTitle()` guard

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -43,9 +43,15 @@ abstract class ApiException extends \Exception
      */
     public function getCustomDetail(): string
     {
-        $translation = Lang::get($this->getTranslationKey('detail'));
+        $key = $this->getTranslationKey('detail');
 
-        return is_string($translation) ? $translation : '';
+        if (Lang::has($key)) {
+            $translation = Lang::get($key);
+
+            return is_string($translation) ? $translation : '';
+        }
+
+        return '';
     }
 
     /**

--- a/tests/Unit/Exceptions/ApiExceptionHandlerTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionHandlerTest.php
@@ -925,4 +925,22 @@ class ApiExceptionHandlerTest extends TestCase
         static::assertArrayHasKey('method', $result);
         static::assertSame(['method', 'path', 'data'], array_keys($result));
     }
+
+    /**
+     * Define the test environment.
+     *
+     * Loads the package's exception translations so rendered error responses
+     * include a non-empty detail rather than relying on the (now-fixed)
+     * raw-key fallback.
+     *
+     * @param  mixed  $app
+     * @return void
+     */
+    protected function defineEnvironment(mixed $app): void
+    {
+        /** @var \Illuminate\Translation\Translator $translator */
+        $translator = $app['translator'];
+
+        $translator->addNamespace('api-toolkit', __DIR__ . '/../../../resources/lang');
+    }
 }

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Exceptions;
 
+use Illuminate\Support\Facades\Lang;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Enums\ErrorCode;
@@ -254,6 +255,12 @@ class ApiExceptionTest extends TestCase
      */
     public function testSubclassesCanOverrideTheTranslationNamespace(): void
     {
+        // Register a detail translation under a custom namespace so the override
+        // can be proven by resolution. A missing key now yields '' (see
+        // testGetCustomDetailReturnsEmptyStringWhenTranslationMissing) rather
+        // than leaking the raw translation key, so resolution is the oracle.
+        Lang::addLines(['exceptions.10100.detail' => 'Custom namespace detail'], 'en', 'custom-namespace');
+
         $exception = new class extends ApiException {
             public const \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface CODE = ErrorCode::BAD_REQUEST;
             public const HttpStatus HTTP_STATUS                                   = HttpStatus::BAD_REQUEST;
@@ -270,9 +277,37 @@ class ApiExceptionTest extends TestCase
             }
         };
 
-        // No translations are registered for the custom namespace, so the
-        // raw translation key is returned, proving the override was used
-        static::assertSame('custom-namespace::exceptions.10100.detail', $exception->getCustomDetail());
+        // The translation registered under the custom namespace resolves,
+        // proving the override changed the translation key.
+        static::assertSame('Custom namespace detail', $exception->getCustomDetail());
+    }
+
+    /**
+     * Test that getCustomDetail returns an empty string when the detail
+     * translation key is missing from every locale, rather than leaking the
+     * raw translation key.
+     *
+     * @return void
+     */
+    public function testGetCustomDetailReturnsEmptyStringWhenTranslationMissing(): void
+    {
+        $exception = new class extends ApiException {
+            public const \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface CODE = ErrorCode::BAD_REQUEST;
+            public const HttpStatus HTTP_STATUS                                   = HttpStatus::BAD_REQUEST;
+
+            /**
+             * Resolve from a namespace with no registered translations.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function getNamespace(): string
+            {
+                return 'missing-namespace';
+            }
+        };
+
+        static::assertSame('', $exception->getCustomDetail());
     }
 
     /**
@@ -314,5 +349,22 @@ class ApiExceptionTest extends TestCase
         };
 
         static::assertSame('Unavailable For Legal Reasons', $exception->getCustomTitle());
+    }
+
+    /**
+     * Define the test environment.
+     *
+     * Loads the package's exception translations so getCustomDetail resolves
+     * real translations rather than the (now-fixed) raw-key fallback.
+     *
+     * @param  mixed  $app
+     * @return void
+     */
+    protected function defineEnvironment(mixed $app): void
+    {
+        /** @var \Illuminate\Translation\Translator $translator */
+        $translator = $app['translator'];
+
+        $translator->addNamespace('api-toolkit', __DIR__ . '/../../../resources/lang');
     }
 }


### PR DESCRIPTION
## Summary

Fixes **BL-10**. `ApiException::getCustomDetail()` called `Lang::get()` without the `Lang::has()` guard that `getCustomTitle()` already uses. When no `detail` translation is registered for an error code (absent from every locale, including the `en` fallback), Laravel's translator returns the key verbatim — so the raw internal key (e.g. `api-toolkit::exceptions.10113.detail`) was set as the exception message and served to API consumers as the error `detail`.

## Change

- `getCustomDetail()` now mirrors `getCustomTitle()`: resolve only when `Lang::has($key)` is true, otherwise return `''`. The exception handler already omits an empty `detail` from the error envelope, so missing translations now produce a clean response instead of a leaked key.

## Tests

- `ApiExceptionTest` / `ApiExceptionHandlerTest` now load the package's `api-toolkit` translations via `defineEnvironment`, so they exercise real resolution rather than the (now-fixed) raw-key fallback that previously satisfied their non-empty assertions.
- `testSubclassesCanOverrideTheTranslationNamespace` rewritten to prove the override by *resolving* a translation registered under a custom namespace (the old assertion encoded the bug).
- New `testGetCustomDetailReturnsEmptyStringWhenTranslationMissing` asserts a missing key yields `''`.
- Full suite green: **1870 tests, 4037 assertions, 0 failures**. `qlty check` clean on all changed files.

## Notes

No `docs/` files touched.