### PR TITLE
fix(repositories): let Cacheable and Deferrable coexist without a boot collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - `ApiException::getCustomDetail()` now returns an empty detail instead of leaking the raw
   translation key when no `detail` translation is registered, matching the existing
   `getCustomTitle()` guard
+- The `Cacheable` and `Deferrable` repository concerns can now be used on the same repository.
+  Both previously declared `boot()`, so combining them raised a fatal trait-method collision; each
+  now boots through a dedicated `bootCacheable()` / `bootDeferrable()` hook invoked by the base
+  repository. (Deferred writes still bypass the per-query cache - flush it manually or rely on its
+  TTL; this is documented on the `Deferrable` trait.)
 
 ### Security
 

--- a/src/Repositories/ApiRepository.php
+++ b/src/Repositories/ApiRepository.php
@@ -163,6 +163,30 @@ abstract class ApiRepository extends Repository
 
         $this->attributeSetter = new AttributeSetter($schemaIntrospector);
         $this->attributeSetter->resolveAttributeCasts($this->model, $this->model());
+
+        $this->bootConcerns();
+    }
+
+    /**
+     * Boot each used concern that exposes a boot{Concern} hook.
+     *
+     * Concerns such as Cacheable and Deferrable each need boot-time setup but
+     * cannot both override boot() without a fatal trait collision, so the base
+     * repository invokes their dedicated boot hooks here instead. This lets a
+     * single repository safely use more than one bootable concern.
+     *
+     * @return void
+     */
+    private function bootConcerns(): void
+    {
+        foreach (class_uses_recursive(static::class) as $concern) {
+
+            $method = 'boot' . class_basename($concern);
+
+            if (method_exists($this, $method)) {
+                $this->{$method}(); // @phpstan-ignore method.dynamicName
+            }
+        }
     }
 
     /**

--- a/src/Repositories/Concerns/Cacheable.php
+++ b/src/Repositories/Concerns/Cacheable.php
@@ -108,18 +108,19 @@ trait Cacheable
     }
 
     /**
-     * Boot the repository instance.
+     * Boot the cacheable concern.
+     *
+     * Invoked by ApiRepository::bootConcerns() rather than overriding boot()
+     * directly, so the concern can coexist with other bootable concerns (e.g.
+     * Deferrable) without a fatal trait collision.
      *
      * @return void
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
-    #[\Override]
-    protected function boot(): void
+    protected function bootCacheable(): void
     {
-        parent::boot();
-
         $table = $this->getModel()->getTable();
         $store = $this->resolveProperty('cacheStoreName') ?? Config::get('api-toolkit.repositories.cache.store') ?? Config::get('cache.default');
         $store = is_string($store) ? $store : 'array';

--- a/src/Repositories/Concerns/Deferrable.php
+++ b/src/Repositories/Concerns/Deferrable.php
@@ -19,6 +19,14 @@ namespace SineMacula\ApiToolkit\Repositories\Concerns;
  * pool for the next boundary; use the log strategy for fire-and-forget
  * writes that may be dropped.
  *
+ * Cache interaction: this concern now coexists with Cacheable on the same
+ * repository (each boots via its own boot{Concern} hook). Note, however, that
+ * deferred writes are persisted through the write pool's bulk INSERT, which
+ * bypasses the per-query cache invalidation that fires only on the repository's
+ * own write verbs. A deferred write therefore leaves any per-query cache for
+ * that table stale until its TTL; call flushCache() after the boundary flush,
+ * or rely on the TTL, when read-after-deferred-write consistency is required.
+ *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
@@ -63,15 +71,16 @@ trait Deferrable
     }
 
     /**
-     * Boot the repository instance.
+     * Boot the deferrable concern.
+     *
+     * Invoked by ApiRepository::bootConcerns() rather than overriding boot()
+     * directly, so the concern can coexist with other bootable concerns (e.g.
+     * Cacheable) without a fatal trait collision.
      *
      * @return void
      */
-    #[\Override]
-    protected function boot(): void
+    protected function bootDeferrable(): void
     {
-        parent::boot();
-
         $this->writePool = $this->app->make(WritePool::class);
     }
 }

--- a/tests/Fixtures/Repositories/CacheableDeferrableTagRepository.php
+++ b/tests/Fixtures/Repositories/CacheableDeferrableTagRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Fixtures\Repositories;
+
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\ApiToolkit\Repositories\Concerns\Cacheable;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use Tests\Fixtures\Models\Tag;
+
+/**
+ * Fixture repository that uses both the Cacheable and Deferrable concerns, to
+ * prove they coexist on one repository without a boot() collision.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ *
+ * @extends \SineMacula\ApiToolkit\Repositories\ApiRepository<\Tests\Fixtures\Models\Tag>
+ */
+class CacheableDeferrableTagRepository extends ApiRepository
+{
+    use Cacheable;
+    use Deferrable;
+
+    /**
+     * Return the model class.
+     *
+     * @return class-string<\Tests\Fixtures\Models\Tag>
+     */
+    public function model(): string
+    {
+        return Tag::class;
+    }
+}

--- a/tests/Unit/Repositories/Concerns/CacheableDeferrableTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheableDeferrableTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Repositories\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Fixtures\Models\Tag;
+use Tests\Fixtures\Repositories\CacheableDeferrableTagRepository;
+use Tests\TestCase;
+
+/**
+ * Tests that the Cacheable and Deferrable concerns coexist on a single
+ * repository without a boot() collision.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+class CacheableDeferrableTest extends TestCase
+{
+    /**
+     * Set up the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Tag::create(['name' => 'php']);
+        Tag::create(['name' => 'laravel']);
+    }
+
+    /**
+     * Test that a repository using both Cacheable and Deferrable boots without a
+     * trait collision and that both concerns are functional: the cache is
+     * populated on read and a deferred write is persisted on flush.
+     *
+     * @return void
+     */
+    public function testCacheableAndDeferrableConcernsCoexist(): void
+    {
+        assert($this->app !== null);
+
+        $repository = $this->app->make(CacheableDeferrableTagRepository::class);
+
+        // Cacheable booted: a read populates the per-query cache.
+        $result = $repository->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+        static::assertInstanceOf(Collection::class, $result);
+        static::assertTrue($repository->getCacheStatus()->isPopulated());
+
+        // Deferrable booted: a deferred write is buffered then persisted.
+        $repository->defer(['name' => 'deferred']);
+        $flush = $repository->flushWrites();
+
+        static::assertTrue($flush->isSuccessful());
+        $this->assertDatabaseHas('tags', ['name' => 'deferred']);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses **BL-11**. `Cacheable` and `Deferrable` both declared `protected function boot()`, so a repository doing `use Cacheable, Deferrable` raised a **fatal trait-method collision** - the class could not even be loaded, and the two concerns could not be combined.

## Fix

Each concern now boots through a dedicated hook instead of overriding `boot()`:

- `Cacheable::boot()` → `Cacheable::bootCacheable()`
- `Deferrable::boot()` → `Deferrable::bootDeferrable()`
- `ApiRepository::boot()` runs a `bootConcerns()` pass that calls `boot{Concern}()` for each used trait (`class_uses_recursive` + `method_exists`), so any number of bootable concerns coexist.

The boot order and behaviour for repositories using a single concern are unchanged (the base sets up its `attributeSetter` then boots concerns, matching the prior `parent::boot()` chain).

## The cache-staleness half (documented, not auto-fixed)

The backlog also notes that deferred writes leave the per-query cache stale (they persist via the write pool's bulk `INSERT`, bypassing `Cacheable`'s write-verb invalidation). Auto-invalidating across the **shared, boundary-flushed** write pool is a cross-collaborator design change (it needs a table → cache-store mapping), so this PR **documents** the interaction on the `Deferrable` trait (flush the cache manually after the boundary flush, or rely on the TTL) rather than rushing a best-effort coupling. Happy to follow up with the automatic invalidation as its own PR if you want it.

## Tests

- New `CacheableDeferrableTagRepository` fixture uses **both** concerns; a regression test asserts it boots and that **both** are functional (cache populated on read, deferred write persisted on flush). Pre-fix this fixture could not load at all (fatal collision), which is the proof.
- All existing `Cacheable` / `Deferrable` tests pass unchanged (the `boot` rename is transparent; `testBootInvokesParentBootChain` still confirms the `attributeSetter` is initialised).
- Full suite green (**1893 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI, no escaped mutants in `ApiRepository`).

## Notes

No `docs/` files touched.