### PR TITLE
feat: filter/sort allowlist posture (secure-by-default query surface) [BL-20]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 
 ### Changed
 
+- Filtering and sorting are now allowlist-by-default: a resource declares which columns are
+  filterable/sortable and which relations are traversable in its schema, and an undeclared filter, sort,
+  or relation key on the root resource is rejected with a `422` validation error. The legacy blocklist
+  behaviour (every column queryable unless excluded) remains available via
+  `API_TOOLKIT_QUERY_POSTURE=blocklist`, and fail-quiet dropping of undeclared keys via
+  `API_TOOLKIT_REJECT_UNDECLARED=false`. See [UPGRADE.md](UPGRADE.md) for the migration steps
 - `ApiResource`, `ApiCriteria`, and `ApiRepository` decomposed into single-responsibility collaborators
 - Service configuration is immutable, with cross-cutting behaviour composed through a concern pipeline
 - `Service::run()` returns an immutable `ServiceResult` value object instead of `bool`
@@ -28,6 +34,11 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 
 ### Added
 
+- Declared-intent query-surface markers on the schema DSL -- `Field::filterable()`, `Field::sortable()`,
+  and `Relation::traversable()` -- compiled into the resource's allowlist of queryable columns and
+  traversable relations
+- `API_TOOLKIT_QUERY_POSTURE` (`allowlist` default, `blocklist` opt-out) and `API_TOOLKIT_REJECT_UNDECLARED`
+  (`true` default) config keys governing filter/sort enforcement
 - Extensible filter operator registry
 - Schema introspection service and boot-time schema validation
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -423,6 +423,63 @@ contract and register it on the `OperatorRegistry` singleton (for example, in a 
 
 The registry also exposes `override()` and `remove()` for adjusting the built-in operator set.
 
+### Changed: Filtering and sorting are allowlist-by-default
+
+API query filtering and sorting are now **allowlist-by-default**. A resource declares which columns are
+filterable and sortable, and which relations may be traversed, in its schema. Any filter, sort, or
+relation key the resource has not declared is rejected with a `422` validation error.
+
+In 1.x and earlier 2.x builds the posture was the opposite: every column the model exposed was
+filterable and sortable unless it was named in `searchable_exclusions` (a blocklist). The exclusion list
+was the only line of defence, so a newly added column was queryable the moment it reached the table. The
+posture is now inverted -- a key is queryable only when the schema declares it intentionally.
+
+**Declare the query surface** with the fluent markers on the schema DSL:
+
+    use SineMacula\ApiToolkit\Schema\Field;
+    use SineMacula\ApiToolkit\Schema\Relation;
+
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id')->filterable()->sortable(),
+            Field::scalar('name')->filterable()->sortable(),
+            Field::scalar('email')->filterable(),
+            Relation::to('posts', PostResource::class)->traversable(),
+        );
+    }
+
+A field's filter and sort key is its **column name**, not its presentation alias.
+`Field::scalar('email_address', 'email')->filterable()` declares `email_address` as the filterable
+column even though the field is presented to clients as `email`.
+
+**Action required.** Audit every API resource and add `filterable()`, `sortable()`, and `traversable()`
+to the fields and relations clients are expected to query. Keys that clients currently rely on but the
+schema does not declare will start returning `422` until they are declared. A resource with no declared
+surface rejects every filter and sort key.
+
+**Restore the previous behaviour** by switching back to the blocklist posture:
+
+    API_TOOLKIT_QUERY_POSTURE=blocklist
+
+Under `blocklist` the legacy shape-derived behaviour applies: every model column is filterable and
+sortable unless excluded via `searchable_exclusions`. This is a transitional escape hatch; new
+applications should adopt the allowlist posture.
+
+**Fail-closed vs fail-quiet.** By default an undeclared key on the root resource is rejected with a named
+`422` validation error so clients learn immediately which key is not permitted (`reject_undeclared`,
+default `true`). Switch it off to silently drop undeclared keys instead:
+
+    API_TOOLKIT_REJECT_UNDECLARED=false
+
+A dropped key applies no constraint, so a filter the client believes is active is silently ignored --
+prefer the default fail-closed behaviour unless a quiet drop is specifically required.
+
+**Widened default exclusions.** The default `searchable_exclusions` (used under the blocklist posture)
+now also covers `two_factor_secret`, `two_factor_recovery_codes`, `two_factor_confirmed_at`, and
+`email_verified_at` alongside the existing `password`, `token`, and `remember_token`, so even the legacy
+posture leaks fewer sensitive columns out of the box.
+
 ### Deprecated: Request macros in favour of RequestCapabilities
 
 The request macros registered by the toolkit -- `includeTrashed()`, `onlyTrashed()`, `expectsExport()`,

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -262,9 +262,33 @@ return [
             'object'  => ['object', 'encrypted:object'],
         ],
 
-        // This configuration allows both columns, and columns for specific
-        // tables e.g. users.password
-        'searchable_exclusions' => ['password'],
+        // Query-access posture for filtering and sorting. 'allowlist' (the 2.0
+        // default) exposes only the columns/relations a resource declares
+        // filterable/sortable/traversable and rejects everything else;
+        // 'blocklist' restores the prior opt-out behaviour where every column
+        // except the searchable_exclusions below is queryable.
+        'query_posture' => env('API_TOOLKIT_QUERY_POSTURE', 'allowlist'),
+
+        // When true (the default), an undeclared filter/sort/relation key under
+        // the allowlist posture is rejected with a validation error naming the
+        // key (fail-closed). Set to false to silently drop undeclared keys
+        // instead (the prior fail-quiet behaviour).
+        'reject_undeclared' => env('API_TOOLKIT_REJECT_UNDECLARED', true),
+
+        // Columns excluded from the blocklist posture's searchable set. Allows
+        // both bare columns and table-scoped columns e.g. users.password. The
+        // default covers the stock Laravel + Fortify auth column family so the
+        // filter layer's sensitive set stays a superset of the export layer's
+        // ignored_fields even under the blocklist opt-out.
+        'searchable_exclusions' => [
+            'password',
+            'token',
+            'remember_token',
+            'two_factor_secret',
+            'two_factor_recovery_codes',
+            'two_factor_confirmed_at',
+            'email_verified_at',
+        ],
 
     ],
 

--- a/src/Repositories/Criteria/ApiCriteria.php
+++ b/src/Repositories/Criteria/ApiCriteria.php
@@ -5,6 +5,7 @@ namespace SineMacula\ApiToolkit\Repositories\Criteria;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
@@ -16,6 +17,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\LimitApplier;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
 use SineMacula\ApiToolkit\Repositories\Traits\ResolvesResource;
 use SineMacula\ApiToolkit\Schema\SafetySetDeriver;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use SineMacula\Repositories\Contracts\CriteriaInterface;
 
 /**
@@ -91,25 +93,28 @@ class ApiCriteria implements CriteriaInterface
         /** @var \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query */
         $query = $model instanceof Model ? $model::query() : $model;
 
-        $query = $this->filterApplier->apply($query, $this->getFilters(), $this->schemaIntrospector, $this->operatorRegistry);
+        $surface = $this->buildQuerySurface($query->getModel());
+
+        $query = $this->filterApplier->apply($query, $this->getFilters(), $this->schemaIntrospector, $this->operatorRegistry, $surface);
         $query = $this->eagerLoadApplier->apply($query, $this->metadataProvider, $this->resolveResource($query->getModel()), $this->getResourceType($query->getModel()));
 
         $query = $this->limitApplier->apply($query, $this->getLimit());
 
         /** @var \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query */
-        return $this->applyOrderingAndProjection($query);
+        return $this->applyOrderingAndProjection($query, $surface);
     }
 
     /**
      * Apply ordering, then narrow the base-table projection as the final step.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
+     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface  $surface
      * @return \Illuminate\Contracts\Database\Eloquent\Builder
      */
-    private function applyOrderingAndProjection(Builder $query): Builder
+    private function applyOrderingAndProjection(Builder $query, QuerySurface $surface): Builder
     {
         /** @var \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query */
-        $query = $this->orderApplier->apply($query, $this->getOrder(), $this->schemaIntrospector);
+        $query = $this->orderApplier->apply($query, $this->getOrder(), $surface);
 
         return $this->columnProjectionApplier->apply(
             $query,
@@ -164,5 +169,35 @@ class ApiCriteria implements CriteriaInterface
         }
 
         return $this->metadataProvider->getResourceType($resource);
+    }
+
+    /**
+     * Build the declared query surface for the resolved resource, honouring the
+     * configured posture. A model with no mapped resource yields an empty
+     * surface, so the allowlist posture rejects every key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface
+     */
+    private function buildQuerySurface(Model $model): QuerySurface
+    {
+        $resource = $this->resolveResource($model);
+
+        $schema = $resource && is_subclass_of($resource, ApiResourceInterface::class)
+            ? SchemaCompiler::compile($resource)
+            : null;
+
+        $posture = Config::get('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_ALLOWLIST);
+        $reject  = Config::get('api-toolkit.repositories.reject_undeclared', true);
+
+        return new QuerySurface(
+            $schema?->getFilterableColumns()    ?? [],
+            $schema?->getSortableColumns()      ?? [],
+            $schema?->getTraversableRelations() ?? [],
+            is_string($posture) ? $posture : QuerySurface::POSTURE_ALLOWLIST,
+            (bool) $reject,
+            $this->schemaIntrospector,
+            $model,
+        );
     }
 }

--- a/src/Repositories/Criteria/Concerns/FilterApplier.php
+++ b/src/Repositories/Criteria/Concerns/FilterApplier.php
@@ -5,6 +5,7 @@ namespace SineMacula\ApiToolkit\Repositories\Criteria\Concerns;
 use Illuminate\Database\Eloquent\Builder;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 
 /**
  * Applies filter trees to an Eloquent query builder.
@@ -31,6 +32,9 @@ final class FilterApplier
     /** @var \SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry */
     private OperatorRegistry $operatorRegistry;
 
+    /** @var \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface */
+    private QuerySurface $querySurface;
+
     /**
      * Apply filters to the query.
      *
@@ -40,12 +44,14 @@ final class FilterApplier
      * @param  array<string, mixed>|null  $filters
      * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider  $schemaIntrospector
      * @param  \SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry  $operatorRegistry
+     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface  $querySurface
      * @return \Illuminate\Database\Eloquent\Builder<TModel>
      */
-    public function apply(Builder $query, ?array $filters, SchemaIntrospectionProvider $schemaIntrospector, OperatorRegistry $operatorRegistry): Builder
+    public function apply(Builder $query, ?array $filters, SchemaIntrospectionProvider $schemaIntrospector, OperatorRegistry $operatorRegistry, QuerySurface $querySurface): Builder
     {
         $this->schemaIntrospector = $schemaIntrospector;
         $this->operatorRegistry   = $operatorRegistry;
+        $this->querySurface       = $querySurface;
 
         $this->applyFilters($query, $filters, null, FilterContext::root());
 
@@ -78,7 +84,9 @@ final class FilterApplier
             } elseif (array_key_exists($key, $this->logicalOperatorMap)) {
                 $this->applyLogicalOperator($query, $key, $value, $context);
             } elseif ($this->schemaIntrospector->isRelation($key, $query->getModel())) {
-                $this->applyRelationFilter($query, $key, $value, $context);
+                if ($this->querySurface->guardRelation($key, $query->getModel())) {
+                    $this->applyRelationFilter($query, $key, $value, $context);
+                }
             } else {
                 $this->applyFilters($query, $value, $key, $context);
             }
@@ -98,7 +106,7 @@ final class FilterApplier
      */
     private function applySimpleFilter(Builder $query, ?string $column, string $value, FilterContext $context): Builder
     {
-        if ($column && $this->schemaIntrospector->isSearchable($query->getModel(), $column)) {
+        if ($column && $this->querySurface->guardFilter($column, $query->getModel())) {
 
             if ($context->getLogicalOperator() === '$or') {
                 $query->orWhere($column, $value);
@@ -128,7 +136,7 @@ final class FilterApplier
             return;
         }
 
-        if (!$field || !$this->schemaIntrospector->isSearchable($query->getModel(), $field)) {
+        if (!$field || !$this->querySurface->guardFilter($field, $query->getModel())) {
             return;
         }
 
@@ -237,10 +245,10 @@ final class FilterApplier
         foreach ((array) $relations as $relation => $filters) {
 
             if (is_int($relation)) {
-                if ($this->schemaIntrospector->isRelation($filters, $query->getModel())) {
+                if ($this->querySurface->guardRelation($filters, $query->getModel())) {
                     $this->applyRelationalMethod($query, $method, $filters);
                 }
-            } elseif ($this->schemaIntrospector->isRelation($relation, $query->getModel())) {
+            } elseif ($this->querySurface->guardRelation($relation, $query->getModel())) {
                 $this->applyRelationalMethod($query, $method, $relation, function (Builder $query) use ($filters): void {
                     $this->processRelationFilters($query, $filters, FilterContext::root());
                 });

--- a/src/Repositories/Criteria/Concerns/OrderApplier.php
+++ b/src/Repositories/Criteria/Concerns/OrderApplier.php
@@ -3,14 +3,14 @@
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
-use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 
 /**
  * Applies ordering to an Eloquent query builder.
  *
  * Supports single and multiple column ordering, random ordering via the
- * `ORDER_BY_RANDOM` keyword, direction validation, and searchable column
- * validation via the schema introspection provider.
+ * `ORDER_BY_RANDOM` keyword, direction validation, and sortable-column
+ * enforcement via the declared query surface.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -30,10 +30,10 @@ final class OrderApplier
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $query
      * @param  array<string, string>  $order
-     * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider  $schemaIntrospector
+     * @param  \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface  $querySurface
      * @return \Illuminate\Database\Eloquent\Builder<TModel>
      */
-    public function apply(Builder $query, array $order, SchemaIntrospectionProvider $schemaIntrospector): Builder
+    public function apply(Builder $query, array $order, QuerySurface $querySurface): Builder
     {
         if (empty($order)) {
             return $query;
@@ -46,7 +46,7 @@ final class OrderApplier
                 continue;
             }
 
-            if ($schemaIntrospector->isSearchable($query->getModel(), $column) && in_array($direction, $this->directions, true)) {
+            if ($querySurface->guardSort($column, $query->getModel()) && in_array($direction, $this->directions, true)) {
                 $query->getQuery()->orderBy($column, $direction);
             }
         }

--- a/src/Repositories/Criteria/QuerySurface.php
+++ b/src/Repositories/Criteria/QuerySurface.php
@@ -107,7 +107,7 @@ final readonly class QuerySurface
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    public function permitsFilter(string $column, Model $model): bool
+    private function permitsFilter(string $column, Model $model): bool
     {
         return $this->governsRoot($model)
             ? in_array($column, $this->filterableColumns, true)
@@ -121,7 +121,7 @@ final readonly class QuerySurface
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    public function permitsSort(string $column, Model $model): bool
+    private function permitsSort(string $column, Model $model): bool
     {
         return $this->governsRoot($model)
             ? in_array($column, $this->sortableColumns, true)
@@ -135,7 +135,7 @@ final readonly class QuerySurface
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    public function permitsRelation(string $relation, Model $model): bool
+    private function permitsRelation(string $relation, Model $model): bool
     {
         return $this->governsRoot($model)
             ? in_array($relation, $this->traversableRelations, true)

--- a/src/Repositories/Criteria/QuerySurface.php
+++ b/src/Repositories/Criteria/QuerySurface.php
@@ -11,12 +11,18 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
  *
  * Bridges the declared filterable/sortable/traversable sets (compiled from the
  * schema DSL) to the filter and sort enforcement gates. Under the allowlist
- * posture a key is permitted only when the resource declared it; under the
- * blocklist posture the legacy shape-derived predicates apply. An undeclared
- * key is rejected with a named ValidationException when fail-closed, or dropped
- * when fail-quiet. A resource with no declared surface (e.g. a model with no
- * mapped resource) yields empty sets, so the allowlist posture rejects every
- * key - secure by default.
+ * posture a key on the root resource is permitted only when the resource
+ * declared it; under the blocklist posture the legacy shape-derived predicates
+ * apply. An undeclared root key is rejected with a named ValidationException
+ * when fail-closed, or dropped when fail-quiet. A resource with no declared
+ * surface (e.g. a model with no mapped resource) yields empty sets, so the
+ * allowlist posture rejects every root key - secure by default.
+ *
+ * Keys that target a nested/related model (within a declared-traversable
+ * relation) fall back to the legacy searchable predicate on that related model:
+ * the top-level relation allowlist is the P0 worker, and per-related-resource
+ * nested-column granularity is deferred (BL-20 P2). The relation gate still
+ * governs which relations may be traversed at all.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -30,7 +36,7 @@ final readonly class QuerySurface
     public const string POSTURE_BLOCKLIST = 'blocklist';
 
     /**
-     * Create a new query surface bound to a query's model.
+     * Create a new query surface bound to the root query's model.
      *
      * @param  array<int, string>  $filterableColumns
      * @param  array<int, string>  $sortableColumns
@@ -38,7 +44,7 @@ final readonly class QuerySurface
      * @param  string  $posture
      * @param  bool  $rejectUndeclared
      * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider  $introspector
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model  $rootModel
      */
     public function __construct(
         private array $filterableColumns,
@@ -47,116 +53,126 @@ final readonly class QuerySurface
         private string $posture,
         private bool $rejectUndeclared,
         private SchemaIntrospectionProvider $introspector,
-        private Model $model,
+        private Model $rootModel,
     ) {}
 
     /**
-     * Guard a filter column, returning whether it may be applied and throwing
-     * on an undeclared key under the fail-closed allowlist posture.
+     * Guard a filter column on the given model, returning whether it may be
+     * applied and throwing on an undeclared root key under the fail-closed
+     * allowlist posture.
      *
      * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function guardFilter(string $column): bool
+    public function guardFilter(string $column, Model $model): bool
     {
-        return $this->guard($this->permitsFilter($column), 'filters', $column);
+        return $this->guard($this->permitsFilter($column, $model), 'filters', $column, $model);
     }
 
     /**
-     * Guard a sort column.
+     * Guard a sort column on the given model.
      *
      * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function guardSort(string $column): bool
+    public function guardSort(string $column, Model $model): bool
     {
-        return $this->guard($this->permitsSort($column), 'order', $column);
+        return $this->guard($this->permitsSort($column, $model), 'order', $column, $model);
     }
 
     /**
-     * Guard a relation traversal key.
+     * Guard a relation traversal key on the given model.
      *
      * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function guardRelation(string $relation): bool
+    public function guardRelation(string $relation, Model $model): bool
     {
-        return $this->guard($this->permitsRelation($relation), 'filters', $relation);
+        return $this->guard($this->permitsRelation($relation, $model), 'filters', $relation, $model);
     }
 
     /**
-     * Determine whether the column is filterable under the current posture.
+     * Determine whether the column is filterable on the given model.
      *
      * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    public function permitsFilter(string $column): bool
+    public function permitsFilter(string $column, Model $model): bool
     {
-        return $this->isAllowlist()
+        return $this->governsRoot($model)
             ? in_array($column, $this->filterableColumns, true)
-            : $this->introspector->isSearchable($this->model, $column);
+            : $this->introspector->isSearchable($model, $column);
     }
 
     /**
-     * Determine whether the column is sortable under the current posture.
+     * Determine whether the column is sortable on the given model.
      *
      * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    public function permitsSort(string $column): bool
+    public function permitsSort(string $column, Model $model): bool
     {
-        return $this->isAllowlist()
+        return $this->governsRoot($model)
             ? in_array($column, $this->sortableColumns, true)
-            : $this->introspector->isSearchable($this->model, $column);
+            : $this->introspector->isSearchable($model, $column);
     }
 
     /**
-     * Determine whether the relation is traversable under the current posture.
+     * Determine whether the relation is traversable on the given model.
      *
      * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    public function permitsRelation(string $relation): bool
+    public function permitsRelation(string $relation, Model $model): bool
     {
-        return $this->isAllowlist()
+        return $this->governsRoot($model)
             ? in_array($relation, $this->traversableRelations, true)
-            : $this->introspector->isRelation($relation, $this->model);
+            : $this->introspector->isRelation($relation, $model);
     }
 
     /**
-     * Determine whether the allowlist posture is in force.
+     * Determine whether the declared allowlist governs the given model - i.e.
+     * the allowlist posture is in force and the model is the root model.
      *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
-    private function isAllowlist(): bool
+    private function governsRoot(Model $model): bool
     {
-        return $this->posture === self::POSTURE_ALLOWLIST;
+        return $this->posture === self::POSTURE_ALLOWLIST && $model::class === $this->rootModel::class;
     }
 
     /**
      * Resolve a permission result into an apply/skip decision, rejecting an
-     * undeclared key when fail-closed under the allowlist posture.
+     * undeclared root key when fail-closed under the allowlist posture.
      *
      * @param  bool  $permitted
      * @param  string  $parameter
      * @param  string  $key
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    private function guard(bool $permitted, string $parameter, string $key): bool
+    private function guard(bool $permitted, string $parameter, string $key, Model $model): bool
     {
         if ($permitted) {
             return true;
         }
 
-        if ($this->isAllowlist() && $this->rejectUndeclared) {
+        if ($this->rejectUndeclared && $this->governsRoot($model)) {
             throw ValidationException::withMessages([$parameter . '.' . $key => sprintf('The "%s" key is not a permitted query parameter for this resource.', $key)]);
         }
 

--- a/src/Repositories/Criteria/QuerySurface.php
+++ b/src/Repositories/Criteria/QuerySurface.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Repositories\Criteria;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
+use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+
+/**
+ * Per-query enforcement policy for a resource's declared query surface.
+ *
+ * Bridges the declared filterable/sortable/traversable sets (compiled from the
+ * schema DSL) to the filter and sort enforcement gates. Under the allowlist
+ * posture a key is permitted only when the resource declared it; under the
+ * blocklist posture the legacy shape-derived predicates apply. An undeclared
+ * key is rejected with a named ValidationException when fail-closed, or dropped
+ * when fail-quiet. A resource with no declared surface (e.g. a model with no
+ * mapped resource) yields empty sets, so the allowlist posture rejects every
+ * key - secure by default.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class QuerySurface
+{
+    /** @var string The opt-in declared-intent posture. */
+    public const string POSTURE_ALLOWLIST = 'allowlist';
+
+    /** @var string The opt-out shape-derived posture. */
+    public const string POSTURE_BLOCKLIST = 'blocklist';
+
+    /**
+     * Create a new query surface bound to a query's model.
+     *
+     * @param  array<int, string>  $filterableColumns
+     * @param  array<int, string>  $sortableColumns
+     * @param  array<int, string>  $traversableRelations
+     * @param  string  $posture
+     * @param  bool  $rejectUndeclared
+     * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider  $introspector
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    public function __construct(
+        private array $filterableColumns,
+        private array $sortableColumns,
+        private array $traversableRelations,
+        private string $posture,
+        private bool $rejectUndeclared,
+        private SchemaIntrospectionProvider $introspector,
+        private Model $model,
+    ) {}
+
+    /**
+     * Guard a filter column, returning whether it may be applied and throwing
+     * on an undeclared key under the fail-closed allowlist posture.
+     *
+     * @param  string  $column
+     * @return bool
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function guardFilter(string $column): bool
+    {
+        return $this->guard($this->permitsFilter($column), 'filters', $column);
+    }
+
+    /**
+     * Guard a sort column.
+     *
+     * @param  string  $column
+     * @return bool
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function guardSort(string $column): bool
+    {
+        return $this->guard($this->permitsSort($column), 'order', $column);
+    }
+
+    /**
+     * Guard a relation traversal key.
+     *
+     * @param  string  $relation
+     * @return bool
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function guardRelation(string $relation): bool
+    {
+        return $this->guard($this->permitsRelation($relation), 'filters', $relation);
+    }
+
+    /**
+     * Determine whether the column is filterable under the current posture.
+     *
+     * @param  string  $column
+     * @return bool
+     */
+    public function permitsFilter(string $column): bool
+    {
+        return $this->isAllowlist()
+            ? in_array($column, $this->filterableColumns, true)
+            : $this->introspector->isSearchable($this->model, $column);
+    }
+
+    /**
+     * Determine whether the column is sortable under the current posture.
+     *
+     * @param  string  $column
+     * @return bool
+     */
+    public function permitsSort(string $column): bool
+    {
+        return $this->isAllowlist()
+            ? in_array($column, $this->sortableColumns, true)
+            : $this->introspector->isSearchable($this->model, $column);
+    }
+
+    /**
+     * Determine whether the relation is traversable under the current posture.
+     *
+     * @param  string  $relation
+     * @return bool
+     */
+    public function permitsRelation(string $relation): bool
+    {
+        return $this->isAllowlist()
+            ? in_array($relation, $this->traversableRelations, true)
+            : $this->introspector->isRelation($relation, $this->model);
+    }
+
+    /**
+     * Determine whether the allowlist posture is in force.
+     *
+     * @return bool
+     */
+    private function isAllowlist(): bool
+    {
+        return $this->posture === self::POSTURE_ALLOWLIST;
+    }
+
+    /**
+     * Resolve a permission result into an apply/skip decision, rejecting an
+     * undeclared key when fail-closed under the allowlist posture.
+     *
+     * @param  bool  $permitted
+     * @param  string  $parameter
+     * @param  string  $key
+     * @return bool
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    private function guard(bool $permitted, string $parameter, string $key): bool
+    {
+        if ($permitted) {
+            return true;
+        }
+
+        if ($this->isAllowlist() && $this->rejectUndeclared) {
+            throw ValidationException::withMessages([$parameter . '.' . $key => sprintf('The "%s" key is not a permitted query parameter for this resource.', $key)]);
+        }
+
+        return false;
+    }
+}

--- a/src/Schema/CompiledSchema.php
+++ b/src/Schema/CompiledSchema.php
@@ -18,6 +18,9 @@ final readonly class CompiledSchema
      *
      * @param  array<string, \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition>  $fields
      * @param  array<string, \SineMacula\ApiToolkit\Schema\CompiledCountDefinition>  $counts
+     * @param  array<int, string>  $filterableColumns
+     * @param  array<int, string>  $sortableColumns
+     * @param  array<int, string>  $traversableRelations
      */
     public function __construct(
 
@@ -26,6 +29,15 @@ final readonly class CompiledSchema
 
         /** The compiled count definitions keyed by present key */
         private array $counts,
+
+        /** Declared filterable column names */
+        private array $filterableColumns = [],
+
+        /** Declared sortable column names */
+        private array $sortableColumns = [],
+
+        /** Declared externally-traversable relation names */
+        private array $traversableRelations = [],
 
     ) {}
 
@@ -71,5 +83,35 @@ final readonly class CompiledSchema
     public function hasField(string $key): bool
     {
         return isset($this->fields[$key]);
+    }
+
+    /**
+     * Return the declared filterable column names.
+     *
+     * @return array<int, string>
+     */
+    public function getFilterableColumns(): array
+    {
+        return $this->filterableColumns;
+    }
+
+    /**
+     * Return the declared sortable column names.
+     *
+     * @return array<int, string>
+     */
+    public function getSortableColumns(): array
+    {
+        return $this->sortableColumns;
+    }
+
+    /**
+     * Return the declared externally-traversable relation names.
+     *
+     * @return array<int, string>
+     */
+    public function getTraversableRelations(): array
+    {
+        return $this->traversableRelations;
     }
 }

--- a/src/Schema/Field.php
+++ b/src/Schema/Field.php
@@ -20,6 +20,12 @@ final class Field extends BaseDefinition
     /** @var mixed Compute callable for dynamic field values */
     private mixed $compute = null;
 
+    /** @var bool Whether this field's column is declared filterable */
+    private bool $filterable = false;
+
+    /** @var bool Whether this field's column is declared sortable */
+    private bool $sortable = false;
+
     /**
      * Prevent direct instantiation.
      *
@@ -137,6 +143,30 @@ final class Field extends BaseDefinition
     }
 
     /**
+     * Declare this field's column as filterable.
+     *
+     * @return self
+     */
+    public function filterable(): self
+    {
+        $this->filterable = true;
+
+        return $this;
+    }
+
+    /**
+     * Declare this field's column as sortable.
+     *
+     * @return self
+     */
+    public function sortable(): self
+    {
+        $this->sortable = true;
+
+        return $this;
+    }
+
+    /**
      * Convert this definition to a normalized array.
      *
      * @return array<string, array<string, mixed>>
@@ -150,6 +180,8 @@ final class Field extends BaseDefinition
             $key => array_filter([
                 'accessor'     => $this->accessor,
                 'compute'      => $this->compute,
+                'filterable'   => $this->filterable ? $this->name : null,
+                'sortable'     => $this->sortable ? $this->name : null,
                 'extras'       => $this->extras ?: null,
                 'needs'        => $this->needs ?: null,
                 'guards'       => $this->getGuards() ?: null,

--- a/src/Schema/Relation.php
+++ b/src/Schema/Relation.php
@@ -30,6 +30,9 @@ final class Relation extends BaseDefinition implements Arrayable
     /** @var (callable(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null Eager-load constraint callback */
     private mixed $constraint = null;
 
+    /** @var bool Whether this relation is declared externally traversable */
+    private bool $traversable = false;
+
     /**
      * Prevent direct instantiation.
      *
@@ -115,6 +118,19 @@ final class Relation extends BaseDefinition implements Arrayable
     }
 
     /**
+     * Declare this relation as externally traversable via $has/$hasnt and
+     * nested relation filters.
+     *
+     * @return self
+     */
+    public function traversable(): self
+    {
+        $this->traversable = true;
+
+        return $this;
+    }
+
+    /**
      * Convert this definition to a normalized array.
      *
      * @return array<string, array<string, mixed>>
@@ -127,6 +143,7 @@ final class Relation extends BaseDefinition implements Arrayable
         return [
             $key => array_filter([
                 'relation'     => $this->name,
+                'traversable'  => $this->traversable ? $this->name : null,
                 'resource'     => $this->resource,
                 'accessor'     => $this->accessor,
                 'extras'       => $this->extras ?: null,

--- a/src/Schema/SchemaCompiler.php
+++ b/src/Schema/SchemaCompiler.php
@@ -71,16 +71,22 @@ final class SchemaCompiler
                 continue;
             }
 
-            if (isset($definition['filterable']) && is_string($definition['filterable'])) {
-                $filterable[] = $definition['filterable'];
+            $filterableMarker = $definition['filterable'] ?? null;
+
+            if (is_string($filterableMarker)) {
+                $filterable[] = $filterableMarker;
             }
 
-            if (isset($definition['sortable']) && is_string($definition['sortable'])) {
-                $sortable[] = $definition['sortable'];
+            $sortableMarker = $definition['sortable'] ?? null;
+
+            if (is_string($sortableMarker)) {
+                $sortable[] = $sortableMarker;
             }
 
-            if (isset($definition['traversable']) && is_string($definition['traversable'])) {
-                $traversable[] = $definition['traversable'];
+            $traversableMarker = $definition['traversable'] ?? null;
+
+            if (is_string($traversableMarker)) {
+                $traversable[] = $traversableMarker;
             }
 
             $fields[$schemaKey] = self::buildFieldDefinition($definition);

--- a/src/Schema/SchemaCompiler.php
+++ b/src/Schema/SchemaCompiler.php
@@ -60,6 +60,10 @@ final class SchemaCompiler
         /** @var array<string, \SineMacula\ApiToolkit\Schema\CompiledCountDefinition> $counts */
         $counts = [];
 
+        $filterable  = [];
+        $sortable    = [];
+        $traversable = [];
+
         foreach ($rawSchema as $schemaKey => $definition) {
 
             if (($definition['metric'] ?? null) === 'count') {
@@ -67,10 +71,28 @@ final class SchemaCompiler
                 continue;
             }
 
+            if (isset($definition['filterable']) && is_string($definition['filterable'])) {
+                $filterable[] = $definition['filterable'];
+            }
+
+            if (isset($definition['sortable']) && is_string($definition['sortable'])) {
+                $sortable[] = $definition['sortable'];
+            }
+
+            if (isset($definition['traversable']) && is_string($definition['traversable'])) {
+                $traversable[] = $definition['traversable'];
+            }
+
             $fields[$schemaKey] = self::buildFieldDefinition($definition);
         }
 
-        return new CompiledSchema($fields, $counts);
+        return new CompiledSchema(
+            $fields,
+            $counts,
+            array_values(array_unique($filterable)),
+            array_values(array_unique($sortable)),
+            array_values(array_unique($traversable)),
+        );
     }
 
     /**

--- a/tests/Fixtures/Resources/FilterableUserResource.php
+++ b/tests/Fixtures/Resources/FilterableUserResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\ApiToolkit\Schema\Relation;
+
+/**
+ * Fixture user resource that declares an explicit query surface.
+ *
+ * The filterable, sortable, and traversable sets are deliberately distinct so
+ * the allowlist enforcement can be exercised independently per capability:
+ * `email` is filterable but not sortable, `created_at` is sortable but not
+ * filterable, `status` is presented but neither, and `organization` is a real
+ * relation that is not traversable.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+class FilterableUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'filterable_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id')->filterable()->sortable(),
+            Field::scalar('name')->filterable()->sortable(),
+            Field::scalar('email')->filterable(),
+            Field::scalar('status'),
+            Field::timestamp('created_at')->sortable(),
+            Relation::to('posts', PostResource::class)->traversable(),
+            Relation::to('organization', OrganizationResource::class),
+        );
+    }
+}

--- a/tests/Integration/ApiCriteriaIntegrationTest.php
+++ b/tests/Integration/ApiCriteriaIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
@@ -11,6 +12,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\LimitApplier;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use SineMacula\Http\Enums\HttpMethod;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
@@ -41,6 +43,12 @@ class ApiCriteriaIntegrationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // These tests assert posture-independent applier mechanics end-to-end
+        // against a real database. Pin the blocklist posture so column gating
+        // follows the legacy isSearchable contract; the allowlist default has
+        // dedicated coverage in QuerySurfaceIntegrationTest.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
 
         $this->seedData();
     }

--- a/tests/Integration/ApiRepositoryIntegrationTest.php
+++ b/tests/Integration/ApiRepositoryIntegrationTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Integration;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use SineMacula\Http\Enums\HttpMethod;
 use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Repositories\UserRepository;
@@ -36,6 +38,11 @@ class ApiRepositoryIntegrationTest extends TestCase
         parent::setUp();
 
         assert($this->app !== null);
+
+        // Pin the blocklist posture so criteria filtering follows the legacy
+        // isSearchable contract these mechanics tests assert; the allowlist
+        // default has dedicated coverage in QuerySurfaceIntegrationTest.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
 
         /** @var \Tests\Fixtures\Repositories\UserRepository $repository */
         $repository = $this->app->make(UserRepository::class);

--- a/tests/Integration/ColumnNarrowingIntegrationTest.php
+++ b/tests/Integration/ColumnNarrowingIntegrationTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\ColumnProjectionApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use SineMacula\Http\Enums\HttpMethod;
@@ -51,6 +52,11 @@ class ColumnNarrowingIntegrationTest extends TestCase
 
         FieldColumnMapper::clearCache();
         SchemaCompiler::clearCache();
+
+        // Pin the blocklist posture so ordering follows the legacy isSearchable
+        // contract; this test asserts column-narrowing mechanics, not the
+        // allowlist posture (covered in QuerySurfaceIntegrationTest).
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
 
         $this->seedData();
     }

--- a/tests/Integration/QuerySurfaceIntegrationTest.php
+++ b/tests/Integration/QuerySurfaceIntegrationTest.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the allowlist query-surface posture end-to-end.
+ *
+ * Exercises the secure-by-default posture against a real database: declared
+ * filterable/sortable columns and traversable relations are applied, while
+ * undeclared keys on the root resource are rejected (fail-closed) or dropped
+ * (fail-quiet). Nested columns on a traversed relation fall back to the legacy
+ * searchable predicate, and a model with no mapped resource rejects every key.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiCriteria::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(OrderApplier::class)]
+#[CoversClass(QuerySurface::class)]
+class QuerySurfaceIntegrationTest extends TestCase
+{
+    /**
+     * Seed users and posts for integration tests.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seedData();
+    }
+
+    /**
+     * The allowlist posture is the default: a declared column is applied while
+     * an undeclared column on the same resource is rejected, with no posture
+     * configuration set.
+     *
+     * @return void
+     */
+    public function testAllowlistIsTheDefaultPosture(): void
+    {
+        $this->parseQuery(['filters' => json_encode(['name' => 'Alice'])]);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        static::assertCount(1, $results);
+
+        $this->assertRejects(
+            ['filters' => json_encode(['status' => 'active'])],
+            'filters.status',
+        );
+    }
+
+    /**
+     * A declared filterable column is applied through an operator.
+     *
+     * @return void
+     */
+    public function testDeclaredFilterableColumnIsApplied(): void
+    {
+        $this->parseQuery(['filters' => json_encode(['email' => ['$like' => 'bob@']])]);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        static::assertCount(1, $results);
+
+        /** @var \Tests\Fixtures\Models\User $first */
+        $first = $results->first();
+
+        static::assertSame('Bob', $first->name);
+    }
+
+    /**
+     * An undeclared filter column is rejected with a named validation error.
+     *
+     * @return void
+     */
+    public function testUndeclaredFilterColumnIsRejectedFailClosed(): void
+    {
+        $this->assertRejects(
+            ['filters' => json_encode(['status' => 'active'])],
+            'filters.status',
+        );
+    }
+
+    /**
+     * A declared sortable column orders the results.
+     *
+     * @return void
+     */
+    public function testDeclaredSortableColumnIsApplied(): void
+    {
+        $this->parseQuery(['order' => 'name:asc']);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        /** @var \Tests\Fixtures\Models\User $first */
+        $first = $results->first();
+
+        /** @var \Tests\Fixtures\Models\User $last */
+        $last = $results->last();
+
+        static::assertSame('Alice', $first->name);
+        static::assertSame('Charlie', $last->name);
+    }
+
+    /**
+     * A column that is declared filterable but not sortable is rejected when
+     * used for ordering: the filterable and sortable sets are independent.
+     *
+     * @return void
+     */
+    public function testFilterableColumnIsNotImplicitlySortable(): void
+    {
+        $this->assertRejects(
+            ['order' => 'email:asc'],
+            'order.email',
+        );
+    }
+
+    /**
+     * A declared traversable relation is applied through the $has operator.
+     *
+     * @return void
+     */
+    public function testDeclaredTraversableRelationIsApplied(): void
+    {
+        $this->parseQuery(['filters' => json_encode(['$has' => 'posts'])]);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        // Only Alice and Bob have posts.
+        static::assertCount(2, $results);
+    }
+
+    /**
+     * An undeclared relation is rejected even though the model defines it.
+     *
+     * @return void
+     */
+    public function testUndeclaredRelationIsRejected(): void
+    {
+        $this->assertRejects(
+            ['filters' => json_encode(['$has' => 'organization'])],
+            'filters.organization',
+        );
+    }
+
+    /**
+     * A column on a declared-traversable relation falls back to the legacy
+     * searchable predicate on the related model, so nested filters still work
+     * without a per-relation column declaration.
+     *
+     * @return void
+     */
+    public function testNestedRelationColumnFallsBackToLegacySearchable(): void
+    {
+        $this->parseQuery(['filters' => json_encode([
+            'posts' => [
+                'title' => ['$like' => 'Alice'],
+            ],
+        ])]);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        static::assertCount(1, $results);
+
+        /** @var \Tests\Fixtures\Models\User $first */
+        $first = $results->first();
+
+        static::assertSame('Alice', $first->name);
+    }
+
+    /**
+     * With fail-quiet rejection an undeclared key is silently dropped: it adds
+     * no constraint and no exception escapes.
+     *
+     * @return void
+     */
+    public function testFailQuietDropsUndeclaredKey(): void
+    {
+        Config::set('api-toolkit.repositories.reject_undeclared', false);
+
+        $this->parseQuery(['filters' => json_encode(['status' => 'active'])]);
+
+        $query   = $this->declaredCriteria()->apply(new User);
+        $results = $query->get();
+
+        static::assertEmpty($query->getQuery()->wheres);
+        static::assertCount(3, $results);
+    }
+
+    /**
+     * A model with no mapped resource yields an empty surface, so the allowlist
+     * posture rejects every key - secure by default.
+     *
+     * @return void
+     */
+    public function testModelWithoutMappedResourceRejectsEveryKey(): void
+    {
+        $this->parseQuery(['filters' => json_encode(['name' => 'Alice'])]);
+
+        $this->expectException(ValidationException::class);
+
+        // No usingResource() and no resource_map entry: the surface is empty.
+        $this->makeCriteria()->apply(new User);
+    }
+
+    /**
+     * Cross-surface coherence: every field hidden from exports must also be
+     * excluded from filtering under the blocklist posture, so a field the API
+     * never serialises cannot be probed through a filter.
+     *
+     * @return void
+     */
+    public function testSensitiveExportFieldsAreExcludedFromBlocklistFiltering(): void
+    {
+        /** @var array<int, string> $ignored */
+        $ignored = Config::get('api-toolkit.exports.ignored_fields', []);
+
+        /** @var array<int, string> $excluded */
+        $excluded = Config::get('api-toolkit.repositories.searchable_exclusions', []);
+
+        foreach ($ignored as $field) {
+
+            if ($field === '_type') {
+                continue;
+            }
+
+            static::assertContains($field, $excluded, sprintf(
+                'Export-ignored field "%s" must also be excluded from filtering.',
+                $field,
+            ));
+        }
+    }
+
+    /**
+     * Assert that applying the given query parameters rejects with a named
+     * validation error under the allowlist posture.
+     *
+     * @param  array<string, string>  $params
+     * @param  string  $expectedKey
+     * @return void
+     */
+    private function assertRejects(array $params, string $expectedKey): void
+    {
+        $this->parseQuery($params);
+
+        try {
+            $this->declaredCriteria()->apply(new User);
+            static::fail('Expected a ValidationException for "' . $expectedKey . '".');
+        } catch (ValidationException $e) {
+            static::assertArrayHasKey($expectedKey, $e->errors());
+        }
+    }
+
+    /**
+     * Parse query parameters through the ApiQuery facade.
+     *
+     * @param  array<string, string>  $params
+     * @return void
+     */
+    private function parseQuery(array $params): void
+    {
+        $request = Request::create('/test', HttpMethod::GET->getVerb(), $params);
+
+        ApiQuery::parse($request);
+    }
+
+    /**
+     * Resolve a fresh ApiCriteria bound to the declared-surface resource.
+     *
+     * @return \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria
+     */
+    private function declaredCriteria(): ApiCriteria
+    {
+        return $this->makeCriteria()->usingResource(FilterableUserResource::class);
+    }
+
+    /**
+     * Resolve a fresh ApiCriteria instance from the container.
+     *
+     * @return \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria
+     */
+    private function makeCriteria(): ApiCriteria
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria */
+        return $this->app->make(ApiCriteria::class);
+    }
+
+    /**
+     * Seed the database with test data.
+     *
+     * @return void
+     */
+    private function seedData(): void
+    {
+        $alice = User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $bob   = User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'status' => 'active']);
+
+        User::create(['name' => 'Charlie', 'email' => 'charlie@example.com', 'status' => 'inactive']);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'Alice Post', 'body' => 'Content', 'published' => true]);
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob Post', 'body' => 'Content', 'published' => false]);
+    }
+}

--- a/tests/Integration/RequestLifecycleTest.php
+++ b/tests/Integration/RequestLifecycleTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Integration;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Repositories\UserRepository;
 use Tests\Fixtures\Resources\UserResource;
@@ -36,6 +38,13 @@ class RequestLifecycleTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // This test verifies the request-lifecycle wiring (middleware ->
+        // repository -> resource), not the query posture. Pin the blocklist
+        // posture so the route's empty-surface criteria follows the legacy
+        // isSearchable contract; the allowlist default is verified end-to-end
+        // in QuerySurfaceIntegrationTest.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
 
         Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository) {
 

--- a/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
@@ -113,6 +113,48 @@ class SchemaCompilerTest extends TestCase
     }
 
     /**
+     * Test that query-surface markers that are present but not strings are
+     * ignored: only a string marker contributes a column or relation.
+     *
+     * @return void
+     */
+    public function testCompileIgnoresNonStringQuerySurfaceMarkers(): void
+    {
+        $schema = SchemaCompiler::compile($this->createStubResourceClass([
+            'a' => ['filterable' => 123],
+            'b' => ['sortable' => true],
+            'c' => ['traversable' => ['organization']],
+        ]));
+
+        static::assertSame([], $schema->getFilterableColumns());
+        static::assertSame([], $schema->getSortableColumns());
+        static::assertSame([], $schema->getTraversableRelations());
+    }
+
+    /**
+     * Test that duplicate markers are de-duplicated and the resulting sets are
+     * reindexed to clean zero-based lists.
+     *
+     * The same column is declared on two fields before a distinct one, so
+     * array_unique removes a non-trailing duplicate (leaving a key gap) and
+     * array_values reindexes the result.
+     *
+     * @return void
+     */
+    public function testCompileDeduplicatesAndReindexesQuerySurfaceSets(): void
+    {
+        $schema = SchemaCompiler::compile($this->createStubResourceClass([
+            'status_a' => ['filterable' => 'status', 'sortable' => 'status', 'traversable' => 'posts'],
+            'status_b' => ['filterable' => 'status', 'sortable' => 'status', 'traversable' => 'posts'],
+            'email'    => ['filterable' => 'email', 'sortable' => 'created_at', 'traversable' => 'tags'],
+        ]));
+
+        static::assertSame(['status', 'email'], $schema->getFilterableColumns());
+        static::assertSame(['status', 'created_at'], $schema->getSortableColumns());
+        static::assertSame(['posts', 'tags'], $schema->getTraversableRelations());
+    }
+
+    /**
      * Test that compile returns a CompiledSchema from a raw schema array.
      *
      * @return void

--- a/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
@@ -74,6 +74,45 @@ class SchemaCompilerTest extends TestCase
     }
 
     /**
+     * Test that compile aggregates the declared filterable, sortable, and
+     * traversable markers into the CompiledSchema query-surface sets,
+     * de-duplicated and column-named.
+     *
+     * @return void
+     */
+    public function testCompileAggregatesQuerySurfaceSets(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            'email'        => ['filterable' => 'email', 'sortable' => 'email'],
+            'name'         => ['filterable' => 'name'],
+            'created_at'   => ['sortable' => 'created_at'],
+            'organization' => ['relation' => 'organization', 'traversable' => 'organization'],
+        ]);
+
+        $schema = SchemaCompiler::compile($resourceClass);
+
+        static::assertSame(['email', 'name'], $schema->getFilterableColumns());
+        static::assertSame(['email', 'created_at'], $schema->getSortableColumns());
+        static::assertSame(['organization'], $schema->getTraversableRelations());
+    }
+
+    /**
+     * Test that a schema declaring no markers yields empty query-surface sets.
+     *
+     * @return void
+     */
+    public function testCompileYieldsEmptyQuerySurfaceWhenNothingDeclared(): void
+    {
+        $schema = SchemaCompiler::compile($this->createStubResourceClass([
+            'email' => [],
+        ]));
+
+        static::assertSame([], $schema->getFilterableColumns());
+        static::assertSame([], $schema->getSortableColumns());
+        static::assertSame([], $schema->getTraversableRelations());
+    }
+
+    /**
      * Test that compile returns a CompiledSchema from a raw schema array.
      *
      * @return void

--- a/tests/Unit/Http/Resources/Schema/FieldTest.php
+++ b/tests/Unit/Http/Resources/Schema/FieldTest.php
@@ -51,6 +51,45 @@ class FieldTest extends TestCase
     }
 
     /**
+     * Test that filterable() and sortable() emit the field's column name.
+     *
+     * @return void
+     */
+    public function testFilterableAndSortableMarkersEmitTheColumnName(): void
+    {
+        $array = Field::scalar('email')->filterable()->sortable()->toArray();
+
+        static::assertSame('email', $array['email']['filterable']);
+        static::assertSame('email', $array['email']['sortable']);
+    }
+
+    /**
+     * Test that the filterable marker declares the underlying column, not the
+     * presentation alias.
+     *
+     * @return void
+     */
+    public function testFilterableMarkerDeclaresColumnNotAlias(): void
+    {
+        $array = Field::scalar('email_address', 'email')->filterable()->toArray();
+
+        static::assertSame('email_address', $array['email']['filterable']);
+    }
+
+    /**
+     * Test that a field without markers omits them.
+     *
+     * @return void
+     */
+    public function testFieldWithoutMarkersOmitsThem(): void
+    {
+        $array = Field::scalar('email')->toArray();
+
+        static::assertArrayNotHasKey('filterable', $array['email']);
+        static::assertArrayNotHasKey('sortable', $array['email']);
+    }
+
+    /**
      * Test that accessor creates a field with a string accessor.
      *
      * @return void

--- a/tests/Unit/Http/Resources/Schema/RelationTest.php
+++ b/tests/Unit/Http/Resources/Schema/RelationTest.php
@@ -36,6 +36,30 @@ class RelationTest extends TestCase
     }
 
     /**
+     * Test that traversable() emits the relation name.
+     *
+     * @return void
+     */
+    public function testTraversableMarkerEmitsTheRelationName(): void
+    {
+        $array = Relation::to('organization', OrganizationResource::class)->traversable()->toArray();
+
+        static::assertSame('organization', $array['organization']['traversable']);
+    }
+
+    /**
+     * Test that a relation without the traversable marker omits it.
+     *
+     * @return void
+     */
+    public function testRelationWithoutTraversableOmitsIt(): void
+    {
+        $array = Relation::to('organization', OrganizationResource::class)->toArray();
+
+        static::assertArrayNotHasKey('traversable', $array['organization']);
+    }
+
+    /**
      * Test that to with a non-class string sets the accessor.
      *
      * @return void

--- a/tests/Unit/Repositories/ApiRepositoryTest.php
+++ b/tests/Unit/Repositories/ApiRepositoryTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Repositories\ApiRepository;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
 use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use SineMacula\Http\Enums\HttpMethod;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Enums\UserStatus;
@@ -58,6 +59,11 @@ class ApiRepositoryTest extends TestCase
         parent::setUp();
 
         assert($this->app !== null);
+
+        // Pin the blocklist posture so criteria filtering follows the legacy
+        // isSearchable contract these mechanics tests assert; the allowlist
+        // default has dedicated coverage in QuerySurfaceIntegrationTest.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
 
         $this->repository = $this->app->make(UserRepository::class);
     }

--- a/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
+++ b/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
@@ -14,6 +14,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\LimitApplier;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Resources\UserResource;
 use Tests\TestCase;
@@ -59,6 +60,12 @@ class ApiCriteriaTest extends TestCase
         parent::setUp();
 
         assert($this->app !== null);
+
+        // These tests assert posture-independent applier mechanics (operators,
+        // logical groups, relations, ordering, limits). Pin the blocklist
+        // posture so column gating follows the legacy isSearchable contract;
+        // the allowlist default has dedicated integration coverage.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
 
         /** @var \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria $criteria */
         $criteria       = $this->app->make(ApiCriteria::class);

--- a/tests/Unit/Repositories/Criteria/Concerns/FilterApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/FilterApplierTest.php
@@ -20,6 +20,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LikeOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use Tests\Fixtures\Models\User;
 use Tests\TestCase;
 
@@ -689,6 +690,19 @@ class FilterApplierTest extends TestCase
             $filters,
             $this->schemaIntrospector,
             $this->operatorRegistry,
+            $this->surface(),
         );
+    }
+
+    /**
+     * Build a blocklist query surface that delegates to the stubbed
+     * introspector, preserving the legacy shape-derived gating these tests
+     * assert.
+     *
+     * @return \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface
+     */
+    private function surface(): QuerySurface
+    {
+        return new QuerySurface([], [], [], QuerySurface::POSTURE_BLOCKLIST, true, $this->schemaIntrospector, new User);
     }
 }

--- a/tests/Unit/Repositories/Criteria/Concerns/OrderApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/OrderApplierTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use Tests\Fixtures\Models\User;
 use Tests\TestCase;
 
@@ -53,7 +54,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithEmptyOrderReturnsUnmodifiedQuery(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, [], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, [], $this->surface());
 
         static::assertEmpty($result->getQuery()->orders ?? []);
     }
@@ -66,7 +67,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithSingleColumnAddsOrderBy(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, ['name' => 'asc'], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, ['name' => 'asc'], $this->surface());
 
         $orders = $result->getQuery()->orders ?? [];
 
@@ -84,7 +85,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithMultipleColumnsAddsMultipleOrderBy(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, ['name' => 'asc', 'email' => 'desc'], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, ['name' => 'asc', 'email' => 'desc'], $this->surface());
 
         $orders = $result->getQuery()->orders ?? [];
 
@@ -103,7 +104,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithRandomOrderAppliesInRandomOrder(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, ['random' => 'asc'], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, ['random' => 'asc'], $this->surface());
 
         $orders = $result->getQuery()->orders ?? [];
 
@@ -120,7 +121,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithInvalidDirectionSkipsColumn(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, ['name' => 'invalid'], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, ['name' => 'invalid'], $this->surface());
 
         static::assertEmpty($result->getQuery()->orders ?? []);
     }
@@ -134,7 +135,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithNonSearchableColumnSkipsColumn(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, ['nonexistent' => 'asc'], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, ['nonexistent' => 'asc'], $this->surface());
 
         static::assertEmpty($result->getQuery()->orders ?? []);
     }
@@ -148,7 +149,7 @@ class OrderApplierTest extends TestCase
     public function testApplyWithRandomAndRegularColumnsAppliesBoth(): void
     {
         $query  = (new User)->newQuery();
-        $result = $this->applier->apply($query, ['random' => 'asc', 'name' => 'desc'], $this->schemaIntrospector);
+        $result = $this->applier->apply($query, ['random' => 'asc', 'name' => 'desc'], $this->surface());
 
         $orders = $result->getQuery()->orders ?? [];
 
@@ -166,5 +167,16 @@ class OrderApplierTest extends TestCase
     public function testOrderByRandomConstantValue(): void
     {
         static::assertSame('random', OrderApplier::ORDER_BY_RANDOM);
+    }
+
+    /**
+     * Build a blocklist query surface that delegates to the stubbed
+     * introspector, preserving the legacy searchable gating these tests assert.
+     *
+     * @return \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface
+     */
+    private function surface(): QuerySurface
+    {
+        return new QuerySurface([], [], [], QuerySurface::POSTURE_BLOCKLIST, true, $this->schemaIntrospector, new User);
     }
 }

--- a/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
+++ b/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Unit\Repositories\Criteria;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
 use Tests\TestCase;
 
 /**
@@ -21,7 +22,7 @@ use Tests\TestCase;
 class QuerySurfaceTest extends TestCase
 {
     /**
-     * Test that the allowlist posture permits a declared filter column and
+     * Test that the allowlist posture permits a declared root filter column and
      * rejects an undeclared one with a validation error naming the key.
      *
      * @return void
@@ -30,10 +31,10 @@ class QuerySurfaceTest extends TestCase
     {
         $surface = $this->make(filterable: ['email']);
 
-        static::assertTrue($surface->guardFilter('email'));
+        static::assertTrue($surface->guardFilter('email', new User));
 
         try {
-            $surface->guardFilter('password');
+            $surface->guardFilter('password', new User);
             static::fail('Expected a ValidationException for an undeclared filter key.');
         } catch (ValidationException $exception) {
             static::assertArrayHasKey('filters.password', $exception->errors());
@@ -51,11 +52,11 @@ class QuerySurfaceTest extends TestCase
     {
         $surface = $this->make(sortable: ['created_at'], relations: ['posts']);
 
-        static::assertTrue($surface->guardSort('created_at'));
-        static::assertTrue($surface->guardRelation('posts'));
+        static::assertTrue($surface->guardSort('created_at', new User));
+        static::assertTrue($surface->guardRelation('posts', new User));
 
-        $this->assertRejects(fn () => $surface->guardSort('secret'), 'order.secret');
-        $this->assertRejects(fn () => $surface->guardRelation('audits'), 'filters.audits');
+        $this->assertRejects(fn () => $surface->guardSort('secret', new User), 'order.secret');
+        $this->assertRejects(fn () => $surface->guardRelation('audits', new User), 'filters.audits');
     }
 
     /**
@@ -67,12 +68,12 @@ class QuerySurfaceTest extends TestCase
     {
         $surface = $this->make(filterable: ['email'], reject: false);
 
-        static::assertFalse($surface->guardFilter('password'));
+        static::assertFalse($surface->guardFilter('password', new User));
     }
 
     /**
-     * Test that a resource with no declared surface rejects every key under the
-     * default allowlist posture (secure by default).
+     * Test that a resource with no declared surface rejects every root key under
+     * the default allowlist posture (secure by default).
      *
      * @return void
      */
@@ -80,7 +81,26 @@ class QuerySurfaceTest extends TestCase
     {
         $surface = $this->make();
 
-        $this->assertRejects(fn () => $surface->guardFilter('email'), 'filters.email');
+        $this->assertRejects(fn () => $surface->guardFilter('email', new User), 'filters.email');
+    }
+
+    /**
+     * Test that a key targeting a nested/related model falls back to the legacy
+     * searchable predicate rather than the root allowlist, and is never rejected
+     * (nested-column granularity is deferred to P2).
+     *
+     * @return void
+     */
+    public function testNestedRelatedModelFallsBackToLegacySearchable(): void
+    {
+        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::type(Post::class), 'title')->andReturnTrue();
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::type(Post::class), 'secret')->andReturnFalse();
+
+        $surface = $this->make(filterable: ['email'], introspector: $introspector);
+
+        static::assertTrue($surface->guardFilter('title', new Post));
+        static::assertFalse($surface->guardFilter('secret', new Post));
     }
 
     /**
@@ -98,9 +118,9 @@ class QuerySurfaceTest extends TestCase
 
         $surface = $this->make(posture: QuerySurface::POSTURE_BLOCKLIST, introspector: $introspector);
 
-        static::assertTrue($surface->guardFilter('email'));
-        static::assertTrue($surface->guardRelation('posts'));
-        static::assertFalse($surface->guardFilter('secret'));
+        static::assertTrue($surface->guardFilter('email', new User));
+        static::assertTrue($surface->guardRelation('posts', new User));
+        static::assertFalse($surface->guardFilter('secret', new User));
     }
 
     /**
@@ -129,7 +149,7 @@ class QuerySurfaceTest extends TestCase
             $posture,
             $reject,
             $introspector ?? \Mockery::mock(SchemaIntrospectionProvider::class),
-            \Mockery::mock(Model::class),
+            new User,
         );
     }
 

--- a/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
+++ b/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Unit\Repositories\Criteria;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\TestCase;
+
+/**
+ * Tests for the QuerySurface enforcement policy.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QuerySurface::class)]
+class QuerySurfaceTest extends TestCase
+{
+    /**
+     * Test that the allowlist posture permits a declared filter column and
+     * rejects an undeclared one with a validation error naming the key.
+     *
+     * @return void
+     */
+    public function testAllowlistPermitsDeclaredAndRejectsUndeclaredFilter(): void
+    {
+        $surface = $this->make(filterable: ['email']);
+
+        static::assertTrue($surface->guardFilter('email'));
+
+        try {
+            $surface->guardFilter('password');
+            static::fail('Expected a ValidationException for an undeclared filter key.');
+        } catch (ValidationException $exception) {
+            static::assertArrayHasKey('filters.password', $exception->errors());
+            static::assertStringContainsString('password', $exception->errors()['filters.password'][0]);
+        }
+    }
+
+    /**
+     * Test that declared sort columns and traversable relations are permitted
+     * and undeclared ones rejected under the allowlist posture.
+     *
+     * @return void
+     */
+    public function testAllowlistGovernsSortAndRelationCapabilities(): void
+    {
+        $surface = $this->make(sortable: ['created_at'], relations: ['posts']);
+
+        static::assertTrue($surface->guardSort('created_at'));
+        static::assertTrue($surface->guardRelation('posts'));
+
+        $this->assertRejects(fn () => $surface->guardSort('secret'), 'order.secret');
+        $this->assertRejects(fn () => $surface->guardRelation('audits'), 'filters.audits');
+    }
+
+    /**
+     * Test that the fail-quiet toggle drops an undeclared key without throwing.
+     *
+     * @return void
+     */
+    public function testFailQuietDropsUndeclaredKeyWithoutThrowing(): void
+    {
+        $surface = $this->make(filterable: ['email'], reject: false);
+
+        static::assertFalse($surface->guardFilter('password'));
+    }
+
+    /**
+     * Test that a resource with no declared surface rejects every key under the
+     * default allowlist posture (secure by default).
+     *
+     * @return void
+     */
+    public function testEmptySurfaceRejectsEveryKey(): void
+    {
+        $surface = $this->make();
+
+        $this->assertRejects(fn () => $surface->guardFilter('email'), 'filters.email');
+    }
+
+    /**
+     * Test that the blocklist posture delegates to the schema introspector and
+     * drops (rather than rejects) an unsearchable key.
+     *
+     * @return void
+     */
+    public function testBlocklistDelegatesToIntrospectorAndDropsUnsearchable(): void
+    {
+        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'email')->andReturnTrue();
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'secret')->andReturnFalse();
+        $introspector->shouldReceive('isRelation')->with('posts', \Mockery::any())->andReturnTrue();
+
+        $surface = $this->make(posture: QuerySurface::POSTURE_BLOCKLIST, introspector: $introspector);
+
+        static::assertTrue($surface->guardFilter('email'));
+        static::assertTrue($surface->guardRelation('posts'));
+        static::assertFalse($surface->guardFilter('secret'));
+    }
+
+    /**
+     * Build a query surface with sensible defaults for the test under focus.
+     *
+     * @param  array<int, string>  $filterable
+     * @param  array<int, string>  $sortable
+     * @param  array<int, string>  $relations
+     * @param  string  $posture
+     * @param  bool  $reject
+     * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider|null  $introspector
+     * @return \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface
+     */
+    private function make(
+        array $filterable = [],
+        array $sortable = [],
+        array $relations = [],
+        string $posture = QuerySurface::POSTURE_ALLOWLIST,
+        bool $reject = true,
+        ?SchemaIntrospectionProvider $introspector = null,
+    ): QuerySurface {
+        return new QuerySurface(
+            $filterable,
+            $sortable,
+            $relations,
+            $posture,
+            $reject,
+            $introspector ?? \Mockery::mock(SchemaIntrospectionProvider::class),
+            \Mockery::mock(Model::class),
+        );
+    }
+
+    /**
+     * Assert that invoking the guard rejects with a ValidationException whose
+     * errors contain the given key.
+     *
+     * @param  callable(): void  $guard
+     * @param  string  $errorKey
+     * @return void
+     */
+    private function assertRejects(callable $guard, string $errorKey): void
+    {
+        try {
+            $guard();
+            static::fail('Expected a ValidationException for key ' . $errorKey . '.');
+        } catch (ValidationException $exception) {
+            static::assertArrayHasKey($errorKey, $exception->errors());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Flips API filtering and sorting from a **blocklist** (shape-derived, opt-out) to an **allowlist** (intent-derived, secure-by-default) posture. A resource now declares which columns are filterable/sortable and which relations are traversable in its schema; any undeclared key on the root resource is rejected (fail-closed) or dropped (fail-quiet). A model with no mapped resource yields an empty surface, so the allowlist rejects every key - secure by default.

Resolves **BL-20**.

## What changed

**Schema DSL (declared intent)**
- `Field::filterable()` / `Field::sortable()` and `Relation::traversable()` fluent markers
- The marker is keyed by the **column name**, not the presentation alias
- `SchemaCompiler` aggregates the markers into de-duplicated query-surface sets on `CompiledSchema`

**Enforcement (`QuerySurface`)**
- New `QuerySurface` policy: under the allowlist posture a key on the **root** model is permitted only when declared; nested/related models fall back to the legacy `isSearchable`/`isRelation` predicates (per-related-resource column granularity deferred to P2)
- Threaded through the six filter/sort gates in `FilterApplier` and `OrderApplier`, built in `ApiCriteria` from the compiled schema + configured posture
- Fail-closed rejects with a named `ValidationException` (`filters.<key>` / `order.<key>`); fail-quiet drops the key

**Config**
- `API_TOOLKIT_QUERY_POSTURE` (`allowlist` default, `blocklist` opt-out)
- `API_TOOLKIT_REJECT_UNDECLARED` (`true` default)
- Widened `searchable_exclusions` defaults (adds the `two_factor_*` columns and `email_verified_at`) so even the legacy posture leaks fewer sensitive columns

**Docs**
- `UPGRADE.md` migration section: action required, restore-previous-behaviour, fail-closed vs fail-quiet, widened exclusions
- `CHANGELOG.md` Changed/Added entries

## Testing

- `composer test` green (1936 tests, 1 pre-existing skip)
- `composer check` clean (only a pre-existing markdown line-length finding in an archived PRD, untouched here)
- `composer test:mutation` passes the MSI gate (Covered MSI 94%)
- New `QuerySurfaceIntegrationTest` drives the full `ApiCriteria` pipeline against a real DB: four capabilities x gates, allowlist default, fail-closed/fail-quiet, nested-relation fallback, null-resource secure default, and cross-surface coherence (export-ignored fields are excluded from filtering)
- Posture-independent mechanics/lifecycle tests are pinned to the blocklist posture so their legacy contract holds unchanged

## Migration

Existing resources must declare their query surface or undeclared keys begin returning `422`. Set `API_TOOLKIT_QUERY_POSTURE=blocklist` to retain the previous behaviour transitionally. See `UPGRADE.md` for details.