### PR TITLE
fix(resources): retain parent FK for plain and extras eager-loaded relations under column narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,11 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
+
+### Fixed
+
+- Column narrowing now retains the parent foreign key for every eager-loaded relation, not only
+  scoped ones. Plain and `extras` relations are stored as list entries in the eager-load map, so
+  deriving relation names via `array_keys()` yielded integer indices that resolved to no relation
+  and dropped the parent key - a narrowed query then silently returned `null` for the relation.
+  Dotted relation paths are reduced to their base-model segment for the same lookup

--- a/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
+++ b/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
@@ -62,7 +62,7 @@ final class ColumnProjectionApplier
             return $query;
         }
 
-        $relationKeys = array_keys($metadataProvider->eagerLoadMapFor($resourceClass, $fields));
+        $relationKeys = $this->relationNames($metadataProvider->eagerLoadMapFor($resourceClass, $fields));
         $safety       = $this->deriveSafetySet($query, $relationKeys, $order);
         $decision     = (new ColumnNarrower)->decide(FieldColumnMapper::for($resourceClass), $fields, $safety);
 
@@ -87,6 +87,37 @@ final class ColumnProjectionApplier
         return in_array(':all', ApiQuery::getFields($resourceType) ?? [], true)
             ? $metadataProvider->getAllFields($resourceClass)
             : $metadataProvider->resolveFields($resourceClass);
+    }
+
+    /**
+     * Extract the base-model relation names from an eager-load map.
+     *
+     * The map mixes plain and extra relations - stored as list entries whose
+     * relation path is the value - with scoped relations stored under a string
+     * key carrying a constraint closure. The relation name is therefore taken
+     * from the value for integer keys and from the key for string keys. Each
+     * path is reduced to its first segment: the relation declared on the base
+     * model, whose parent-side key the narrowed query must retain.
+     *
+     * @param  array<int|string, mixed>  $map
+     * @return array<int, string>
+     */
+    private function relationNames(array $map): array
+    {
+        $names = [];
+
+        foreach ($map as $key => $value) {
+
+            $path = is_string($key) ? $key : $value;
+
+            if (!is_string($path)) {
+                continue;
+            }
+
+            $names[] = explode('.', $path)[0];
+        }
+
+        return $names;
     }
 
     /**

--- a/tests/Fixtures/Resources/ArticleResource.php
+++ b/tests/Fixtures/Resources/ArticleResource.php
@@ -46,6 +46,14 @@ class ArticleResource extends ApiResource
 
                 return mb_substr($article->summary, 0, 20);
             })->needs('summary'),
+            Field::accessor('author_name', static function ($resource): ?string {
+
+                $article = $resource->resource;
+
+                assert($article instanceof Article);
+
+                return $article->author?->name;
+            })->needs('status')->extras('author'),
             Relation::to('author', UserResource::class),
         );
     }

--- a/tests/Integration/ColumnNarrowingIntegrationTest.php
+++ b/tests/Integration/ColumnNarrowingIntegrationTest.php
@@ -158,6 +158,27 @@ class ColumnNarrowingIntegrationTest extends TestCase
     }
 
     /**
+     * With the flag on, a column-mapped field that pulls a `belongsTo` via
+     * `extras` retains the relation's parent foreign key in the narrowed
+     * select, so the eager-loaded relation still hydrates instead of silently
+     * resolving to null.
+     *
+     * @return void
+     */
+    public function testSafetySetRetainsParentKeyForExtrasEagerLoadedBelongsTo(): void
+    {
+        $off = $this->serialiseArticles('id,author_name', null);
+
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $columns = $this->captureArticleColumns('id,author_name', null);
+
+        static::assertNotContains('*', $columns);
+        static::assertContains('user_id', $columns);
+        static::assertSame($off, $this->serialiseArticles('id,author_name', null));
+    }
+
+    /**
      * A field set changed imperatively after the query executes cannot reach the
      * built query, so an opaque field set leaves the executed query selecting all
      * columns while the late field set still renders correctly.

--- a/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Repositories\Criteria\Concerns;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -213,6 +214,87 @@ class ColumnProjectionApplierTest extends TestCase
         $result = $this->makeApplier()->apply($query, $provider, UserResource::class, []);
 
         static::assertSame(['id', 'name'], $result->getQuery()->columns);
+    }
+
+    /**
+     * Test that the parent key of every list-keyed (plain or extra) relation in
+     * the eager-load map is retained, not just the first. The relation name of a
+     * list entry lives in the value, so deriving keys via array_keys would yield
+     * integer indices that resolve to no relation.
+     *
+     * @return void
+     */
+    public function testRetainsParentKeysForEveryListKeyedRelation(): void
+    {
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $this->parseRequest(new Request);
+
+        $provider = static::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(self::USER_DEFAULT_FIELDS);
+        $provider->method('eagerLoadMapFor')->willReturn(['author', 'editor']);
+
+        $author = static::createStub(Relation::class);
+        $editor = static::createStub(Relation::class);
+
+        $introspector = static::createStub(SchemaIntrospectionProvider::class);
+        $introspector->method('getColumns')->willReturn([...self::USER_COLUMNS, 'author_id', 'editor_id']);
+        $introspector->method('getDeletedAtColumn')->willReturn(null);
+        $introspector->method('resolveRelation')->willReturnCallback(
+            static fn (string $key): ?Relation => match ($key) {
+                'author' => $author,
+                'editor' => $editor,
+                default  => null,
+            },
+        );
+        $introspector->method('parentKeysFor')->willReturnCallback(
+            static fn (Relation $relation): array => $relation === $author ? ['author_id'] : ['editor_id'],
+        );
+
+        $applier = new ColumnProjectionApplier(new SafetySetDeriver($introspector));
+
+        $columns = $applier->apply((new User)->newQuery(), $provider, UserResource::class, [])->getQuery()->columns;
+
+        static::assertNotNull($columns);
+        static::assertContains('author_id', $columns);
+        static::assertContains('editor_id', $columns);
+    }
+
+    /**
+     * Test that a dotted relation path is reduced to its first segment - the
+     * relation declared on the base model - so the base-model parent key is
+     * resolved rather than the whole path, which matches no relation.
+     *
+     * @return void
+     */
+    public function testStripsDottedPathToBaseRelationForParentKey(): void
+    {
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $this->parseRequest(new Request);
+
+        $provider = static::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(self::USER_DEFAULT_FIELDS);
+        $provider->method('eagerLoadMapFor')->willReturn(['posts.comments']);
+
+        $relation = static::createStub(Relation::class);
+
+        $introspector = static::createStub(SchemaIntrospectionProvider::class);
+        $introspector->method('getColumns')->willReturn(self::USER_COLUMNS);
+        $introspector->method('getDeletedAtColumn')->willReturn(null);
+        $introspector->method('resolveRelation')->willReturnCallback(
+            static fn (string $key): ?Relation => $key === 'posts' ? $relation : null,
+        );
+        $introspector->method('parentKeysFor')->willReturn(['organization_id']);
+
+        $applier = new ColumnProjectionApplier(new SafetySetDeriver($introspector));
+
+        $columns = $applier->apply((new User)->newQuery(), $provider, UserResource::class, [])->getQuery()->columns;
+
+        static::assertNotNull($columns);
+        static::assertContains('organization_id', $columns);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes **BL-8**. With column narrowing enabled (`narrow_columns=true`), a column-mapped field that eager-loads a `belongsTo` via a **plain** or **`extras`** relation had the relation's parent foreign key dropped from the narrowed `SELECT`, so the eager-loaded relation silently resolved to `null`.

## Root cause

`EagerLoadPlanner::buildEagerLoadMap()` returns `array_merge($plain, $scoped)`, where plain/extras relations are **list entries** (relation path in the *value*, integer key) and scoped relations are **string-keyed** (path as key, closure as value). `ColumnProjectionApplier` derived the relation names with `array_keys()` on that map, yielding integer indices (`0, 1, ...`) for every plain/extras relation. `SchemaIntrospector::resolveRelation('0', $model)` is not a relation, so those relations contributed no parent key to the safety set - only scoped (string-keyed) relations survived. The narrowed `SELECT` then omitted e.g. `user_id`, and the eager load of the `belongsTo` found no foreign key.

## Fix

`ColumnProjectionApplier::relationNames()` now extracts the relation name from the **value** for list entries and from the **key** for scoped entries, and reduces dotted paths to their base-model first segment before resolving the parent key.

## Tests

- **Integration** (`ColumnNarrowingIntegrationTest`): a column-mapped accessor that pulls the `author` `belongsTo` via `extras` retains `user_id` in the narrowed `SELECT`, and the response stays byte-identical to narrow-off (the relation hydrates instead of resolving to `null`). Verified to fail on the pre-fix code.
- **Unit** (`ColumnProjectionApplierTest`): the parent key of *every* list-keyed relation is retained (not just the first), and dotted paths reduce to their base-model segment.
- Full suite green (**1872 tests**); `qlty check` clean; `composer test:mutation` passes (covered MSI 94%, zero net-new escaped mutants in the changed file).

## Notes

The only fixture change is a new **non-default** accessor field on `ArticleResource` (used solely by the integration test). No `docs/` files touched.