### PR TITLE
fix(repositories): sync relations by the related model's key, not a hardcoded id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,9 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
+
+### Fixed
+
+- `AttributeSetter` relation sync now plucks the related model's primary key (`getKeyName()`) instead
+  of a hardcoded `id`, so syncing a model or collection into a `BelongsToMany` whose related model
+  uses a non-`id` primary key attaches the correct keys rather than null

--- a/src/Repositories/Concerns/AttributeSetter.php
+++ b/src/Repositories/Concerns/AttributeSetter.php
@@ -256,6 +256,12 @@ final class AttributeSetter
      */
     private function setSyncAttribute(Model $model, string $attribute, mixed $value): void
     {
+        $relation = $this->resolveRelationInstance($model, $attribute);
+
+        if (!($relation instanceof BelongsToMany)) {
+            throw new \LogicException(sprintf('Attribute "%s" on %s does not resolve to a BelongsToMany relation', $attribute, $model::class));
+        }
+
         if ($value instanceof Model || $value instanceof Collection) {
 
             $value = [
@@ -263,17 +269,11 @@ final class AttributeSetter
                 'detaching' => true,
             ];
 
-            $values = $value['values']->pluck('id');
+            $values = $value['values']->pluck($relation->getRelated()->getKeyName());
         }
 
         $values ??= $value;
         $detaching = $value['detaching'] ?? true;
-
-        $relation = $this->resolveRelationInstance($model, $attribute);
-
-        if (!($relation instanceof BelongsToMany)) {
-            throw new \LogicException(sprintf('Attribute "%s" on %s does not resolve to a BelongsToMany relation', $attribute, $model::class));
-        }
 
         $relation->sync($values, $detaching);
     }

--- a/tests/Fixtures/Models/Country.php
+++ b/tests/Fixtures/Models/Country.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Fixture country model with a non-incrementing string primary key.
+ *
+ * Used to exercise relation sync against a related model whose primary key is
+ * not `id`.
+ *
+ * @method static static create(array<string, mixed> $attributes = [])
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+class Country extends Model
+{
+    /** @var bool */
+    public $incrementing = false;
+
+    /** @var string|null */
+    protected $table = 'countries';
+
+    /** @var string */
+    protected $primaryKey = 'code';
+
+    /** @var string */
+    protected $keyType = 'string';
+
+    /** @var array<int, string> */
+    protected $fillable = ['code', 'name'];
+}

--- a/tests/Fixtures/Models/Post.php
+++ b/tests/Fixtures/Models/Post.php
@@ -49,6 +49,16 @@ class Post extends Model
     }
 
     /**
+     * Get the countries associated with the post via a non-`id` related key.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\Tests\Fixtures\Models\Country, $this>
+     */
+    public function countries(): BelongsToMany
+    {
+        return $this->belongsToMany(Country::class, 'country_post', 'post_id', 'country_code', 'id', 'code');
+    }
+
+    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -105,6 +105,8 @@ abstract class TestCase extends OrchestraTestCase
         $this->createProfilesTable();
         $this->createTagsTable();
         $this->createPostTagTable();
+        $this->createCountriesTable();
+        $this->createCountryPostTable();
         $this->createLogsTable();
         $this->createArticlesTable();
     }
@@ -246,6 +248,36 @@ abstract class TestCase extends OrchestraTestCase
             $table->unsignedBigInteger('post_id');
             $table->unsignedBigInteger('tag_id');
             $table->primary(['post_id', 'tag_id']);
+        });
+    }
+
+    /**
+     * Create the countries table with a non-incrementing string primary key.
+     *
+     * @return void
+     */
+    private function createCountriesTable(): void
+    {
+        Schema::dropIfExists('countries');
+        Schema::create('countries', function (Blueprint $table): void {
+            $table->string('code')->primary();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Create the country_post pivot table keyed by the country code.
+     *
+     * @return void
+     */
+    private function createCountryPostTable(): void
+    {
+        Schema::dropIfExists('country_post');
+        Schema::create('country_post', function (Blueprint $table): void {
+            $table->unsignedBigInteger('post_id');
+            $table->string('country_code');
+            $table->primary(['post_id', 'country_code']);
         });
     }
 

--- a/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
+++ b/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
@@ -13,6 +13,7 @@ use SineMacula\ApiToolkit\Enums\CacheKeys;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Enums\UserStatus;
+use Tests\Fixtures\Models\Country;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\Tag;
@@ -241,6 +242,33 @@ class AttributeSetterTest extends TestCase
 
         static::assertTrue($result);
         static::assertCount(1, $post->fresh()?->tags()->get() ?? collect([]));
+    }
+
+    /**
+     * Test that syncing a collection of related models with a non-`id` primary
+     * key plucks the related model's key name rather than a hardcoded `id`, so
+     * the relation is synced instead of attaching null keys.
+     *
+     * @return void
+     */
+    public function testPersistSyncWithCollectionUsesRelatedModelKeyForNonIdPrimaryKey(): void
+    {
+        $user = User::create(['name' => 'Alice', 'email' => self::ALICE_EMAIL]);
+        $post = Post::create(['user_id' => $user->id, 'title' => 'T', 'body' => 'B']);
+        $us   = Country::create(['code' => 'US', 'name' => 'United States']);
+        $gb   = Country::create(['code' => 'GB', 'name' => 'United Kingdom']);
+
+        $this->setProperty($this->attributeSetter, 'casts', ['countries' => 'sync']);
+
+        $result = $this->attributeSetter->persist($post, ['countries' => collect([$us, $gb])], Post::class);
+
+        static::assertTrue($result);
+
+        $synced = $post->fresh()?->countries()->pluck('code')->all() ?? [];
+
+        sort($synced);
+
+        static::assertSame(['GB', 'US'], $synced);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes **BL-13 (3)**. `AttributeSetter::setSyncAttribute()` plucked `id` from a synced `Model`/`Collection`, so a `BelongsToMany` whose related model uses a **non-`id` primary key** was synced with `null` keys - nothing was attached, silently.

## Fix

Resolve the relation first, then pluck the related model's `getKeyName()` instead of the literal `'id'`:

```php
$relation = $this->resolveRelationInstance($model, $attribute);
// ...validate BelongsToMany...
$values = $value['values']->pluck($relation->getRelated()->getKeyName());
```

For the common `id`-keyed case the behaviour is unchanged (`getKeyName()` is `id`). Resolving the relation first also means a non-`BelongsToMany` attribute throws the existing `LogicException` slightly earlier, with no change to the message.

## Tests

- New custom-PK fixture: `Country` model (string `code` primary key, non-incrementing) + a `Post::countries()` `BelongsToMany` with a `country_code` pivot key, plus the `countries` / `country_post` migrations in the test base.
- Regression test syncs a collection of `Country` models and asserts the codes are attached (`['GB', 'US']`). Verified to fail on the pre-fix code (it attached `null` and synced nothing).
- Full suite green (**1870 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI, zero escaped mutants in the changed file).

## Notes

This is one of two remaining BL-13 sub-bugs; the duplicate-relation-count fix (BL-13 (2)) follows separately. No `docs/` files touched.