### PR TITLE
fix(resources): disambiguate multiple counts on the same relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 
 ### Fixed
 
+- Duplicate relation counts no longer collide. `EagerLoadPlanner::buildCountMap()` now aliases each
+  count as `{relation} as {presentKey}_count` and `ValueResolver` reads it back by presentation key,
+  so two counts on the same relation (e.g. a total and a constrained subset) resolve to distinct
+  values instead of both reporting the same one
 - Lifecycle and error boundaries now preserve the full throwable (type, stack, cause) rather than
   only its message: the write-pool flush subscriber, the database log handler's fallback, and the
   write-pool chunk-failure logger log the throwable under an `exception` key, and the write-pool

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -71,12 +71,17 @@ final class EagerLoadPlanner
                 continue;
             }
 
+            // Alias each count by its presentation key so two counts on the
+            // same relation (e.g. all + constrained) resolve to distinct
+            // `{presentKey}_count` attributes instead of colliding on one.
+            $aliased = $definition->relation . ' as ' . $definition->presentKey . '_count';
+
             $constraint = $definition->constraint;
 
             if ($constraint instanceof \Closure) {
-                $with[$definition->relation] = $constraint;
+                $with[$aliased] = $constraint;
             } else {
-                $with[] = $definition->relation;
+                $with[] = $aliased;
             }
         }
 

--- a/src/Http/Resources/Concerns/ValueResolver.php
+++ b/src/Http/Resources/Concerns/ValueResolver.php
@@ -104,7 +104,7 @@ final class ValueResolver
                 continue;
             }
 
-            $attribute = $definition->relation . '_count';
+            $attribute = $definition->presentKey . '_count';
             $value     = $this->getAttributeIfLoaded($owner, $attribute);
 
             if ($value !== null) {

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -835,7 +835,7 @@ class ApiResourceTest extends TestCase
     {
         $counts = UserResource::eagerLoadCountsFor(['posts']);
 
-        static::assertContains('posts', $counts);
+        static::assertContains('posts as posts_count', $counts);
     }
 
     /**
@@ -847,7 +847,7 @@ class ApiResourceTest extends TestCase
     {
         $counts = UserResource::eagerLoadCountsFor(null);
 
-        static::assertContains('posts', $counts);
+        static::assertContains('posts as posts_count', $counts);
     }
 
     /**
@@ -871,7 +871,7 @@ class ApiResourceTest extends TestCase
     {
         $counts = OrganizationResource::eagerLoadCountsFor(['users']);
 
-        static::assertContains('users', $counts);
+        static::assertContains('users as users_count', $counts);
     }
 
     /**
@@ -1326,8 +1326,8 @@ class ApiResourceTest extends TestCase
 
         $counts = $resource_class::eagerLoadCountsFor(null);
 
-        static::assertArrayHasKey('items', $counts);
-        static::assertIsCallable($counts['items']);
+        static::assertArrayHasKey('items as items_count', $counts);
+        static::assertIsCallable($counts['items as items_count']);
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -224,7 +224,7 @@ class EagerLoadPlannerTest extends TestCase
     {
         $result = EagerLoadPlanner::buildCountMap(UserResource::class);
 
-        static::assertContains('posts', $result);
+        static::assertContains('posts as posts_count', $result);
     }
 
     /**
@@ -236,11 +236,11 @@ class EagerLoadPlannerTest extends TestCase
     {
         $result = EagerLoadPlanner::buildCountMap(UserResource::class, ['posts']);
 
-        static::assertContains('posts', $result);
+        static::assertContains('posts as posts_count', $result);
 
         $nonDefaultResult = EagerLoadPlanner::buildCountMap(OrganizationResource::class, ['users']);
 
-        static::assertContains('users', $nonDefaultResult);
+        static::assertContains('users as users_count', $nonDefaultResult);
     }
 
     /**
@@ -274,8 +274,8 @@ class EagerLoadPlannerTest extends TestCase
         $resourceClass = $constrainedCountResource::class;
         $result        = EagerLoadPlanner::buildCountMap($resourceClass);
 
-        static::assertArrayHasKey('posts', $result);
-        static::assertInstanceOf(\Closure::class, $result['posts']);
+        static::assertArrayHasKey('posts as active_posts_count', $result);
+        static::assertInstanceOf(\Closure::class, $result['posts as active_posts_count']);
     }
 
     /**
@@ -443,7 +443,7 @@ class EagerLoadPlannerTest extends TestCase
         $resourceClass = $multiCountResource::class;
         $result        = EagerLoadPlanner::buildCountMap($resourceClass);
 
-        static::assertSame(['published', 'archived'], array_values($result));
+        static::assertSame(['published as published_count', 'archived as archived_count'], array_values($result));
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
@@ -247,6 +247,57 @@ class ValueResolverTest extends TestCase
     }
 
     /**
+     * Test that two counts on the same relation but with different presentation
+     * keys resolve to their own `{presentKey}_count` attributes rather than
+     * colliding on a single `{relation}_count` value.
+     *
+     * @return void
+     */
+    public function testResolveCountsPayloadDisambiguatesCountsOnTheSameRelation(): void
+    {
+
+        ApiQuery::shouldReceive('getCounts')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_count' => 10, 'active_posts_count' => 3];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [
+            'posts'        => new CompiledCountDefinition('posts', 'posts', null, true, []),
+            'active_posts' => new CompiledCountDefinition('active_posts', 'posts', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveCountsPayload($resource, $schema, 'users', null);
+
+        static::assertSame(['posts' => 10, 'active_posts' => 3], $result);
+    }
+
+    /**
      * Test that only explicitly requested count aliases are included.
      *
      * @return void


### PR DESCRIPTION
## Summary

Fixes **BL-13 (2)** - the last of the BL-13 cluster. Two relation counts that targeted the **same Eloquent relation** collided on a single value: `EagerLoadPlanner::buildCountMap()` keyed `withCount` by the relation name, and `ValueResolver` read the result from `{relation}_count`. So a "total posts" count and a "published posts only" count on `posts` both resolved to one `posts_count` attribute and reported the same number.

## Fix

- `buildCountMap()` now aliases each count as `{relation} as {presentKey}_count` (in both the plain and constrained branches), so each count produces a distinct `withCount` attribute.
- `ValueResolver` reads the count from `{presentKey}_count` to match.

For the common single-count case (`presentKey == relation`) the attribute is still `{relation}_count`, so runtime behaviour is unchanged - only genuinely colliding counts are disambiguated.

## Tests

- New `ValueResolver` regression: two count definitions on relation `posts` with present keys `posts` and `active_posts` resolve to **distinct** values (`['posts' => 10, 'active_posts' => 3]`). Verified to fail on the pre-fix code (both reported `10`).
- Existing `buildCountMap` shape assertions updated to the aliased form (`'posts as posts_count'`, etc.).
- Full suite green (**1886 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI, zero escaped mutants in the changed files).

## Notes

This completes BL-13: sub-bugs (1) and (4) shipped in #260, (3) in #261, and (5) was found to be a non-bug. No `docs/` files touched.