### PR TITLE
perf(repositories): negatively cache null/miss reads with a short negative TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - `Service::run()` returns an immutable `ServiceResult` value object instead of `bool`
 - HTTP enums are provided by `sinemacula/http-primitives-php`
 - Request capabilities are exposed through the typed `RequestCapabilities` API; the request macros are deprecated
+- The transparent repository cache now negatively caches null/miss reads under a separate, shorter
+  `negative_ttl` (default 10s), so a repeated lookup for a missing key is served from cache instead of
+  re-querying every time. The short TTL bounds stale-null visibility and probe-fill memory, and a write
+  still invalidates the negative entry like any other
 
 ### Added
 

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -204,6 +204,7 @@ return [
     |   - `max_rows`        → `protected ?int $cacheMaxRows`
     |   - `max_bytes`       → `protected ?int $cacheMaxBytes`
     |   - `reference_ttl`   → `protected int $cacheReferenceTtl`
+    |   - `negative_ttl`    → `protected ?int $cacheNegativeTtl`
     |   - (key prefix)      → `protected ?string $cacheKeyPrefix`
     |   - (reference mode)  → `protected bool $cacheReferenceTable`
     |
@@ -212,7 +213,10 @@ return [
     | to disable that bound. `registry_enabled` controls how non-taggable stores
     | invalidate per-query entries: when true a per-table key registry is kept so
     | every live entry can be forgotten on a write; when false invalidation falls
-    | back to TTL expiry only (a documented degraded behaviour).
+    | back to TTL expiry only (a documented degraded behaviour). `negative_ttl` is
+    | the shorter lifetime applied to negatively cached null/miss reads, bounding
+    | how long a stale "not found" is served and how much memory probe-fill can
+    | occupy; it defaults to 10 seconds.
     |
     */
 
@@ -229,6 +233,8 @@ return [
             'max_bytes' => is_numeric($cache_max_bytes = env('API_TOOLKIT_REPOSITORY_CACHE_MAX_BYTES', 262144)) ? (int) $cache_max_bytes : 262144,
 
             'reference_ttl' => is_numeric($cache_reference_ttl = env('API_TOOLKIT_REPOSITORY_CACHE_REFERENCE_TTL', 3600)) ? (int) $cache_reference_ttl : 3600,
+
+            'negative_ttl' => is_numeric($cache_negative_ttl = env('API_TOOLKIT_REPOSITORY_CACHE_NEGATIVE_TTL', 10)) ? (int) $cache_negative_ttl : 10,
 
             'registry_enabled' => env('API_TOOLKIT_REPOSITORY_CACHE_REGISTRY_ENABLED', true),
 

--- a/src/Repositories/Concerns/CacheMiss.php
+++ b/src/Repositories/Concerns/CacheMiss.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Repositories\Concerns;
+
+/**
+ * Marker stored in the per-query cache to represent a negatively cached
+ * null/miss read.
+ *
+ * A dedicated marker type lets the cache distinguish "this query was executed
+ * and returned nothing" from an absent entry, without colliding with any real
+ * repository result (no query result is an instance of this class) and while
+ * surviving serialization on non-array cache stores - it is matched via
+ * instanceof rather than object identity.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class CacheMiss {}

--- a/src/Repositories/Concerns/CacheStore.php
+++ b/src/Repositories/Concerns/CacheStore.php
@@ -67,12 +67,17 @@ final class CacheStore
     /**
      * Get the cached result for the given query fingerprint, or null on a miss.
      *
+     * A negatively cached read is stored as a CacheMiss marker and translated
+     * back to null here, so callers see a transparent null on a negative hit.
+     *
      * @param  string  $hash
      * @return mixed
      */
     public function get(string $hash): mixed
     {
-        return $this->scopedStore()->get($this->keyFor($hash));
+        $value = $this->scopedStore()->get($this->keyFor($hash));
+
+        return $value instanceof CacheMiss ? null : $value;
     }
 
     /**
@@ -102,6 +107,23 @@ final class CacheStore
 
         $this->scopedStore()->put($this->keyFor($hash), $result, $this->options->ttl);
         $this->store->put($this->metaKey, ['populated_at' => now()->timestamp], $this->options->ttl);
+    }
+
+    /**
+     * Store a negative (null/miss) marker for a query fingerprint under the
+     * shorter negative TTL.
+     *
+     * The marker is scoped to the table tag/version like any other entry, so a
+     * write still invalidates it; it bypasses the size guard because it is a
+     * constant-size sentinel, and it does not touch the populated_at metadata
+     * because it represents the absence of data rather than cached data.
+     *
+     * @param  string  $hash
+     * @return void
+     */
+    public function putMiss(string $hash): void
+    {
+        $this->scopedStore()->put($this->keyFor($hash), new CacheMiss, $this->options->negativeTtl);
     }
 
     /**

--- a/src/Repositories/Concerns/CacheStoreOptions.php
+++ b/src/Repositories/Concerns/CacheStoreOptions.php
@@ -5,9 +5,10 @@ namespace SineMacula\ApiToolkit\Repositories\Concerns;
 /**
  * Immutable configuration bundle for a per-query repository cache store.
  *
- * Groups the correlated tuning parameters — lifetime, size guard, and registry
- * behaviour — so the cache store constructor stays within the parameter limit
- * and the options can be resolved once at boot.
+ * Groups the correlated tuning parameters — lifetime, size guard, registry
+ * behaviour, and negative-lookup lifetime — so the cache store constructor
+ * stays within the parameter limit and the options can be resolved once at
+ * boot.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -20,11 +21,13 @@ final readonly class CacheStoreOptions
      * @param  int  $ttl
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\CacheSizeGuard  $sizeGuard
      * @param  bool  $registryEnabled
+     * @param  int  $negativeTtl
      * @return void
      */
     public function __construct(
         public int $ttl,
         public CacheSizeGuard $sizeGuard,
         public bool $registryEnabled,
+        public int $negativeTtl,
     ) {}
 }

--- a/src/Repositories/Concerns/Cacheable.php
+++ b/src/Repositories/Concerns/Cacheable.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Config;
  *   - `protected ?int $cacheMaxRows` — size guard row ceiling
  *   - `protected ?int $cacheMaxBytes` — size guard byte ceiling
  *   - `protected int $cacheReferenceTtl` — reference-mode cache duration
+ *   - `protected ?int $cacheNegativeTtl` — null/miss cache duration
  *   - `protected bool $cacheReferenceTable = true` — opt into whole-table mode
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
@@ -203,6 +204,8 @@ trait Cacheable
 
         if ($result !== null) {
             $this->cacheStore->put($hash, $result, $this->rowCount($result));
+        } else {
+            $this->cacheStore->putMiss($hash);
         }
 
         return parent::resetAndReturn($result);
@@ -321,6 +324,18 @@ trait Cacheable
     }
 
     /**
+     * Resolve the configured negative-lookup (null/miss) cache TTL.
+     *
+     * @return int
+     */
+    private function resolveNegativeTtl(): int
+    {
+        $ttl = $this->resolveProperty('cacheNegativeTtl') ?? Config::get('api-toolkit.repositories.cache.negative_ttl', 10);
+
+        return is_numeric($ttl) ? (int) $ttl : 10;
+    }
+
+    /**
      * Resolve the per-query cache store options from properties and config.
      *
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\CacheStoreOptions
@@ -330,7 +345,7 @@ trait Cacheable
         $registryEnabled = $this->resolveProperty('cacheRegistryEnabled')
             ?? Config::get('api-toolkit.repositories.cache.registry_enabled', true);
 
-        return new CacheStoreOptions($this->resolveTtl(), $this->resolveSizeGuard(), (bool) $registryEnabled);
+        return new CacheStoreOptions($this->resolveTtl(), $this->resolveSizeGuard(), (bool) $registryEnabled, $this->resolveNegativeTtl());
     }
 
     /**

--- a/tests/Fixtures/Repositories/TunedCacheableTagRepository.php
+++ b/tests/Fixtures/Repositories/TunedCacheableTagRepository.php
@@ -25,6 +25,9 @@ class TunedCacheableTagRepository extends ApiRepository
     /** @var int Reference-mode cache duration in seconds. */
     protected int $cacheReferenceTtl = 240;
 
+    /** @var int Negative-lookup cache duration in seconds. */
+    protected int $cacheNegativeTtl = 30;
+
     /** @var int The maximum cacheable row count. */
     protected int $cacheMaxRows = 50;
 

--- a/tests/Integration/Repositories/PerQueryCacheTest.php
+++ b/tests/Integration/Repositories/PerQueryCacheTest.php
@@ -255,12 +255,12 @@ class PerQueryCacheTest extends TestCase
     }
 
     /**
-     * Test that a repeated null find re-queries the database each time (null
-     * results are not cached).
+     * Test that a repeated null find is served from the negative cache without
+     * re-querying the database.
      *
      * @return void
      */
-    public function testNullFindReQueriesOnEveryCall(): void
+    public function testNullFindIsServedFromNegativeCache(): void
     {
         $repository = $this->makeRepository(CacheableTagRepository::class);
 
@@ -271,7 +271,7 @@ class PerQueryCacheTest extends TestCase
         $result = $repository->find(999); // @phpstan-ignore staticMethod.dynamicCall
 
         static::assertNull($result);
-        static::assertCount(1, DB::getQueryLog());
+        static::assertCount(0, DB::getQueryLog());
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/CacheStoreTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheStoreTest.php
@@ -40,7 +40,7 @@ class CacheStoreTest extends TestCase
 
         Carbon::setTestNow(Carbon::parse('2026-03-09 12:00:00'));
 
-        $this->cacheStore = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
+        $this->cacheStore = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10));
     }
 
     /**
@@ -71,6 +71,54 @@ class CacheStoreTest extends TestCase
 
         static::assertInstanceOf(Collection::class, $cached);
         static::assertSame(['foo', 'bar', 'baz'], $cached->all());
+    }
+
+    /**
+     * Test that a negatively cached miss is present yet reads back as null.
+     *
+     * @return void
+     */
+    public function testPutMissStoresMarkerThatReadsBackAsNull(): void
+    {
+        $this->cacheStore->putMiss(self::HASH);
+
+        static::assertTrue($this->cacheStore->has(self::HASH));
+        static::assertNull($this->cacheStore->get(self::HASH));
+    }
+
+    /**
+     * Test that a negative entry expires after the shorter negative TTL while a
+     * positive entry stored at the same moment survives on the full TTL.
+     *
+     * @return void
+     */
+    public function testPutMissExpiresAfterNegativeTtlNotFullTtl(): void
+    {
+        $this->cacheStore->putMiss(self::HASH);
+        $this->cacheStore->put('positive', collect(['x']), 1);
+
+        static::assertTrue($this->cacheStore->has(self::HASH));
+
+        // 11 seconds on: past the 10s negative TTL but well within the 3600s TTL.
+        Carbon::setTestNow(Carbon::parse('2026-03-09 12:00:11'));
+
+        static::assertFalse($this->cacheStore->has(self::HASH));
+        static::assertTrue($this->cacheStore->has('positive'));
+    }
+
+    /**
+     * Test that a negative entry is invalidated by a table flush, so a write
+     * does not leave a stale "not found" behind.
+     *
+     * @return void
+     */
+    public function testPutMissIsInvalidatedByFlushTable(): void
+    {
+        $this->cacheStore->putMiss(self::HASH);
+
+        $this->cacheStore->flushTable();
+
+        static::assertFalse($this->cacheStore->has(self::HASH));
     }
 
     /**
@@ -140,7 +188,7 @@ class CacheStoreTest extends TestCase
      */
     public function testSizeGuardSkipsStoringWhenRowCountExceeded(): void
     {
-        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(2, 262144), true));
+        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(2, 262144), true, 10));
 
         $store->put(self::HASH, collect(['a', 'b', 'c']), 3);
 
@@ -156,7 +204,7 @@ class CacheStoreTest extends TestCase
      */
     public function testSizeGuardSkipsStoringWhenByteSizeExceeded(): void
     {
-        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 8), true));
+        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 8), true, 10));
 
         $store->put(self::HASH, collect([str_repeat('x', 256)]), 1);
 
@@ -185,7 +233,7 @@ class CacheStoreTest extends TestCase
      */
     public function testFlushTableInvalidatesEntryViaVersionBumpOnNonTaggableStore(): void
     {
-        $store = new CacheStore('file', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
+        $store = new CacheStore('file', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10));
 
         $store->put(self::HASH, collect(['item']), 1);
 
@@ -205,7 +253,7 @@ class CacheStoreTest extends TestCase
      */
     public function testFlushTableBumpsGenerationalVersionOnNonTaggableStore(): void
     {
-        $store      = new CacheStore('file', 'versioned-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
+        $store      = new CacheStore('file', 'versioned-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10));
         $versionKey = 'api-toolkit:repository-cache-version:versioned-table';
 
         $store->put(self::HASH, collect(['first']), 1);
@@ -235,7 +283,7 @@ class CacheStoreTest extends TestCase
      */
     public function testFlushTableLeavesEntryWhenRegistryDisabledOnNonTaggableStore(): void
     {
-        $store = new CacheStore('file', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), false));
+        $store = new CacheStore('file', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), false, 10));
 
         $store->put(self::HASH, collect(['item']), 1);
 
@@ -327,7 +375,7 @@ class CacheStoreTest extends TestCase
      */
     public function testTaggableStoreFlushesViaTagsWhenRegistryDisabled(): void
     {
-        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), false));
+        $store = new CacheStore('array', 'test-table', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), false, 10));
 
         $store->put(self::HASH, collect(['item']), 1);
 
@@ -346,8 +394,8 @@ class CacheStoreTest extends TestCase
      */
     public function testTagIsolatesEntriesBetweenTables(): void
     {
-        $tableA = new CacheStore('array', 'table-a', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
-        $tableB = new CacheStore('array', 'table-b', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true));
+        $tableA = new CacheStore('array', 'table-a', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10));
+        $tableB = new CacheStore('array', 'table-b', new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10));
 
         $tableA->put(self::HASH, collect(['a']), 1);
         $tableB->put(self::HASH, collect(['b']), 1);

--- a/tests/Unit/Repositories/Concerns/CacheableTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheableTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Repositories\Concerns;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use SineMacula\ApiToolkit\Repositories\ApiRepository;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
@@ -454,6 +455,26 @@ class CacheableTest extends TestCase
     }
 
     /**
+     * Test that a null/miss read is negatively cached, so a repeated read for
+     * the same missing key is served from the cache without a database query.
+     *
+     * @return void
+     */
+    public function testMissingReadIsServedFromNegativeCacheWithoutRequery(): void
+    {
+        static::assertNull($this->repository->find(999)); // @phpstan-ignore staticMethod.dynamicCall
+
+        DB::enableQueryLog();
+
+        $result = $this->repository->find(999); // @phpstan-ignore staticMethod.dynamicCall
+
+        DB::disableQueryLog();
+
+        static::assertNull($result);
+        static::assertCount(0, DB::getQueryLog());
+    }
+
+    /**
      * Test that the row count used by the size guard is the collection size for
      * a collection, exactly one for a single model, and zero otherwise.
      *
@@ -500,15 +521,18 @@ class CacheableTest extends TestCase
 
         $resolveTtl          = new \ReflectionMethod($repository, 'resolveTtl');
         $resolveReferenceTtl = new \ReflectionMethod($repository, 'resolveReferenceTtl');
+        $resolveNegativeTtl  = new \ReflectionMethod($repository, 'resolveNegativeTtl');
         $resolveStoreOptions = new \ReflectionMethod($repository, 'resolveStoreOptions');
 
         static::assertSame(120, $resolveTtl->invoke($repository));
         static::assertSame(240, $resolveReferenceTtl->invoke($repository));
+        static::assertSame(30, $resolveNegativeTtl->invoke($repository));
 
         $options = $resolveStoreOptions->invoke($repository);
 
         static::assertInstanceOf(CacheStoreOptions::class, $options);
         static::assertSame(120, $options->ttl);
+        static::assertSame(30, $options->negativeTtl);
         static::assertFalse($options->registryEnabled);
         static::assertSame(50, (new \ReflectionProperty(CacheSizeGuard::class, 'maxRows'))->getValue($options->sizeGuard));
         static::assertSame(2048, (new \ReflectionProperty(CacheSizeGuard::class, 'maxBytes'))->getValue($options->sizeGuard));
@@ -531,5 +555,27 @@ class CacheableTest extends TestCase
 
         static::assertSame(3600, (new \ReflectionMethod($repository, 'resolveTtl'))->invoke($repository));
         static::assertSame(3600, (new \ReflectionMethod($repository, 'resolveReferenceTtl'))->invoke($repository));
+    }
+
+    /**
+     * Test that the negative-lookup TTL casts a numeric configuration value to
+     * an int and falls back to ten seconds for a non-numeric value.
+     *
+     * @return void
+     */
+    public function testNegativeTtlCastsNumericConfigAndFallsBackForNonNumeric(): void
+    {
+        assert($this->app !== null);
+
+        $repository = $this->app->make(CacheableTagRepository::class);
+        $resolve    = new \ReflectionMethod($repository, 'resolveNegativeTtl');
+
+        Config::set('api-toolkit.repositories.cache.negative_ttl', '25');
+
+        static::assertSame(25, $resolve->invoke($repository));
+
+        Config::set('api-toolkit.repositories.cache.negative_ttl', 'not-numeric');
+
+        static::assertSame(10, $resolve->invoke($repository));
     }
 }


### PR DESCRIPTION
## Summary

Resolves **BL-16 #4** - the final BL-16 item. The transparent per-query repository cache previously skipped `null`/miss reads (`if ($result !== null)`), so a repeated lookup for a missing key (`find(999)`, `firstWhere(...)`, etc.) re-queried the database every time. It now negatively caches the miss.

## How it works

- **`CacheStore::putMiss()`** stores a `CacheMiss` marker for the query fingerprint under a separate, shorter **negative TTL**; `get()` translates the marker back to `null` so callers see a transparent null on a negative hit.
- **`Cacheable::resolveCachedRead()`** calls `putMiss()` on a null result instead of skipping it.
- **`CacheMiss`** is a tiny marker class matched via `instanceof` - it survives serialization on non-array stores (redis/file/database) and can never collide with a real `value()`/`pluck()` result (unlike a sentinel string or an identity-based object).
- The marker is scoped to the table tag/version like any other entry, so **a write still invalidates it**; the short TTL additionally bounds stale-null visibility and probe-fill memory.

## Config

New `repositories.cache.negative_ttl` (env `API_TOOLKIT_REPOSITORY_CACHE_NEGATIVE_TTL`, default **10s**), overridable per repository via `protected ?int $cacheNegativeTtl`. Mirrors the existing `ttl` / `reference_ttl` resolution.

## Verification

- `composer test` - 1901 pass (1 pre-existing skip). The obsolete integration test `testNullFindReQueriesOnEveryCall` (which asserted the old "null not cached" behaviour BL-16 #4 fixes) was updated to assert the new negative-caching behaviour.
- `composer test:mutation` - Covered MSI 94% (meets the `--min-msi=94 --min-covered-msi=94` gate)
- `composer check` / `composer format` - clean (qlty diff mode vs `2.x`: no new issues)
- New tests: `CacheStore` marker round-trip, negative-TTL-vs-full-TTL expiry (Carbon), flush invalidation; `Cacheable` zero-requery negative hit + TTL resolution (cast / property-precedence / non-numeric fallback). Red-green verified.

Independent of #268; both branch off `2.x` and touch disjoint files.