### PR TITLE
fix: BL-13 contained correctness fixes (SSE encode failure, empty schema cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,12 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
+
+### Fixed
+
+- The SSE `Emitter::emit()` now encodes array payloads with `JSON_THROW_ON_ERROR`, so an
+  unencodable payload raises a `JsonException` (which the event stream's error handler can act on)
+  instead of silently writing a single blank `data:` frame
+- `SchemaIntrospector::getColumns()` now caches an empty column listing instead of re-querying the
+  schema on every request, by gating the cache hit on the cache key's presence rather than on a
+  non-empty cached value

--- a/src/Services/SchemaIntrospector.php
+++ b/src/Services/SchemaIntrospector.php
@@ -54,10 +54,11 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
 
         $cacheKey = CacheKeys::MODEL_SCHEMA_COLUMNS->resolveKey([$model::class]);
 
-        /** @var array<int, string> $cached */
-        $cached = Cache::memo()->get($cacheKey, []);
+        if (Cache::memo()->has($cacheKey)) {
 
-        if (!empty($cached)) {
+            /** @var array<int, string> $cached */
+            $cached = Cache::memo()->get($cacheKey, []);
+
             $this->columns[$model::class] = $cached;
 
             return $cached;

--- a/src/Sse/Emitter.php
+++ b/src/Sse/Emitter.php
@@ -25,6 +25,8 @@ final class Emitter
      * @param  array<mixed>|string  $data
      * @param  string|null  $event
      * @return void
+     *
+     * @throws \JsonException
      */
     public function emit(array|string $data, ?string $event = null): void
     {
@@ -33,7 +35,7 @@ final class Emitter
         }
 
         if (is_array($data)) {
-            $data = json_encode($data);
+            $data = json_encode($data, JSON_THROW_ON_ERROR);
         }
 
         foreach ((array) preg_split('/\r\n|\r|\n/', $data) as $line) {

--- a/tests/Unit/Services/SchemaIntrospectorTest.php
+++ b/tests/Unit/Services/SchemaIntrospectorTest.php
@@ -94,6 +94,30 @@ class SchemaIntrospectorTest extends TestCase
     }
 
     /**
+     * Test that an empty column listing is served from the memo cache on a
+     * later instance rather than being re-queried every time, since an empty
+     * array is a valid cached result.
+     *
+     * @return void
+     */
+    public function testGetColumnsCachesEmptyColumnListAcrossInstances(): void
+    {
+        Cache::memo()->flush(); // @phpstan-ignore method.notFound
+
+        Schema::shouldReceive('getColumnListing')
+            ->once()
+            ->andReturn([]);
+
+        $model = new User;
+
+        $first  = (new SchemaIntrospector)->getColumns($model);
+        $second = (new SchemaIntrospector)->getColumns($model);
+
+        static::assertSame([], $first);
+        static::assertSame([], $second);
+    }
+
+    /**
      * Test that getColumns stores the result in the memo cache under a key
      * scoped to the model class.
      *

--- a/tests/Unit/Sse/EmitterTest.php
+++ b/tests/Unit/Sse/EmitterTest.php
@@ -107,6 +107,19 @@ class EmitterTest extends TestCase
     }
 
     /**
+     * Test that emit raises a JsonException for unencodable array data instead
+     * of silently writing a blank data frame.
+     *
+     * @return void
+     */
+    public function testEmitThrowsJsonExceptionForUnencodableArrayData(): void
+    {
+        $this->expectException(\JsonException::class);
+
+        $this->emitter->emit(['invalid' => "\xB1\x31"]);
+    }
+
+    /**
      * Test that comment writes an empty comment line.
      *
      * @return void


### PR DESCRIPTION
## Summary

Addresses two of the five sub-bugs in **BL-13** - the two that are self-contained and cleanly testable without new fixtures or render-path changes. The remaining three are covered under "Status of the other BL-13 items" below.

### (1) SSE `Emitter::emit()` swallowed `json_encode` failures
`emit()` encoded array data with `json_encode()` and no error flag. An unencodable payload (e.g. invalid UTF-8) returned `false`, which `preg_split()` coerced to `['']`, producing a single **blank `data:` frame** with the failure invisible. Now encodes with `JSON_THROW_ON_ERROR`, so the failure raises a `JsonException` that the `EventStream` stream-error handler (`handleStreamError`) can act on.

### (4) `SchemaIntrospector::getColumns()` never cached an empty column listing
The cache hit was gated on `!empty($cached)`, so a model whose `getColumnListing()` returns `[]` (a missing or empty-schema table) was cached as `[]` but then **re-queried the schema on every request** (`!empty([])` is false). Now gated on `Cache::memo()->has($cacheKey)`, so an empty listing is a valid cached result.

## Tests

- `EmitterTest`: unencodable array data raises `JsonException` instead of writing a blank frame.
- `SchemaIntrospectorTest`: an empty column listing is served from the memo cache on a later instance (asserts `getColumnListing` is queried exactly once across two instances).
- Both verified to fail on the pre-fix code (via stash). Full suite green (**1871 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI, zero escaped mutants in the changed files).

## Status of the other BL-13 items

- **(2) Duplicate relation counts collide** (`EagerLoadPlanner::buildCountMap` + `ValueResolver`): confirmed real - two `withCount`s on one relation collide because both the emit (`buildCountMap` keys by `relation`) and the read (`ValueResolver` reads `{relation}_count`) ignore the alias. The fix changes the count **render path** (emit `relation as {presentKey}`, read by `presentKey`), so it warrants its own focused PR.
- **(3) `AttributeSetter` sync hardcodes `id`** (`setSyncAttribute`): confirmed real for non-`id` primary keys (`pluck('id')` should pluck the related model's `getKeyName()`). The red-green test needs a custom-PK fixture model + pivot, so it is best done as its own PR.
- **(5) `ContainsOperator` key-0 reliance**: investigated and found **not a functional bug** - Laravel's grammar strips the leading boolean of the nested `where()` group, so the all-`orWhereJsonContains` path compiles to identical SQL and bindings. No behavioural fix is needed (a `array_values()` would be cosmetic only), so no change is made here.

No `docs/` files touched.