### PR TITLE
fix(repositories): include read verb and arguments in per-query cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,10 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
+
+### Fixed
+
+- The transparent repository cache now folds the read verb, its arguments, and the registered
+  eager loads into the per-query cache key, so reads that share a base builder but differ only at
+  execution time - `find(1)` vs `find(2)`, `value()` vs `get()`, column projections, and
+  `with(...)`-eager-loaded vs plain reads - no longer collide on a single cache entry

--- a/src/Repositories/Concerns/Cacheable.php
+++ b/src/Repositories/Concerns/Cacheable.php
@@ -192,7 +192,7 @@ trait Cacheable
     private function resolveCachedRead(string $method, array $arguments): mixed
     {
         $query = $this->prepareQueryBuilder();
-        $hash  = QueryFingerprint::for($query);
+        $hash  = QueryFingerprint::for($query, $method, $arguments);
 
         if ($this->cacheStore->has($hash)) {
             return parent::resetAndReturn($this->cacheStore->get($hash));

--- a/src/Repositories/Concerns/QueryFingerprint.php
+++ b/src/Repositories/Concerns/QueryFingerprint.php
@@ -3,14 +3,21 @@
 namespace SineMacula\ApiToolkit\Repositories\Concerns;
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 /**
  * Derives a stable, collision-resistant fingerprint for a prepared query
- * builder so that distinct queries map to distinct cache keys.
+ * builder and the read verb applied to it, so that distinct reads map to
+ * distinct cache keys.
  *
- * The fingerprint combines the connection name, the compiled SQL, and the
- * normalised bindings, ensuring a filtered or by-id read never collides with
- * a full-table read.
+ * The fingerprint combines the connection name, the compiled SQL, the
+ * normalised bindings, the read verb, its arguments, and the registered eager
+ * loads. Folding the verb and its arguments in is essential: read verbs such as
+ * find(), value(), pluck(), and a column-projected get() apply their
+ * constraints at execution time - after the base builder is compiled - so two
+ * reads sharing one base builder (e.g. find(1) and find(2)) would otherwise
+ * collide on a single cache key. Eager loads are likewise invisible to the
+ * compiled base SQL, so with('posts')->get() would collide with a plain get().
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -18,30 +25,39 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 final class QueryFingerprint
 {
     /**
-     * Build a fingerprint for the given prepared query builder.
+     * Build a fingerprint for the given prepared query builder and read verb.
      *
      * @param  \Illuminate\Contracts\Database\Eloquent\Builder  $query
+     * @param  string  $method
+     * @param  array<int, mixed>  $arguments
      * @return string
      */
-    public static function for(Builder $query): string
+    public static function for(Builder $query, string $method = '', array $arguments = []): string
     {
         $base = $query->getQuery();
 
-        $connection = $base->getConnection()->getDatabaseName();
-        $bindings   = self::normaliseBindings($base->getBindings());
+        $components = [
+            $base->getConnection()->getDatabaseName(),
+            $base->toSql(),
+            self::normalise($base->getBindings()),
+            $method,
+            self::normalise($arguments),
+            self::normaliseEagerLoads($query),
+        ];
 
-        return hash('xxh128', $connection . '|' . $base->toSql() . '|' . $bindings);
+        return hash('xxh128', implode('|', $components));
     }
 
     /**
-     * Normalise the query bindings into a stable string representation.
+     * Normalise a value list into a stable string representation, falling back
+     * to serialisation when the values are not JSON-encodable.
      *
-     * @param  array<int|string, mixed>  $bindings
+     * @param  array<int|string, mixed>  $values
      * @return string
      */
-    private static function normaliseBindings(array $bindings): string
+    private static function normalise(array $values): string
     {
-        $normalised = array_map(fn (mixed $value): mixed => self::normaliseValue($value), $bindings);
+        $normalised = array_map(fn (mixed $value): mixed => self::normaliseValue($value), $values);
 
         $encoded = json_encode($normalised);
 
@@ -49,7 +65,23 @@ final class QueryFingerprint
     }
 
     /**
-     * Normalise a single binding value into a comparable scalar form.
+     * Normalise the registered eager loads into a stable, order-independent
+     * string representation.
+     *
+     * @param  \Illuminate\Contracts\Database\Eloquent\Builder  $query
+     * @return string
+     */
+    private static function normaliseEagerLoads(Builder $query): string
+    {
+        $relations = $query instanceof EloquentBuilder ? array_keys($query->getEagerLoads()) : [];
+
+        sort($relations);
+
+        return implode(',', $relations);
+    }
+
+    /**
+     * Normalise a single value into a comparable scalar form.
      *
      * @param  mixed  $value
      * @return mixed

--- a/tests/Unit/Repositories/Concerns/CacheableTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheableTest.php
@@ -345,6 +345,44 @@ class CacheableTest extends TestCase
     }
 
     /**
+     * Test that find() does not collide across distinct ids. The by-id
+     * constraint is applied at execution time - after the base builder is
+     * fingerprinted - so without folding the verb arguments into the cache key
+     * find(2) would be served the cached find(1) record.
+     *
+     * @return void
+     */
+    public function testFindDoesNotCollideAcrossDistinctIds(): void
+    {
+        $first  = $this->repository->find(1); // @phpstan-ignore staticMethod.dynamicCall
+        $second = $this->repository->find(2); // @phpstan-ignore staticMethod.dynamicCall
+
+        static::assertInstanceOf(Tag::class, $first);
+        static::assertInstanceOf(Tag::class, $second);
+        static::assertSame('php', $first->name);      // @phpstan-ignore property.notFound
+        static::assertSame('laravel', $second->name); // @phpstan-ignore property.notFound
+    }
+
+    /**
+     * Test that a scalar value() read does not collide with a cached get(). The
+     * two reads share an identical base builder, so without folding the verb
+     * into the cache key value('name') would be served the cached get()
+     * collection instead of the scalar column value.
+     *
+     * @return void
+     */
+    public function testScalarValueReadDoesNotCollideWithCachedGet(): void
+    {
+        $this->repository->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+        $cached = $this->repository->value('name');                 // @phpstan-ignore staticMethod.dynamicCall
+        $fresh  = $this->repository->withoutCache()->value('name'); // @phpstan-ignore staticMethod.dynamicCall
+
+        static::assertIsString($cached);     // a scalar column value, never the cached get() collection
+        static::assertSame($fresh, $cached); // and the same value the database returns uncached
+    }
+
+    /**
      * Test that create() returning a Model invalidates the cache.
      *
      * @return void

--- a/tests/Unit/Repositories/Concerns/QueryFingerprintTest.php
+++ b/tests/Unit/Repositories/Concerns/QueryFingerprintTest.php
@@ -113,4 +113,139 @@ class QueryFingerprintTest extends TestCase
 
         static::assertSame($first, $second);
     }
+
+    /**
+     * Test that the read verb is folded into the fingerprint, so two reads on
+     * an identical base builder (e.g. value() vs get()) do not collide.
+     *
+     * @return void
+     */
+    public function testDifferingReadVerbYieldsDistinctFingerprint(): void
+    {
+        $value = QueryFingerprint::for(Tag::query(), 'value', ['name']);
+        $get   = QueryFingerprint::for(Tag::query(), 'get');
+
+        static::assertNotSame($value, $get);
+    }
+
+    /**
+     * Test that the read verb alone discriminates the fingerprint, so two reads
+     * with identical arguments but a different verb (e.g. first() vs get()) do
+     * not collide.
+     *
+     * @return void
+     */
+    public function testDifferingReadVerbWithIdenticalArgumentsYieldsDistinctFingerprint(): void
+    {
+        $first = QueryFingerprint::for(Tag::query(), 'first');
+        $get   = QueryFingerprint::for(Tag::query(), 'get');
+
+        static::assertNotSame($first, $get);
+    }
+
+    /**
+     * Test that the read verb arguments are folded into the fingerprint, so
+     * find(1) and find(2) on an identical base builder do not collide - the
+     * by-id read whose constraint is applied at execution time.
+     *
+     * @return void
+     */
+    public function testDifferingArgumentsYieldDistinctFingerprint(): void
+    {
+        $one = QueryFingerprint::for(Tag::query(), 'find', [1]);
+        $two = QueryFingerprint::for(Tag::query(), 'find', [2]);
+
+        static::assertNotSame($one, $two);
+    }
+
+    /**
+     * Test that a differing column projection (the array argument to get())
+     * yields a distinct fingerprint, so get(['id','name']) does not collide
+     * with get(['id','email']).
+     *
+     * @return void
+     */
+    public function testDifferingColumnListYieldsDistinctFingerprint(): void
+    {
+        $name  = QueryFingerprint::for(Tag::query(), 'get', [['id', 'name']]);
+        $email = QueryFingerprint::for(Tag::query(), 'get', [['id', 'email']]);
+
+        static::assertNotSame($name, $email);
+    }
+
+    /**
+     * Test that an identical verb and arguments on an identical base builder
+     * yield a stable fingerprint, so a repeat read still hits the cache.
+     *
+     * @return void
+     */
+    public function testIdenticalVerbAndArgumentsYieldStableFingerprint(): void
+    {
+        $first  = QueryFingerprint::for(Tag::query(), 'find', [1]);
+        $second = QueryFingerprint::for(Tag::query(), 'find', [1]);
+
+        static::assertSame($first, $second);
+    }
+
+    /**
+     * Test that the registered eager loads are folded into the fingerprint, so
+     * with('posts')->get() does not collide with a plain get() (the eager
+     * loads are invisible to the compiled base SQL).
+     *
+     * @return void
+     */
+    public function testDifferingEagerLoadsYieldDistinctFingerprint(): void
+    {
+        $eager = QueryFingerprint::for(Tag::query()->with('posts'), 'get');
+        $plain = QueryFingerprint::for(Tag::query(), 'get');
+
+        static::assertNotSame($eager, $plain);
+    }
+
+    /**
+     * Test that the eager load ordering does not affect the fingerprint, so two
+     * reads requesting the same relations in a different order still share a
+     * cache entry.
+     *
+     * @return void
+     */
+    public function testEagerLoadOrderIsIgnored(): void
+    {
+        $first  = QueryFingerprint::for(Tag::query()->with('posts')->with('articles'), 'get');
+        $second = QueryFingerprint::for(Tag::query()->with('articles')->with('posts'), 'get');
+
+        static::assertSame($first, $second);
+    }
+
+    /**
+     * Test that a DateTime binding is normalised to its ATOM representation, so
+     * a query bound with a DateTime and one bound with the equivalent ATOM
+     * string resolve to the same fingerprint.
+     *
+     * @return void
+     */
+    public function testDateTimeBindingMatchesItsAtomStringRepresentation(): void
+    {
+        $moment = new \DateTimeImmutable('2026-01-01 12:00:00', new \DateTimeZone('UTC'));
+
+        $object = QueryFingerprint::for(Tag::query()->where('created_at', $moment));
+        $string = QueryFingerprint::for(Tag::query()->where('created_at', $moment->format(\DateTimeInterface::ATOM)));
+
+        static::assertSame($object, $string);
+    }
+
+    /**
+     * Test that bindings which cannot be JSON-encoded (e.g. invalid UTF-8) fall
+     * back to a stable serialised representation that still distinguishes
+     * distinct values.
+     *
+     * @return void
+     */
+    public function testNonJsonEncodableBindingsYieldDistinctFingerprints(): void
+    {
+        $one = QueryFingerprint::for(Tag::query()->where('name', "\xB1\x31"));
+        $two = QueryFingerprint::for(Tag::query()->where('name', "\xB2\x32"));
+
+        static::assertNotSame($one, $two);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes **BL-7**. The opt-in transparent repository cache (`Cacheable`) keyed each read by a fingerprint of the **prepared base builder only** - computed *before* the read verb and its arguments are applied at execution time. Reads that share a base builder therefore collided on one cache entry, silently returning the wrong data:

- `find(1)` then `find(2)` on the same scope - `find(2)` was served the cached record 1 (the by-id `where` is added at execution, after the hash).
- `value('name')` after a cached `get()` - served the cached collection instead of the scalar column value.
- `get(['id','name'])` vs `get(['id','email'])`, `value()` vs `get()`, `pluck('a')` vs `pluck('b')` - all collided.
- `with('posts')->get()` vs `get()` - eager loads are invisible to the compiled base SQL, so they collided too.

## Change

- `QueryFingerprint::for()` now folds the **read verb**, its **arguments**, and the **sorted eager-load relation names** into the hash. The eager-load keys are read via an `instanceof` narrowing to the concrete Eloquent builder (the `prepareQueryBuilder()` contract type doesn't expose `getEagerLoads()`), keeping PHPStan level 8 clean.
- `Cacheable::resolveCachedRead()` passes the intercepted `$method` and `$arguments` through.

## Tests

- **Integration (`CacheableTest`)**: `find(1)` ≠ `find(2)` returns the correct distinct records; a scalar `value()` read after a cached `get()` returns a scalar matching the uncached source of truth (never the cached collection).
- **Unit (`QueryFingerprintTest`)**: distinct fingerprints for differing verb, differing arguments, column-list projection, and eager loads; stable fingerprints for identical verb+arguments and for eager-load reordering.
- **Mutation**: also closes three pre-existing escaped mutants in `QueryFingerprint` (DateTime→ATOM normalisation; non-JSON-encodable binding fallback), so the change is net-positive for the Infection MSI gate.
- Full suite green (**1880 tests, 4051 assertions**); `qlty check` clean; `composer test:mutation` passes (covered MSI 94.5%).

## Notes

No `docs/` files touched.