### PR TITLE
fix(middleware): key the request throttle by client IP for anonymous requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,6 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
   (`password`, `*token*`, `*secret*`, and `authorization` by default, matched case-insensitively
   and recursively) are redacted from the request data written to the `api-exceptions` log context,
   preventing credentials from leaking to logs and CloudWatch (CWE-532)
+- The request throttle key now includes the client IP for unauthenticated requests, so anonymous
+  callers no longer share a single rate-limit bucket per endpoint - one caller could previously
+  exhaust it and 429-lock every other anonymous caller

--- a/src/Http/Middleware/Traits/ThrottleRequestsTrait.php
+++ b/src/Http/Middleware/Traits/ThrottleRequestsTrait.php
@@ -35,11 +35,14 @@ trait ThrottleRequestsTrait
 
         $server_name = $request->server('SERVER_NAME');
 
+        // Key by the authenticated user when present, otherwise by the client
+        // IP, so anonymous callers do not all share a single throttle bucket
+        // (which would let one caller rate-limit every other anonymous caller).
         return sha1(
             $request->method()
             . '|' . (is_string($server_name) ? $server_name : '')
             . '|' . $request->path()
-            . '|' . $request->user()?->getAuthIdentifier(),
+            . '|' . ($request->user()?->getAuthIdentifier() ?? $request->ip()),
         );
     }
 }

--- a/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
+++ b/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
@@ -78,9 +78,8 @@ class ThrottleRequestsTraitTest extends TestCase
     /**
      * Test that the signature handles unauthenticated users.
      *
-     * Due to operator precedence, the null coalescing operator applies to the
-     * entire concatenated string when user is null. Since string concatenation
-     * with null produces a non-null string, the IP fallback is not used.
+     * An unauthenticated request is keyed by its client IP, so anonymous
+     * callers each get their own throttle bucket instead of sharing one.
      *
      * @return void
      */
@@ -90,9 +89,29 @@ class ThrottleRequestsTraitTest extends TestCase
         $request = $this->createRequestWithRoute(self::API_DATA_URI, HttpMethod::GET->getVerb(), '192.168.1.50');
 
         $result   = $trait->resolveRequestSignature($request); // @phpstan-ignore method.notFound
-        $expected = sha1('GET|localhost|api/data|');
+        $expected = sha1('GET|localhost|api/data|192.168.1.50');
 
         static::assertSame($expected, $result);
+    }
+
+    /**
+     * Test that two unauthenticated requests to the same endpoint from
+     * different client IPs produce different signatures, so one anonymous
+     * caller cannot exhaust the shared throttle bucket for everyone.
+     *
+     * @return void
+     */
+    public function testSignatureDiffersByClientIpForUnauthenticatedRequests(): void
+    {
+        $trait = $this->createTraitInstance();
+
+        $first  = $this->createRequestWithRoute(self::API_DATA_URI, HttpMethod::GET->getVerb(), '203.0.113.1');
+        $second = $this->createRequestWithRoute(self::API_DATA_URI, HttpMethod::GET->getVerb(), '203.0.113.2');
+
+        $firstSignature  = $trait->resolveRequestSignature($first);  // @phpstan-ignore method.notFound
+        $secondSignature = $trait->resolveRequestSignature($second); // @phpstan-ignore method.notFound
+
+        static::assertNotSame($firstSignature, $secondSignature);
     }
 
     /**
@@ -158,7 +177,7 @@ class ThrottleRequestsTraitTest extends TestCase
 
         $result = $middleware->callResolveRequestSignature($request);
 
-        static::assertSame(sha1('GET|localhost|api/data|'), $result);
+        static::assertSame(sha1('GET|localhost|api/data|127.0.0.1'), $result);
     }
 
     /**


### PR DESCRIPTION
## Summary

Addresses the **anonymous-throttle** item of **BL-15**. `ThrottleRequestsTrait::resolveRequestSignature()` built the throttle key as `sha1(method | server_name | path | user_id)`. For an unauthenticated request `user_id` is `null`, so **every anonymous caller to a given endpoint shared one rate-limit bucket** - a single caller could exhaust it and `429`-lock every other anonymous caller (DoS amplification).

A code comment / test even documented the latent cause: a previous `?? $request->ip()` fallback was dead code because `??` binds looser than `.`, so it applied to the whole concatenated (non-null) string.

## Fix

Key by the authenticated user when present, otherwise by the **client IP**, with the identifier parenthesised so the coalesce binds correctly:

```php
. '|' . ($request->user()?->getAuthIdentifier() ?? $request->ip())
```

This matches Laravel's own `ThrottleRequests` convention (user id when authenticated, IP otherwise). Authenticated requests are unchanged (still keyed by user id, IP-independent).

## Tests

- Two existing tests that asserted the IP-less signature (`sha1('...|')`) are corrected to the new behaviour (the unauthenticated key now includes the IP).
- New regression: two anonymous requests to the same endpoint from different IPs (`203.0.113.1` vs `.2`) produce **different** signatures. Verified to fail on the pre-fix code (identical signatures).
- Full suite green (**1893 tests**); `qlty check` clean; `composer test:mutation` passes (94% MSI, no escaped mutants in the changed file).

## Notes

The remaining BL-15 items (the `searchable_exclusions` default and the relation-traversal allowlist) are subsumed by the BL-20 filter/sort posture decision and are best handled there. No `docs/` files touched.