### PR TITLE
fix(logging): preserve exception type and stack at lifecycle and error boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,12 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
+
+### Fixed
+
+- Lifecycle and error boundaries now preserve the full throwable (type, stack, cause) rather than
+  only its message: the write-pool flush subscriber, the database log handler's fallback, and the
+  write-pool chunk-failure logger log the throwable under an `exception` key, and the write-pool
+  failure accumulator records the `exception_class` alongside the message. The Octane cache-flush
+  listener now wraps the flush in an error boundary, so a flush failure is logged instead of
+  propagating into Octane's dispatch and crashing the worker

--- a/src/Listeners/OctaneFlushListener.php
+++ b/src/Listeners/OctaneFlushListener.php
@@ -2,6 +2,7 @@
 
 namespace SineMacula\ApiToolkit\Listeners;
 
+use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Cache\CacheManager;
 
 /**
@@ -41,6 +42,10 @@ final class OctaneFlushListener
      */
     public function handle(object $event): void
     {
-        $this->cacheManager->flush();
+        try {
+            $this->cacheManager->flush();
+        } catch (\Throwable $exception) {
+            Log::error('Octane cache flush failed', ['exception' => $exception]);
+        }
     }
 }

--- a/src/Listeners/WritePoolFlushSubscriber.php
+++ b/src/Listeners/WritePoolFlushSubscriber.php
@@ -88,7 +88,7 @@ final class WritePoolFlushSubscriber
             }
         } catch (\Throwable $e) {
 
-            Log::error('WritePool flush subscriber failed', ['error' => $e->getMessage()]);
+            Log::error('WritePool flush subscriber failed', ['error' => $e->getMessage(), 'exception' => $e]);
         }
     }
 

--- a/src/Logging/DatabaseHandler.php
+++ b/src/Logging/DatabaseHandler.php
@@ -79,7 +79,7 @@ class DatabaseHandler extends AbstractProcessingHandler
 
         Log::stack($fallback_channels)->debug($record->formatted ?? $record->message);
         Log::stack($fallback_channels)->debug('Could not log to the database.', [
-            'exception' => $exception->getMessage(),
+            'exception' => $exception,
         ]);
     }
 }

--- a/src/Repositories/Concerns/WritePool.php
+++ b/src/Repositories/Concerns/WritePool.php
@@ -228,7 +228,7 @@ final class WritePool
 
         $records = array_merge(...$context->chunks());
 
-        $accumulator->recordFailure($context->table(), $records, $exception->getMessage());
+        $accumulator->recordFailure($context->table(), $records, $exception);
 
         if ($context->strategy() === FlushStrategy::THROW) {
             // Whole-table retain: set buffer to the merged records + all remaining tables.
@@ -293,7 +293,7 @@ final class WritePool
         \Throwable $exception,
     ): void {
 
-        $accumulator->recordFailure($context->table(), $chunk, $exception->getMessage());
+        $accumulator->recordFailure($context->table(), $chunk, $exception);
 
         if ($context->strategy() === FlushStrategy::THROW) {
             // Per-chunk retain: failed chunk + remaining chunks + remaining tables.
@@ -324,6 +324,7 @@ final class WritePool
             'table'      => $table,
             'chunk_size' => count($chunk),
             'error'      => $exception->getMessage(),
+            'exception'  => $exception,
         ]);
     }
 

--- a/src/Repositories/Concerns/WritePoolFlushAccumulator.php
+++ b/src/Repositories/Concerns/WritePoolFlushAccumulator.php
@@ -28,7 +28,7 @@ final class WritePoolFlushAccumulator
     /** @var int The number of records contained in failed chunks. */
     private int $failedRecordCount = 0;
 
-    /** @var array<string, list<array{records: list<array<string, mixed>>, exception: string}>> Failure details keyed by table name. */
+    /** @var array<string, list<array{records: list<array<string, mixed>>, exception: string, exception_class: string}>> Failure details keyed by table name. */
     private array $failures = [];
 
     /** @var array<string, list<array<string, mixed>>> Records retained in the buffer for retry, keyed by table name. */
@@ -51,15 +51,19 @@ final class WritePoolFlushAccumulator
      *
      * @param  string  $table
      * @param  list<array<string, mixed>>  $chunk
-     * @param  string  $exception
+     * @param  \Throwable  $exception
      * @return void
      */
-    public function recordFailure(string $table, array $chunk, string $exception): void
+    public function recordFailure(string $table, array $chunk, \Throwable $exception): void
     {
         $this->failureCount++;
         $this->failedRecordCount += count($chunk);
 
-        $this->failures[$table][] = ['records' => $chunk, 'exception' => $exception];
+        $this->failures[$table][] = [
+            'records'         => $chunk,
+            'exception'       => $exception->getMessage(),
+            'exception_class' => $exception::class,
+        ];
     }
 
     /**

--- a/src/Repositories/Concerns/WritePoolFlushResult.php
+++ b/src/Repositories/Concerns/WritePoolFlushResult.php
@@ -16,7 +16,7 @@ final class WritePoolFlushResult
      *
      * @param  int  $successCount
      * @param  int  $failureCount
-     * @param  array<string, list<array{records: list<array<string, mixed>>, exception: string}>>  $failures
+     * @param  array<string, list<array{records: list<array<string, mixed>>, exception: string, exception_class: string}>>  $failures
      * @param  int  $flushedRecordCount
      * @param  int  $failedRecordCount
      * @param  int  $retainedRecordCount
@@ -76,7 +76,7 @@ final class WritePoolFlushResult
     /**
      * Get the failure details keyed by table name.
      *
-     * @return array<string, list<array{records: list<array<string, mixed>>, exception: string}>>
+     * @return array<string, list<array{records: list<array<string, mixed>>, exception: string, exception_class: string}>>
      */
     public function failures(): array
     {

--- a/tests/Unit/Listeners/OctaneFlushListenerTest.php
+++ b/tests/Unit/Listeners/OctaneFlushListenerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Listeners;
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Cache\CacheManager;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
@@ -49,5 +50,34 @@ class OctaneFlushListenerTest extends TestCase
 
         // Assert
         static::assertNull(Cache::memo()->get($key));
+    }
+
+    /**
+     * Test that a CacheManager flush failure is caught and logged with the full
+     * throwable rather than propagating into Octane's event dispatch and
+     * crashing the worker.
+     *
+     * @return void
+     */
+    public function testHandleSwallowsAndLogsCacheFlushFailure(): void
+    {
+        Event::fake();
+
+        $this->mock(SchemaIntrospectionProvider::class)
+            ->shouldReceive('flush')
+            ->once()
+            ->andThrow(new \RuntimeException('flush boom'));
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Octane cache flush failed', \Mockery::on(
+                static fn (array $context): bool => $context['exception'] instanceof \RuntimeException
+                    && $context['exception']->getMessage() === 'flush boom',
+            ));
+
+        $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $listener     = new OctaneFlushListener($cacheManager);
+
+        $listener->handle(new \stdClass);
     }
 }

--- a/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
@@ -326,7 +326,11 @@ class WritePoolFlushSubscriberTest extends TestCase
 
         Log::shouldReceive('error')
             ->once()
-            ->with('WritePool flush subscriber failed', ['error' => 'Database connection lost']);
+            ->with('WritePool flush subscriber failed', \Mockery::on(
+                static fn (array $context): bool => $context['error'] === 'Database connection lost'
+                    && $context['exception'] instanceof \RuntimeException
+                    && $context['exception']->getMessage() === 'Database connection lost',
+            ));
 
         $subscriber = new WritePoolFlushSubscriber($container);
 

--- a/tests/Unit/Logging/DatabaseHandlerTest.php
+++ b/tests/Unit/Logging/DatabaseHandlerTest.php
@@ -286,8 +286,7 @@ class DatabaseHandlerTest extends TestCase
             ->withArgs(fn (mixed $message, mixed $context = null): bool => $message === 'Could not log to the database.'
                 && is_array($context)
                 && isset($context['exception'])
-                && is_string($context['exception'])
-                && $context['exception'] !== '');
+                && $context['exception'] instanceof \Throwable);
 
         // Drop the logs table so the insert fails
         \Illuminate\Support\Facades\Schema::drop('logs');

--- a/tests/Unit/Repositories/Concerns/WritePoolTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolTest.php
@@ -326,6 +326,7 @@ class WritePoolTest extends TestCase
         static::assertArrayHasKey('nonexistent_table', $flushResult->failures());
         static::assertSame([['col' => 'val']], $flushResult->failures()['nonexistent_table'][0]['records']);
         static::assertNotEmpty($flushResult->failures()['nonexistent_table'][0]['exception']);
+        static::assertSame(\Illuminate\Database\QueryException::class, $flushResult->failures()['nonexistent_table'][0]['exception_class']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes **BL-14**. Several lifecycle / error boundaries caught `\Throwable` and logged only `$e->getMessage()`, discarding the exception class, stack, and cause - and the Octane cache-flush listener had **no error boundary at all**, so a flush failure propagated into Octane's event dispatch and could crash the worker.

## Changes

- **`WritePoolFlushSubscriber`** (`:91`), **`DatabaseHandler`** fallback (`:82`), and **`WritePool::logChunkFailure`** now log the throwable under an `exception` key (the `DatabaseHandler` already stringifies a throwable in that key to class + message + trace).
- **`WritePoolFlushAccumulator::recordFailure`** now takes the `\Throwable` and records `exception_class` alongside the message in each failure entry; the shape is propagated through `WritePoolFlushResult`. The existing `exception` (message) key is unchanged, so this is additive.
- **`OctaneFlushListener::handle`** wraps `cacheManager->flush()` in a try/catch and logs the throwable, so a flush failure is logged instead of crashing the worker.

## Tests

- Existing subscriber and database-handler boundary tests updated to assert the **throwable** (type + message) is logged, not a bare string.
- `WritePoolTest` now asserts the failure entry carries `exception_class` (`QueryException`).
- New `OctaneFlushListenerTest` case proves a flush failure is caught and logged rather than propagated (verified to error on the pre-fix, boundary-less code).
- Full suite green (**1870 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI, zero escaped mutants in the changed files).

## Notes

No `docs/` files touched.