### PR TITLE
perf(resources): memoise serialization hot-path reflection and eager-load maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - `Service::run()` returns an immutable `ServiceResult` value object instead of `bool`
 - HTTP enums are provided by `sinemacula/http-primitives-php`
 - Request capabilities are exposed through the typed `RequestCapabilities` API; the request macros are deprecated
+- Resource serialization memoises its hot-path lookups: `ValueResolver` caches the per-`(class, field)`
+  cast-accessor reflection result and the per-definition child field set, and `EagerLoadPlanner` caches the
+  eager-load and count maps per request. The memos are static but request-scoped - `CacheManager::flush()` clears
+  them at request and worker boundaries (Octane, queues) - so repeated reads no longer re-reflect or rebuild the
+  same map once per record
 
 ### Added
 

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\SchemaCompiler;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
 
 /**
  * Centralized orchestrator for flushing all toolkit caches.
@@ -43,6 +45,8 @@ final class CacheManager
         Cache::memo()->getStore()->flush();
 
         SchemaCompiler::clearCache();
+        ValueResolver::clearCache();
+        EagerLoadPlanner::clearCache();
 
         $this->container->make(SchemaIntrospectionProvider::class)->flush();
 

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -24,11 +24,22 @@ use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition;
  */
 final class EagerLoadPlanner
 {
+    /** @var array<string, array<int|string, mixed>> Memo of eager-load maps, keyed by resource class + field signature. */
+    private static array $eagerLoadCache = [];
+
+    /** @var array<string, array<int|string, mixed>> Memo of count maps, keyed by resource class + alias signature. */
+    private static array $countCache = [];
+
     /**
      * Build a with()-ready eager-load map for the given fields.
      *
      * Returns a mixed array where numeric keys are plain eager-load paths and
      * string keys are scoped paths with constraint closures.
+     *
+     * The result is memoised per (resource class, field signature); the memo is
+     * request-scoped because CacheManager::flush() clears it at request and
+     * worker boundaries, so it never serves a map built against a different
+     * request's child field selection.
      *
      * @param  string  $resourceClass
      * @param  array<int, string>  $fields
@@ -36,17 +47,34 @@ final class EagerLoadPlanner
      */
     public static function buildEagerLoadMap(string $resourceClass, array $fields): array
     {
+        $key = $resourceClass . '|' . implode("\0", $fields);
+
+        if (isset(self::$eagerLoadCache[$key])) {
+            return self::$eagerLoadCache[$key];
+        }
+
         $plain   = [];
         $scoped  = [];
         $visited = [];
 
         self::walkRelations($resourceClass, $fields, '', $plain, $scoped, $visited);
 
-        if ($plain === [] && $scoped === []) {
-            return [];
-        }
+        $map = $plain === [] && $scoped === [] ? [] : array_merge($plain, $scoped);
 
-        return array_merge($plain, $scoped);
+        return self::$eagerLoadCache[$key] = $map;
+    }
+
+    /**
+     * Clear the static eager-load and count map memos.
+     *
+     * Invoked by CacheManager::flush() at request and worker boundaries.
+     *
+     * @return void
+     */
+    public static function clearCache(): void
+    {
+        self::$eagerLoadCache = [];
+        self::$countCache     = [];
     }
 
     /**
@@ -61,6 +89,11 @@ final class EagerLoadPlanner
      */
     public static function buildCountMap(string $resourceClass, ?array $requestedAliases = null): array
     {
+        $key = $resourceClass . '|' . ($requestedAliases === null ? '*' : implode("\0", $requestedAliases));
+
+        if (isset(self::$countCache[$key])) {
+            return self::$countCache[$key];
+        }
 
         $schema = SchemaCompiler::compile($resourceClass);
         $with   = [];
@@ -85,7 +118,7 @@ final class EagerLoadPlanner
             }
         }
 
-        return $with;
+        return self::$countCache[$key] = $with;
     }
 
     /**

--- a/src/Http/Resources/Concerns/ValueResolver.php
+++ b/src/Http/Resources/Concerns/ValueResolver.php
@@ -25,6 +25,12 @@ use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema;
  */
 final class ValueResolver
 {
+    /** @var array<string, array<string, bool>> Memo of cast-accessor reflection results, keyed by [class][field]. */
+    private static array $castAccessorCache = [];
+
+    /** @var \WeakMap<\SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition, array<int, string>|null>|null Memo of resolved child field sets, keyed by compiled definition. */
+    private static ?\WeakMap $relationFieldsCache = null;
+
     /**
      * Create a new value resolver instance.
      *
@@ -36,6 +42,22 @@ final class ValueResolver
         private readonly GuardEvaluator $guardEvaluator,
 
     ) {}
+
+    /**
+     * Clear the static serialization memo caches.
+     *
+     * Invoked by CacheManager::flush() at request and worker boundaries so the
+     * per-(class, field) cast-accessor results and per-definition child field
+     * sets do not leak across requests under long-running runtimes (Octane,
+     * queues).
+     *
+     * @return void
+     */
+    public static function clearCache(): void
+    {
+        self::$castAccessorCache   = [];
+        self::$relationFieldsCache = null;
+    }
 
     /**
      * Resolve a single field's value from the schema definition.
@@ -194,6 +216,23 @@ final class ValueResolver
      */
     private function isCastAccessor(object $model, string $field): bool
     {
+        return self::$castAccessorCache[$model::class][$field] ??= $this->computeIsCastAccessor($model, $field);
+    }
+
+    /**
+     * Determine, via reflection, whether the field is an Eloquent cast accessor
+     * (returns Attribute).
+     *
+     * Isolated from isCastAccessor() so the expensive ReflectionMethod
+     * construction runs at most once per (class, field) on the serialization
+     * hot path.
+     *
+     * @param  object  $model
+     * @param  string  $field
+     * @return bool
+     */
+    private function computeIsCastAccessor(object $model, string $field): bool
+    {
         if (!method_exists($model, $field)) {
             return false;
         }
@@ -332,15 +371,24 @@ final class ValueResolver
      */
     private function getRelationFields(CompiledFieldDefinition $definition): ?array
     {
-        $fields = $definition->fields;
+        self::$relationFieldsCache ??= new \WeakMap;
 
-        if (!is_array($fields)) {
-            return null;
+        if (isset(self::$relationFieldsCache[$definition])) {
+            return self::$relationFieldsCache[$definition];
         }
 
-        $fields = array_values(array_filter($fields, static fn ($f) => is_string($f) && $f !== '')); // @phpstan-ignore function.alreadyNarrowedType
+        $fields = $definition->fields;
 
-        return $fields === [] ? [] : $fields;
+        // Resolve once per compiled definition rather than once per parent
+        // record on the serialization hot path; null when no explicit child
+        // field set was declared.
+        if (is_array($fields)) {
+            $fields = array_values(array_filter($fields, static fn ($f) => is_string($f) && $f !== '')); // @phpstan-ignore function.alreadyNarrowedType
+        } else {
+            $fields = null;
+        }
+
+        return self::$relationFieldsCache[$definition] = $fields;
     }
 
     /**

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -9,7 +9,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Cache\CacheManager;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\SchemaCompiler;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\TestCase;
 
@@ -70,6 +72,50 @@ class CacheManagerTest extends TestCase
 
         // Assert
         static::assertSame([], $this->getStaticProperty(SchemaCompiler::class, 'cache'));
+    }
+
+    /**
+     * Test that flush clears the ValueResolver serialization memo caches.
+     *
+     * @return void
+     */
+    public function testFlushClearsValueResolverCache(): void
+    {
+        // Arrange
+        Event::fake();
+
+        $this->setStaticProperty(ValueResolver::class, 'castAccessorCache', ['FakeModel' => ['field' => true]]);
+
+        static::assertNotEmpty($this->getStaticProperty(ValueResolver::class, 'castAccessorCache'));
+
+        // Act
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        static::assertSame([], $this->getStaticProperty(ValueResolver::class, 'castAccessorCache'));
+    }
+
+    /**
+     * Test that flush clears the EagerLoadPlanner static memo caches.
+     *
+     * @return void
+     */
+    public function testFlushClearsEagerLoadPlannerCache(): void
+    {
+        // Arrange
+        Event::fake();
+
+        $this->setStaticProperty(EagerLoadPlanner::class, 'eagerLoadCache', ['FakeResource|fields' => ['relation']]);
+
+        static::assertNotEmpty($this->getStaticProperty(EagerLoadPlanner::class, 'eagerLoadCache'));
+
+        // Act
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        static::assertSame([], $this->getStaticProperty(EagerLoadPlanner::class, 'eagerLoadCache'));
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -7,6 +7,7 @@ use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\SchemaCompiler;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Resources\OrganizationResource;
 use Tests\Fixtures\Resources\PostResource;
 use Tests\Fixtures\Resources\TagResource;
@@ -24,8 +25,10 @@ use Tests\TestCase;
 #[CoversClass(EagerLoadPlanner::class)]
 class EagerLoadPlannerTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /**
-     * Clear the schema compiler cache before each test.
+     * Clear the schema compiler and planner caches before each test.
      *
      * @return void
      */
@@ -34,16 +37,18 @@ class EagerLoadPlannerTest extends TestCase
         parent::setUp();
 
         SchemaCompiler::clearCache();
+        EagerLoadPlanner::clearCache();
     }
 
     /**
-     * Clear the schema compiler cache after each test.
+     * Clear the schema compiler and planner caches after each test.
      *
      * @return void
      */
     protected function tearDown(): void
     {
         SchemaCompiler::clearCache();
+        EagerLoadPlanner::clearCache();
 
         parent::tearDown();
     }
@@ -365,6 +370,74 @@ class EagerLoadPlannerTest extends TestCase
         $result = EagerLoadPlanner::buildEagerLoadMap(UserResource::class, ['organization']);
 
         static::assertContains('organization', $result);
+    }
+
+    /**
+     * Test that repeated calls with the same class and fields are served from
+     * the memo, so the child field lookup runs only once.
+     *
+     * @return void
+     */
+    public function testBuildEagerLoadMapIsMemoisedAcrossRepeatedCalls(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->once()
+            ->with('organizations')
+            ->andReturn(['id']);
+
+        $first  = EagerLoadPlanner::buildEagerLoadMap(UserResource::class, ['organization']);
+        $second = EagerLoadPlanner::buildEagerLoadMap(UserResource::class, ['organization']);
+
+        static::assertSame($first, $second);
+    }
+
+    /**
+     * Test that clearing the cache forces a full rebuild on the next call, so
+     * the child field lookup runs again.
+     *
+     * @return void
+     */
+    public function testClearCacheForcesEagerLoadMapRebuild(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->twice()
+            ->with('organizations')
+            ->andReturn(['id']);
+
+        EagerLoadPlanner::buildEagerLoadMap(UserResource::class, ['organization']);
+        EagerLoadPlanner::clearCache();
+        EagerLoadPlanner::buildEagerLoadMap(UserResource::class, ['organization']);
+    }
+
+    /**
+     * Test that a memoised count map is returned without rebuilding.
+     *
+     * @return void
+     */
+    public function testBuildCountMapReturnsMemoisedResult(): void
+    {
+        $this->setStaticProperty(EagerLoadPlanner::class, 'countCache', [UserResource::class . '|*' => ['sentinel_count']]);
+
+        $result = EagerLoadPlanner::buildCountMap(UserResource::class);
+
+        static::assertSame(['sentinel_count'], $result);
+    }
+
+    /**
+     * Test that the eager-load memo is keyed by resource class and field
+     * signature, so a seeded entry is returned only for the exact key.
+     *
+     * @return void
+     */
+    public function testBuildEagerLoadMapReturnsMemoisedResultForKey(): void
+    {
+        $this->setStaticProperty(EagerLoadPlanner::class, 'eagerLoadCache', [UserResource::class . '|' . 'organization' => ['sentinel_relation']]);
+
+        $result = EagerLoadPlanner::buildEagerLoadMap(UserResource::class, ['organization']);
+
+        static::assertSame(['sentinel_relation'], $result);
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Http\Resources\Concerns;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
@@ -13,6 +14,7 @@ use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
 use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledCountDefinition;
 use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Http\Resources\Schema\CompiledSchema;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
@@ -32,6 +34,8 @@ use Tests\TestCase;
 #[CoversClass(ValueResolver::class)]
 class ValueResolverTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /** @var \SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver */
     private ValueResolver $resolver;
 
@@ -45,7 +49,189 @@ class ValueResolverTest extends TestCase
     {
         parent::setUp();
 
+        ValueResolver::clearCache();
+
         $this->resolver = new ValueResolver(new GuardEvaluator);
+    }
+
+    /**
+     * Clear the static memo caches after each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ValueResolver::clearCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the cast-accessor reflection result is memoised per class and
+     * field after the first resolution.
+     *
+     * @return void
+     */
+    public function testCastAccessorReflectionIsMemoisedPerClassAndField(): void
+    {
+
+        $model = new class {
+            /**
+             * A cast accessor returning an Attribute instance.
+             *
+             * @return \Illuminate\Database\Eloquent\Casts\Attribute
+             */
+            public function nickname(): Attribute
+            {
+                return Attribute::make(get: fn () => 'Nick');
+            }
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+
+            /**
+             * Magic getter resolving the cast accessor value.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return 'Nick';
+            }
+        };
+
+        $result = $this->resolver->resolveFieldValue('nickname', $this->makeFieldDefinition(), new JsonResource($model), null);
+
+        static::assertSame('Nick', $result);
+
+        $cache = $this->getStaticProperty(ValueResolver::class, 'castAccessorCache');
+
+        static::assertTrue($cache[$model::class]['nickname']);
+    }
+
+    /**
+     * Test that a seeded cast-accessor memo short-circuits the reflection, so
+     * the cached decision is honoured rather than recomputed.
+     *
+     * @return void
+     */
+    public function testCastAccessorMemoShortCircuitsReflection(): void
+    {
+
+        $model = new class {
+            /**
+             * A plain method whose return type is not an Attribute.
+             *
+             * @return string
+             */
+            public function label(): string
+            {
+                return 'real';
+            }
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+
+            /**
+             * Magic getter used when the field resolves via the memoised path.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return 'from-memo';
+            }
+        };
+
+        // Seed a decision reflection would never produce: label() returns string,
+        // not Attribute, so an honoured memo yields the __get value while a
+        // recomputation would yield MissingValue.
+        $this->setStaticProperty(ValueResolver::class, 'castAccessorCache', [$model::class => ['label' => true]]);
+
+        $result = $this->resolver->resolveFieldValue('label', $this->makeFieldDefinition(), new JsonResource($model), null);
+
+        static::assertSame('from-memo', $result);
+    }
+
+    /**
+     * Test that the resolved child field set is memoised per compiled
+     * definition.
+     *
+     * @return void
+     */
+    public function testRelationFieldsAreMemoisedPerDefinition(): void
+    {
+        // A leading empty entry makes the array_values re-index observable: a
+        // plain array_filter would leave the kept entries on keys 1 and 2.
+        $definition = $this->makeFieldDefinition(fields: ['', 'id', 'name']);
+
+        $first  = $this->invokeMethod($this->resolver, 'getRelationFields', $definition);
+        $second = $this->invokeMethod($this->resolver, 'getRelationFields', $definition);
+
+        static::assertSame(['id', 'name'], $first);
+        static::assertSame($first, $second);
+
+        $cache = $this->getStaticProperty(ValueResolver::class, 'relationFieldsCache');
+
+        static::assertInstanceOf(\WeakMap::class, $cache);
+        static::assertCount(1, $cache);
+        static::assertTrue($cache->offsetExists($definition));
+    }
+
+    /**
+     * Test that a seeded child-field memo is consulted rather than recomputed.
+     *
+     * @return void
+     */
+    public function testRelationFieldsMemoIsConsulted(): void
+    {
+        $definition = $this->makeFieldDefinition(fields: ['id', 'name']);
+
+        $weakMap              = new \WeakMap;
+        $weakMap[$definition] = ['sentinel_field'];
+
+        $this->setStaticProperty(ValueResolver::class, 'relationFieldsCache', $weakMap);
+
+        $result = $this->invokeMethod($this->resolver, 'getRelationFields', $definition);
+
+        static::assertSame(['sentinel_field'], $result);
+    }
+
+    /**
+     * Test that clearing the cache empties both serialization memo caches.
+     *
+     * @return void
+     */
+    public function testClearCacheEmptiesMemoCaches(): void
+    {
+        $definition           = $this->makeFieldDefinition(fields: ['id']);
+        $weakMap              = new \WeakMap;
+        $weakMap[$definition] = ['id'];
+
+        $this->setStaticProperty(ValueResolver::class, 'castAccessorCache', ['Foo' => ['bar' => true]]);
+        $this->setStaticProperty(ValueResolver::class, 'relationFieldsCache', $weakMap);
+
+        ValueResolver::clearCache();
+
+        static::assertSame([], $this->getStaticProperty(ValueResolver::class, 'castAccessorCache'));
+        static::assertNull($this->getStaticProperty(ValueResolver::class, 'relationFieldsCache'));
     }
 
     /**


### PR DESCRIPTION
## Summary

Resolves **BL-16 #1 and #2** - serialization hot-path performance. Behaviour-preserving memoisation of the per-record work the resource layer repeats across a page of records:

- **`ValueResolver`** caches the per-`(class, field)` cast-accessor reflection result (the `new \ReflectionMethod` in `isCastAccessor`, previously run for every field of every record) and the per-definition resolved child field set (`getRelationFields`).
- **`EagerLoadPlanner`** caches the eager-load map and the count map per `(resource class, field signature)`, so the map is built once per request rather than once per record (`loadMissingRelations` runs in each resource constructor).

### Request-scoped, not process-global

The memos are static but cleared by `CacheManager::flush()`, which already runs at request and worker boundaries (`OctaneFlushListener` on `OperationTerminated`, `QueueFlushSubscriber`); FPM gets a fresh process per request. This is the same basis `SchemaCompiler`'s static cache relies on. Because the eager-load map depends on per-request child field selection (`ApiQuery::getFields`), request-scoping is what guarantees it never serves a map built against a different request - no new request-signature plumbing or public API was needed.

### Out of scope

- The `getAttributes()`-once-per-record sub-item of BL-16 #1 is intentionally **not** included: `Model::getAttributes()` is copy-on-write and the call sites only do `array_key_exists` + a live read, so the COW copy is never realised - memoising it would add staleness risk for no real gain.
- BL-16 #4 (negative caching of null/miss reads) is a separate follow-up PR.

## Verification

- `composer test` - 1907 pass (1 pre-existing skip)
- `composer test:mutation` - Covered MSI 94% (meets the `--min-msi=94 --min-covered-msi=94` gate); changed-line MSI 100%
- `composer check` (qlty diff mode vs `2.x`) - no new issues
- New tests cover memo population, short-circuit (seeded sentinels prove the reflection/rebuild is skipped), `clearCache`, and `CacheManager::flush` clearing both caches; red-green verified