### PR TITLE
fix(parser): clamp query limit to a configurable maximum to prevent unbounded page sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,6 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
   (`password`, `*token*`, `*secret*`, and `authorization` by default, matched case-insensitively
   and recursively) are redacted from the request data written to the `api-exceptions` log context,
   preventing credentials from leaking to logs and CloudWatch (CWE-532)
+- API query `limit` values are now clamped to a configurable hard ceiling (`parser.max_limit`,
+  default 100) instead of being honoured unbounded, so a request such as `?limit=100000000` can no
+  longer force an unbounded page size that exhausts memory

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -172,6 +172,11 @@ return [
 
         'register_middleware' => env('API_PARSER_REGISTER_MIDDLEWARE', true),
 
+        // Hard ceiling for a client-supplied `limit`. Requests above it are
+        // clamped (not rejected) to prevent unbounded page sizes exhausting
+        // memory. Set to 0 (or null) to disable the ceiling.
+        'max_limit' => env('API_PARSER_MAX_LIMIT', 100),
+
         'defaults' => [
             'limit' => env('API_PARSER_DEFAULT_LIMIT', 50),
         ],

--- a/src/ApiQueryParser.php
+++ b/src/ApiQueryParser.php
@@ -3,6 +3,7 @@
 namespace SineMacula\ApiToolkit;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Concerns\QueryParameterExtractor;
 use SineMacula\ApiToolkit\Concerns\QueryParameterValidator;
 
@@ -134,7 +135,14 @@ class ApiQueryParser
 
         $limit = is_numeric($limit) ? (int) $limit : 0;
 
-        return $limit > 0 ? $limit : null;
+        if ($limit <= 0) {
+            return null;
+        }
+
+        $max = Config::get('api-toolkit.parser.max_limit');
+        $max = is_numeric($max) ? (int) $max : 0;
+
+        return $max > 0 ? min($limit, $max) : $limit;
     }
 
     /**

--- a/tests/Unit/ApiQueryParserTest.php
+++ b/tests/Unit/ApiQueryParserTest.php
@@ -295,6 +295,54 @@ class ApiQueryParserTest extends TestCase
     }
 
     /**
+     * Test that getLimit clamps a request above the configured maximum to that
+     * ceiling, so an unbounded page size cannot exhaust memory.
+     *
+     * @return void
+     */
+    public function testGetLimitClampsToConfiguredMaximum(): void
+    {
+        config()->set('api-toolkit.parser.max_limit', 100);
+
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['limit' => '100000']);
+        $this->parser->parse($request);
+
+        static::assertSame(100, $this->parser->getLimit());
+    }
+
+    /**
+     * Test that getLimit leaves the requested value untouched when the maximum
+     * ceiling is disabled (zero).
+     *
+     * @return void
+     */
+    public function testGetLimitIsNotClampedWhenMaximumDisabled(): void
+    {
+        config()->set('api-toolkit.parser.max_limit', 0);
+
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['limit' => '100000']);
+        $this->parser->parse($request);
+
+        static::assertSame(100000, $this->parser->getLimit());
+    }
+
+    /**
+     * Test that a non-numeric maximum configuration disables clamping rather
+     * than capping the limit to an unintended value.
+     *
+     * @return void
+     */
+    public function testGetLimitTreatsNonNumericMaximumAsDisabled(): void
+    {
+        config()->set('api-toolkit.parser.max_limit', 'not-a-number');
+
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['limit' => '100000']);
+        $this->parser->parse($request);
+
+        static::assertSame(100000, $this->parser->getLimit());
+    }
+
+    /**
      * Test that getLimit returns null for zero.
      *
      * @return void


### PR DESCRIPTION
## Summary

Addresses the **unbounded `limit`** item of **BL-15**. The `limit` query parameter was validated as `integer|min:1` with **no upper bound**, and `ApiQueryParser::getLimit()` returned it unclamped. A request such as `?limit=100000000` was therefore honoured verbatim, forcing an unbounded page size that the repository/pagination would try to materialise - a memory-exhaustion / DoS vector.

## Fix

- New config `api-toolkit.parser.max_limit` (default `100`, env `API_PARSER_MAX_LIMIT`) - a hard ceiling.
- `getLimit()` now **clamps** the requested limit to that ceiling (`min($limit, $max)`) rather than rejecting it, so over-limit requests still succeed with a capped page size. Setting `max_limit` to `0` (or a non-numeric / null value) disables the ceiling for apps that need unbounded limits.

`getLimit()` is the single choke point for all three consumers (`ApiRepository`, `ApiCriteria`, `RespondsWithStream`), so the clamp covers every path. The default request limit (50) is unchanged and well under the ceiling.

## Tests

- A limit above the ceiling is clamped to the ceiling (verified failing pre-fix: returned `100000`).
- A limit below the ceiling is returned unchanged (existing tests, all ≤ 25).
- `max_limit` of `0` or a non-numeric value disables clamping.
- Full suite green (**1894 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI; the two residual mutants in `getLimit` are equivalent `:0`-fallback mutants).

## Notes

BL-15 has three further sub-items (anonymous-throttle keying, `searchable_exclusions` default, relation-traversal allowlist) that are independent and can follow as their own PRs. No `docs/` files touched.