### PR TITLE
feat: stateless lifecycle flush by default under Octane/queue [BL-18]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,20 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
   eager-load and count maps per request. The memos are static but request-scoped - `CacheManager::flush()` clears
   them at request and worker boundaries (Octane, queues) - so repeated reads no longer re-reflect or rebuild the
   same map once per record
+- The cross-request metadata cache flush is now enabled by default when the application is actively serving
+  under Octane or as a queue worker (php-fpm and CLI commands are unaffected). Operators who need to opt out
+  can set `API_TOOLKIT_LIFECYCLE_OCTANE=false` or `API_TOOLKIT_LIFECYCLE_QUEUE=false`. See
+  [UPGRADE.md](UPGRADE.md) for migration steps
+- The lifecycle flush is now scoped to the toolkit's own metadata keys via a per-key registry, so non-toolkit
+  application cache entries and repository result caches are no longer cleared at the request boundary
 
 ### Added
 
+- Serving-runtime detection that discriminates between a runtime merely having Octane or a queue driver
+  installed versus actively serving requests, gating the lifecycle flush to only fire when the process is
+  inside a live Octane worker or a non-`sync` queue worker
+- A non-silent off-state diagnostic: when a serving runtime is detected but the lifecycle flush is opted-out,
+  an `info`-level log entry is emitted so operators know the flush is intentionally disabled
 - Extensible filter operator registry
 - Schema introspection service and boot-time schema validation
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -520,3 +520,61 @@ use `log` for fire-and-forget writes that must never be retained.
 `flushedRecordCount()`, `failedRecordCount()`, `retainedRecordCount()`, and `droppedRecordCount()` --
 alongside the existing chunk counters. Subscribe to the `WritePoolFlushFailed` event to escalate
 retained failures to a dead-letter sink, alerting, or metrics.
+
+### Changed: Lifecycle metadata flush is now on by default on serving runtimes
+
+Under 2.x, the cross-request metadata flush ships **enabled by default** on runtimes that are actively
+serving requests under Octane or running as a queue worker. php-fpm is unaffected because each request
+already starts with a clean process; the runtime detector gates engagement and does not fire under
+php-fpm even when Octane is installed.
+
+**Runtime detection.** Serving is discriminated from mere installation:
+
+- Octane: the `$_SERVER['LARAVEL_OCTANE']` superglobal is set by a booted Octane worker, not by
+  package installation, so the flush only engages when the worker is actually serving.
+- Queue worker: `JobProcessed` and `JobFailed` fire inside a real worker loop. A job dispatched over
+  the `sync` driver fires the same events within the originating HTTP request; the toolkit checks the
+  connection driver and treats `sync` as a non-worker boundary, leaving php-fpm unaffected.
+
+**What survives across requests (the cache-site inventory).** Three in-process metadata caches
+accumulate state across requests under a long-lived runtime:
+
+- The process-static schema compile cache (`SchemaCompiler::$cache`), cleared by
+  `SchemaCompiler::clearCache()`.
+- The `SchemaIntrospector` singleton's in-memory arrays (column definitions, relations, resources),
+  cleared by its `flush()` method.
+- The `Cache::memo()` `rememberForever` metadata store -- the toolkit metadata keys: model schema
+  columns, column definitions, relations, resources, and repository model casts.
+
+The single surface that clears all three is `CacheManager::flush()`, invoked automatically by the
+Octane and queue lifecycle listeners at every request/job boundary.
+
+**Scoped flush -- what is NOT cleared.** The flush is scoped to the toolkit's own metadata keys via
+a key registry and per-key `Cache::memo()->forget()` calls. It does **not** issue a whole-store
+clear. Non-toolkit application keys and repository result caches on a shared cache store survive the
+flush. Any new toolkit metadata key must be written through the `MetadataCacheWriter` chokepoint so
+it is registered and cleared at the next boundary.
+
+**Re-warm trade-off.** Clearing metadata at the serving boundary means the next request re-warms
+that metadata from the database (a small, bounded re-introspection cost). This is the price of
+correct schema and cast data after a deploy without a worker restart. Operators who accept potential
+staleness in exchange for zero re-warm cost should use the opt-out below.
+
+**Action required.** No action is needed for most applications. The flush is additive on Octane and
+queue-worker runtimes; php-fpm behaviour is unchanged.
+
+**Restore the previous behaviour** (metadata is not flushed at boundaries -- staleness risk on
+long-lived runtimes after a deploy):
+
+    API_TOOLKIT_LIFECYCLE_OCTANE=false
+    API_TOOLKIT_LIFECYCLE_QUEUE=false
+
+Or set the equivalent config keys to `false` in a published `config/api-toolkit.php`:
+
+    'lifecycle' => [
+        'octane' => false,
+        'queue'  => false,
+    ],
+
+When a serving runtime is detected but the flush is opted out, the toolkit logs a one-line
+`Log::info` diagnostic so the disabled state is not silent.

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -336,16 +336,20 @@ return [
     | the toolkit automatically flushes all cached metadata at the appropriate
     | lifecycle boundaries to prevent stale data.
     |
-    | Both options are disabled by default, meaning standard PHP-FPM
-    | deployments incur no additional overhead.
+    | Both options are enabled by default. Engagement is gated on runtime
+    | detection (LARAVEL_OCTANE server variable / non-sync queue connection),
+    | so standard PHP-FPM deployments incur no additional overhead - detection
+    | returns false and the flush is skipped. Operators running Octane or queue
+    | workers who wish to opt out may set API_TOOLKIT_LIFECYCLE_OCTANE=false
+    | or API_TOOLKIT_LIFECYCLE_QUEUE=false in their environment.
     |
     */
 
     'lifecycle' => [
 
-        'octane' => env('API_TOOLKIT_LIFECYCLE_OCTANE', false),
+        'octane' => env('API_TOOLKIT_LIFECYCLE_OCTANE', true),
 
-        'queue' => env('API_TOOLKIT_LIFECYCLE_QUEUE', false),
+        'queue' => env('API_TOOLKIT_LIFECYCLE_QUEUE', true),
 
     ],
 

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -26,12 +26,16 @@ final class CacheManager
      * Create a new cache manager instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry  $registry
      * @return void
      */
     public function __construct(
 
         /** The service container for resolving cache site instances. */
         private readonly Container $container,
+
+        /** The registry of toolkit metadata keys to forget on flush. */
+        private readonly MetadataKeyRegistry $registry,
 
     ) {}
 
@@ -42,7 +46,11 @@ final class CacheManager
      */
     public function flush(): void
     {
-        Cache::memo()->getStore()->flush();
+        foreach ($this->registry->keys() as $key) {
+            Cache::memo()->forget($key); // @phpstan-ignore method.notFound
+        }
+
+        $this->registry->clear();
 
         SchemaCompiler::clearCache();
         ValueResolver::clearCache();

--- a/src/Cache/MetadataCacheWriter.php
+++ b/src/Cache/MetadataCacheWriter.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Cache;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * The single sanctioned path for writing forever-memoised toolkit metadata.
+ *
+ * Every write registers its key with the MetadataKeyRegistry so a scoped flush
+ * can forget exactly the toolkit's own keys. A metadata write that bypasses
+ * this writer would not be registered and would survive the flush.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class MetadataCacheWriter
+{
+    /**
+     * Create a new metadata cache writer instance.
+     *
+     * @param  \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry  $registry
+     * @return void
+     */
+    public function __construct(
+
+        /** The registry that tracks live toolkit metadata keys for scoped flushing. */
+        private readonly MetadataKeyRegistry $registry,
+
+    ) {}
+
+    /**
+     * Store a forever-memoised metadata value and register its key.
+     *
+     * The key is registered before the memo write so it is tracked even when
+     * the value is already warm and the callback is never invoked.
+     *
+     * @template TValue
+     *
+     * @param  string  $key
+     * @param  callable():TValue  $callback
+     * @return TValue
+     */
+    public function rememberMetadataForever(string $key, callable $callback): mixed
+    {
+        $this->registry->register($key);
+
+        return Cache::memo()->rememberForever($key, static fn () => $callback()); // @phpstan-ignore method.notFound
+    }
+}

--- a/src/Cache/MetadataKeyRegistry.php
+++ b/src/Cache/MetadataKeyRegistry.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Cache;
+
+/**
+ * Tracks the live set of toolkit metadata cache keys so the cache manager can
+ * forget exactly those keys on flush, leaving non-toolkit keys intact.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class MetadataKeyRegistry
+{
+    /** @var array<string, bool> The registered keys, keyed by the key string for O(1) deduplication. */
+    private array $keys = [];
+
+    /**
+     * Register a metadata cache key.
+     *
+     * Registering a key that is already present is a no-op; the set remains
+     * deduplicated.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function register(string $key): void
+    {
+        $this->keys[$key] = true;
+    }
+
+    /**
+     * Return the distinct registered keys as an integer-indexed list.
+     *
+     * @return array<int, string>
+     */
+    public function keys(): array
+    {
+        return array_keys($this->keys);
+    }
+
+    /**
+     * Empty the registry.
+     *
+     * After calling this method, {@see keys()} returns an empty array.
+     *
+     * @return void
+     */
+    public function clear(): void
+    {
+        $this->keys = [];
+    }
+}

--- a/src/Cache/MetadataKeyRegistry.php
+++ b/src/Cache/MetadataKeyRegistry.php
@@ -11,7 +11,7 @@ namespace SineMacula\ApiToolkit\Cache;
  */
 final class MetadataKeyRegistry
 {
-    /** @var array<string, bool> The registered keys, keyed by the key string for O(1) deduplication. */
+    /** @var array<string, string> The registered keys, mapped to themselves for O(1) deduplication. */
     private array $keys = [];
 
     /**
@@ -25,7 +25,7 @@ final class MetadataKeyRegistry
      */
     public function register(string $key): void
     {
-        $this->keys[$key] = true;
+        $this->keys[$key] = $key;
     }
 
     /**
@@ -35,7 +35,7 @@ final class MetadataKeyRegistry
      */
     public function keys(): array
     {
-        return array_keys($this->keys);
+        return array_values($this->keys);
     }
 
     /**

--- a/src/Listeners/OctaneFlushListener.php
+++ b/src/Listeners/OctaneFlushListener.php
@@ -4,12 +4,14 @@ namespace SineMacula\ApiToolkit\Listeners;
 
 use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 
 /**
  * Flushes all toolkit caches after each Octane request.
  *
  * Prevents stale metadata from persisting across requests in long-running
- * Octane processes by delegating to the centralized CacheManager.
+ * Octane processes by delegating to the centralized CacheManager. When not
+ * serving under Octane (e.g. php-fpm), the flush is skipped entirely.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -20,12 +22,16 @@ final class OctaneFlushListener
      * Create a new octane flush listener instance.
      *
      * @param  \SineMacula\ApiToolkit\Cache\CacheManager  $cacheManager
+     * @param  \SineMacula\ApiToolkit\Runtime\RuntimeContext  $runtime
      * @return void
      */
     public function __construct(
 
         /** The cache manager for flushing toolkit caches. */
         private readonly CacheManager $cacheManager,
+
+        /** The runtime context for detecting the serving environment. */
+        private readonly RuntimeContext $runtime,
 
     ) {}
 
@@ -42,6 +48,10 @@ final class OctaneFlushListener
      */
     public function handle(object $event): void
     {
+        if (!$this->runtime->isServingUnderOctane()) {
+            return;
+        }
+
         try {
             $this->cacheManager->flush();
         } catch (\Throwable $exception) {

--- a/src/Listeners/QueueFlushSubscriber.php
+++ b/src/Listeners/QueueFlushSubscriber.php
@@ -6,12 +6,15 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 
 /**
  * Flushes all toolkit caches after each queue job completes or fails.
  *
  * Prevents stale metadata from persisting across jobs in long-running
- * worker processes by delegating to the centralized CacheManager.
+ * worker processes by delegating to the centralized CacheManager. When the
+ * job was dispatched via the sync driver (i.e. within an HTTP request), the
+ * flush is skipped entirely.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -22,12 +25,16 @@ final class QueueFlushSubscriber
      * Create a new queue flush subscriber instance.
      *
      * @param  \SineMacula\ApiToolkit\Cache\CacheManager  $cacheManager
+     * @param  \SineMacula\ApiToolkit\Runtime\RuntimeContext  $runtime
      * @return void
      */
     public function __construct(
 
         /** The cache manager for flushing toolkit caches. */
         private readonly CacheManager $cacheManager,
+
+        /** The runtime context for detecting the serving environment. */
+        private readonly RuntimeContext $runtime,
 
     ) {}
 
@@ -44,12 +51,20 @@ final class QueueFlushSubscriber
     }
 
     /**
-     * Flush all toolkit caches.
+     * Flush all toolkit caches when running inside a real queue worker.
      *
+     * Jobs dispatched via the sync driver run within the HTTP request and do
+     * not constitute a worker boundary; those are skipped.
+     *
+     * @param  \Illuminate\Queue\Events\JobFailed|\Illuminate\Queue\Events\JobProcessed  $event
      * @return void
      */
-    public function handleFlush(): void
+    public function handleFlush(JobFailed|JobProcessed $event): void
     {
+        if (!$this->runtime->isServingAsQueueWorker($event->connectionName)) {
+            return;
+        }
+
         $this->cacheManager->flush();
     }
 }

--- a/src/Providers/Registrars/ContainerBindingRegistrar.php
+++ b/src/Providers/Registrars/ContainerBindingRegistrar.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\ApiQueryParser;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\FlushStrategy;
 use SineMacula\ApiToolkit\OpenApi\Contracts\DocumentWriter;
@@ -26,6 +28,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LikeOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 use SineMacula\ApiToolkit\Services\SchemaIntrospector;
 use SineMacula\ApiToolkit\Services\SchemaValidator;
 use SineMacula\ApiToolkit\Services\Validation\Rules\ValidateAccessors;
@@ -76,6 +79,7 @@ final class ContainerBindingRegistrar
         $this->registerSchemaValidator();
         $this->registerWritePool();
         $this->registerCacheManager();
+        $this->registerLifecycleRuntime();
         $this->registerOpenApiExporter();
     }
 
@@ -193,6 +197,22 @@ final class ContainerBindingRegistrar
     private function registerCacheManager(): void
     {
         $this->container->singleton(CacheManager::class);
+    }
+
+    /**
+     * Bind the lifecycle runtime collaborators to the service container.
+     *
+     * RuntimeContext, MetadataKeyRegistry, and MetadataCacheWriter are each
+     * bound as singletons so write-time and flush-time share one live instance
+     * within a worker process.
+     *
+     * @return void
+     */
+    private function registerLifecycleRuntime(): void
+    {
+        $this->container->singleton(RuntimeContext::class);
+        $this->container->singleton(MetadataKeyRegistry::class);
+        $this->container->singleton(MetadataCacheWriter::class);
     }
 
     /**

--- a/src/Providers/Registrars/LifecycleRegistrar.php
+++ b/src/Providers/Registrars/LifecycleRegistrar.php
@@ -4,9 +4,11 @@ namespace SineMacula\ApiToolkit\Providers\Registrars;
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 
 /**
  * Registers the toolkit lifecycle listeners.
@@ -30,6 +32,7 @@ final class LifecycleRegistrar
         $this->registerWritePoolFlushSubscriber();
         $this->registerOctaneFlushListener();
         $this->registerQueueFlushSubscriber();
+        $this->reportOffStateDiagnostic();
     }
 
     /**
@@ -73,5 +76,27 @@ final class LifecycleRegistrar
         }
 
         Event::subscribe(QueueFlushSubscriber::class);
+    }
+
+    /**
+     * Emit a boot-time informational log when a serving runtime is detected but
+     * the corresponding lifecycle flush is opted-out, so the off state is
+     * observable rather than silent.
+     *
+     * Under php-fpm both runtime checks return false and nothing is logged.
+     *
+     * @return void
+     */
+    private function reportOffStateDiagnostic(): void
+    {
+        $runtime = app(RuntimeContext::class);
+
+        if ($runtime->isServingUnderOctane() && !(bool) Config::get('api-toolkit.lifecycle.octane')) {
+            Log::info('API Toolkit: serving under Octane but the lifecycle cache flush is disabled (API_TOOLKIT_LIFECYCLE_OCTANE=false); cross-request metadata may go stale.');
+        }
+
+        if ($runtime->isServingAsQueueWorker() && !(bool) Config::get('api-toolkit.lifecycle.queue')) {
+            Log::info('API Toolkit: serving as a queue worker but the lifecycle cache flush is disabled (API_TOOLKIT_LIFECYCLE_QUEUE=false); cross-request metadata may go stale.');
+        }
     }
 }

--- a/src/Repositories/Concerns/AttributeSetter.php
+++ b/src/Repositories/Concerns/AttributeSetter.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 
@@ -300,7 +301,17 @@ final class AttributeSetter
      */
     private function storeCastsInCache(string $modelClass): void
     {
-        Cache::memo()->rememberForever(CacheKeys::REPOSITORY_MODEL_CASTS->resolveKey([$modelClass]), fn () => $this->casts);
+        $this->metadataCacheWriter()->rememberMetadataForever(CacheKeys::REPOSITORY_MODEL_CASTS->resolveKey([$modelClass]), fn () => $this->casts);
+    }
+
+    /**
+     * Resolve the metadata cache writer from the container.
+     *
+     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+     */
+    private function metadataCacheWriter(): MetadataCacheWriter
+    {
+        return app(MetadataCacheWriter::class);
     }
 
     /**

--- a/src/Repositories/Traits/ResolvesResource.php
+++ b/src/Repositories/Traits/ResolvesResource.php
@@ -5,6 +5,7 @@ namespace SineMacula\ApiToolkit\Repositories\Traits;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
 use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 
@@ -63,7 +64,7 @@ trait ResolvesResource
     {
         $class = $model::class;
 
-        return Cache::memo()->rememberForever(CacheKeys::MODEL_RESOURCES->resolveKey([$class]), function () use ($class) {
+        return app(MetadataCacheWriter::class)->rememberMetadataForever(CacheKeys::MODEL_RESOURCES->resolveKey([$class]), function () use ($class) {
 
             $resource = Config::get('api-toolkit.resources.resource_map.' . $class);
 

--- a/src/Runtime/RuntimeContext.php
+++ b/src/Runtime/RuntimeContext.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Runtime;
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Detects whether the current process is actually serving under a long-lived
+ * worker runtime (Octane or a real queue worker), as opposed to one where the
+ * runtime is merely installed.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class RuntimeContext
+{
+    /**
+     * Determine whether the current process is being served under Octane.
+     *
+     * Returns true only when `$_SERVER['LARAVEL_OCTANE']` is set. A booted
+     * Octane worker sets this key; merely having laravel/octane installed under
+     * php-fpm does not.
+     *
+     * @return bool
+     */
+    public function isServingUnderOctane(): bool
+    {
+        return isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Determine whether the current process is serving as a real queue worker.
+     *
+     * When `$connection` is null, the default queue connection is resolved from
+     * config. Returns true only when the resolved driver is a non-`sync` string.
+     * The `sync` driver runs jobs inside the dispatching HTTP request and is
+     * therefore not a real worker boundary.
+     *
+     * @param  string|null  $connection
+     * @return bool
+     */
+    public function isServingAsQueueWorker(?string $connection = null): bool
+    {
+        if ($connection === null) {
+            $default = Config::get('queue.default');
+
+            if (!is_string($default) || $default === '') {
+                return false;
+            }
+
+            $connection = $default;
+        }
+
+        $driver = Config::get("queue.connections.{$connection}.driver");
+
+        if (!is_string($driver) || $driver === '') {
+            return false;
+        }
+
+        return $driver !== 'sync';
+    }
+}

--- a/src/Services/SchemaIntrospector.php
+++ b/src/Services/SchemaIntrospector.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 use SineMacula\ApiToolkit\Services\Introspection\ColumnDefinition;
@@ -66,7 +67,7 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
 
         $columns = Schema::getColumnListing($model->getTable());
 
-        Cache::memo()->rememberForever($cacheKey, fn () => $columns);
+        $this->metadataCacheWriter()->rememberMetadataForever($cacheKey, fn () => $columns);
 
         $this->columns[$model::class] = $columns;
 
@@ -102,7 +103,7 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
 
         $definitions = $this->mapColumnDefinitions(Schema::getColumns($model->getTable()));
 
-        Cache::memo()->rememberForever($cacheKey, fn () => $definitions);
+        $this->metadataCacheWriter()->rememberMetadataForever($cacheKey, fn () => $definitions);
 
         $this->columnDefinitions[$model::class] = $definitions;
 
@@ -169,7 +170,7 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
     #[\Override]
     public function isRelation(string $key, Model $model): bool
     {
-        return Cache::memo()->rememberForever(CacheKeys::MODEL_RELATIONS->resolveKey([
+        return $this->metadataCacheWriter()->rememberMetadataForever(CacheKeys::MODEL_RELATIONS->resolveKey([
             $model::class,
             $key,
         ]), function () use ($key, $model) {
@@ -256,6 +257,16 @@ class SchemaIntrospector implements SchemaIntrospectionProvider
         $this->columns           = [];
         $this->columnDefinitions = [];
         $this->searchable        = [];
+    }
+
+    /**
+     * Resolve the metadata cache writer from the container.
+     *
+     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+     */
+    private function metadataCacheWriter(): MetadataCacheWriter
+    {
+        return app(MetadataCacheWriter::class);
     }
 
     /**

--- a/tests/Integration/ApiServiceProviderTest.php
+++ b/tests/Integration/ApiServiceProviderTest.php
@@ -1080,6 +1080,10 @@ class ApiServiceProviderTest extends TestCase
     {
         $app = $this->getApplication();
 
+        // Reset the dispatcher so the boot-time wiring (now default-on) does not
+        // pollute the baseline being tested.
+        \Illuminate\Support\Facades\Event::swap(new \Illuminate\Events\Dispatcher($app));
+
         $this->getConfig()->set('api-toolkit.lifecycle.queue', false);
 
         $provider = new ApiServiceProvider($app);

--- a/tests/Integration/LifecycleDefaultEngagementTest.php
+++ b/tests/Integration/LifecycleDefaultEngagementTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
+use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
+use Tests\TestCase;
+
+/**
+ * Proves that the SHIPPED DEFAULT config engages the lifecycle flush.
+ *
+ * No lifecycle config keys are set in this file - the tests read the merged
+ * package default directly to pin that the shipped default is true and that
+ * the flush engages under a detected serving runtime. This kills the
+ * default-value mutation (a mutant flipping the default back to false must
+ * fail these assertions).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(CacheManager::class)]
+#[CoversClass(OctaneFlushListener::class)]
+#[CoversClass(QueueFlushSubscriber::class)]
+class LifecycleDefaultEngagementTest extends TestCase
+{
+    /** @var bool Whether LARAVEL_OCTANE was set before each test. */
+    private bool $octaneWasSet;
+
+    /**
+     * Capture the initial LARAVEL_OCTANE server state.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore LARAVEL_OCTANE to its pre-test state after each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        } else {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the shipped default for lifecycle.octane and lifecycle.queue
+     * is true and that the Octane flush engages on a detected serving runtime.
+     *
+     * Validates TAC-09-01 and TAC-09-02: with no config override the merged
+     * default is true, and invoking the Octane boundary on a serving runtime
+     * clears the registered toolkit key.
+     *
+     * @return void
+     */
+    public function testShippedDefaultEngagesOctaneFlushOnServingRuntime(): void
+    {
+        // Assert the shipped defaults are on - kills the default-value mutation.
+        static::assertTrue((bool) config('api-toolkit.lifecycle.octane'));
+        static::assertTrue((bool) config('api-toolkit.lifecycle.queue'));
+
+        // Arrange: simulate a serving Octane runtime.
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        Event::fake();
+
+        $key = 'integration:default-engagement-octane';
+
+        // Write through the writer so the key is registered in the registry.
+        $this->writer()->rememberMetadataForever($key, static fn () => 'value');
+        static::assertSame('value', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Act: invoke the Octane boundary with the shipped default config.
+        $this->octaneListener()->handle(new \stdClass);
+
+        // Assert: the toolkit key was cleared (flush engaged on the default).
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that the shipped queue default engages the flush on a non-sync
+     * worker boundary.
+     *
+     * Validates TAC-09-01: the shipped queue default is true, and the flush
+     * engages when a real (non-sync) queue connection processes a job.
+     *
+     * @return void
+     */
+    public function testShippedDefaultEngagesQueueFlushOnServingRuntime(): void
+    {
+        // Assert the shipped queue default is on.
+        static::assertTrue((bool) config('api-toolkit.lifecycle.queue'));
+
+        // Arrange: configure a non-sync connection to signal a real worker.
+        \Illuminate\Support\Facades\Config::set('queue.connections.database.driver', 'database');
+
+        Event::fake();
+
+        $key = 'integration:default-engagement-queue';
+
+        // Write through the writer so the key is registered in the registry.
+        $this->writer()->rememberMetadataForever($key, static fn () => 'value');
+        static::assertSame('value', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Act: invoke the queue boundary with the shipped default config.
+        $event = new JobProcessed('database', static::createStub(Job::class));
+        $this->queueSubscriber()->handleFlush($event);
+
+        // Assert: the toolkit key was cleared (flush engaged on the default).
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Resolve the wired MetadataCacheWriter singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+     */
+    private function writer(): MetadataCacheWriter
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataCacheWriter */
+        return $this->app->make(MetadataCacheWriter::class);
+    }
+
+    /**
+     * Build an OctaneFlushListener backed by the wired CacheManager singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Listeners\OctaneFlushListener
+     */
+    private function octaneListener(): OctaneFlushListener
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->make(CacheManager::class);
+
+        return new OctaneFlushListener($cacheManager, new RuntimeContext);
+    }
+
+    /**
+     * Build a QueueFlushSubscriber backed by the wired CacheManager singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber
+     */
+    private function queueSubscriber(): QueueFlushSubscriber
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->make(CacheManager::class);
+
+        return new QueueFlushSubscriber($cacheManager, new RuntimeContext);
+    }
+}

--- a/tests/Integration/LifecycleFlushDefaultsTest.php
+++ b/tests/Integration/LifecycleFlushDefaultsTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
+use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
+use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
+use Tests\TestCase;
+
+/**
+ * Integration harness: cross-request metadata staleness under Octane and queue.
+ *
+ * Proves that stale metadata is cleared at the correct lifecycle boundary,
+ * that php-fpm does not engage, that opt-out is honoured, and that non-toolkit
+ * keys on the shared store survive the scoped flush.
+ *
+ * Every test sets the relevant config and $_SERVER state EXPLICITLY so the
+ * mechanism is validated before the shipped default is flipped in Tier 4.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(CacheManager::class)]
+class LifecycleFlushDefaultsTest extends TestCase
+{
+    /** @var bool Whether LARAVEL_OCTANE was set before each test. */
+    private bool $octaneWasSet;
+
+    /**
+     * Capture the initial LARAVEL_OCTANE state and resolve shared singletons.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore the LARAVEL_OCTANE server variable after each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        } else {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that an Octane boundary flushes stale metadata so request 2 reads
+     * the new shape rather than the memoised old shape.
+     *
+     * Validates AC-03 / AC-04: under a long-lived Octane worker, metadata
+     * written before the request boundary must not survive into the next request.
+     *
+     * @return void
+     */
+    public function testOctaneServingFlushesStaleMetadataAcrossRequests(): void
+    {
+        // Arrange
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+        Config::set('api-toolkit.lifecycle.octane', true);
+
+        Event::fake();
+
+        $key    = 'integration:octane-staleness-test';
+        $writer = $this->writer();
+
+        // Request 1: write and confirm the old shape is memoised.
+        $writer->rememberMetadataForever($key, static fn () => 'old-shape');
+        static::assertSame('old-shape', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Boundary: simulate end-of-request Octane flush.
+        $this->octaneListener()->handle(new \stdClass);
+
+        // Deploy + Request 2: the memo is clear; writing the new shape must
+        // return 'new-shape', not the previously memoised 'old-shape'.
+        $result = $writer->rememberMetadataForever($key, static fn () => 'new-shape');
+
+        // Assert
+        static::assertSame('new-shape', $result);
+        static::assertSame('new-shape', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that a queue worker boundary flushes stale metadata so job 2 reads
+     * the new shape rather than the memoised old shape.
+     *
+     * Validates AC-06: under a long-lived queue worker, metadata must not leak
+     * across job boundaries.
+     *
+     * @return void
+     */
+    public function testQueueWorkerFlushesStaleMetadataBetweenJobs(): void
+    {
+        // Arrange
+        Config::set('queue.connections.database.driver', 'database');
+        Config::set('api-toolkit.lifecycle.queue', true);
+
+        Event::fake();
+
+        $key    = 'integration:queue-staleness-test';
+        $writer = $this->writer();
+
+        // Job 1: write old shape and confirm memoised.
+        $writer->rememberMetadataForever($key, static fn () => 'old-shape');
+        static::assertSame('old-shape', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Boundary: simulate end-of-job queue flush.
+        $event = new JobProcessed('database', static::createStub(Job::class));
+        $this->queueSubscriber()->handleFlush($event);
+
+        // Job 2: the memo is clear; writing the new shape must return 'new-shape'.
+        $result = $writer->rememberMetadataForever($key, static fn () => 'new-shape');
+
+        // Assert
+        static::assertSame('new-shape', $result);
+        static::assertSame('new-shape', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that under php-fpm (no LARAVEL_OCTANE signal), the Octane listener
+     * does not perform a flush even when the config flag is on.
+     *
+     * Validates AC-09: the runtime gate, not the config flag, prevents flush
+     * engagement outside a long-lived Octane worker.
+     *
+     * @return void
+     */
+    public function testPhpFpmRequestPerformsNoFlush(): void
+    {
+        // Arrange - no LARAVEL_OCTANE signal (php-fpm).
+        unset($_SERVER['LARAVEL_OCTANE']);
+        Config::set('api-toolkit.lifecycle.octane', true);
+
+        Event::fake();
+
+        $key    = 'integration:php-fpm-no-flush-test';
+        $writer = $this->writer();
+
+        $writer->rememberMetadataForever($key, static fn () => 'value');
+        static::assertSame('value', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Act: invoke the boundary under php-fpm conditions.
+        $this->octaneListener()->handle(new \stdClass);
+
+        // Assert: the key must survive because no flush ran.
+        static::assertSame('value', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that the opt-out flag prevents the lifecycle flush from being wired
+     * to its boundary at all.
+     *
+     * Validates AC-02: with the lifecycle flag off, LifecycleRegistrar does not
+     * subscribe the flush, so no boundary can fire it. The queue path is the
+     * representative opt-out oracle - the Octane path additionally gates on
+     * class_exists(OperationTerminated), which is always false here because
+     * laravel/octane is not installed, so the queue gate is the one that can be
+     * isolated. The enabled control proves the assertion tracks the flag rather
+     * than passing vacuously.
+     *
+     * @return void
+     */
+    public function testOptOutDisablesLifecycleFlushSubscription(): void
+    {
+        // Opt-out: the flag is off, so the registrar must not wire the subscriber.
+        Config::set('api-toolkit.lifecycle.queue', false);
+
+        (new LifecycleRegistrar)->register();
+
+        static::assertFalse(
+            $this->eventHasSubscriberListener(JobProcessed::class, QueueFlushSubscriber::class),
+            'QueueFlushSubscriber must not be wired when lifecycle.queue is false',
+        );
+
+        // Control: with the flag on, the registrar wires it - proving the gate,
+        // not an always-false assertion, drives the opt-out behaviour.
+        Config::set('api-toolkit.lifecycle.queue', true);
+
+        (new LifecycleRegistrar)->register();
+
+        static::assertTrue(
+            $this->eventHasSubscriberListener(JobProcessed::class, QueueFlushSubscriber::class),
+            'QueueFlushSubscriber must be wired when lifecycle.queue is true',
+        );
+    }
+
+    /**
+     * Test that a non-toolkit key written directly to the shared memo store
+     * survives the scoped metadata flush while the toolkit key is cleared.
+     *
+     * Validates NFR-01 / AC-08: the flush must not blast non-toolkit keys off
+     * the shared memo store.
+     *
+     * @return void
+     */
+    public function testSharedStoreNonToolkitKeySurvivesFlush(): void
+    {
+        // Arrange
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+        Config::set('api-toolkit.lifecycle.octane', true);
+
+        Event::fake();
+
+        $toolkitKey    = 'integration:toolkit-key';
+        $nonToolkitKey = 'app:user-prefs';
+        $writer        = $this->writer();
+
+        // Write the toolkit key through the writer (registered for scoped flush).
+        $writer->rememberMetadataForever($toolkitKey, static fn () => 'toolkit-value');
+
+        // Write the non-toolkit key directly (NOT registered; must survive flush).
+        Cache::memo()->rememberForever($nonToolkitKey, static fn () => 'keep-me'); // @phpstan-ignore method.notFound
+
+        static::assertSame('toolkit-value', Cache::memo()->get($toolkitKey)); // @phpstan-ignore method.notFound
+        static::assertSame('keep-me', Cache::memo()->get($nonToolkitKey)); // @phpstan-ignore method.notFound
+
+        // Act: invoke the Octane boundary.
+        $this->octaneListener()->handle(new \stdClass);
+
+        // Assert: the toolkit key is gone; the non-toolkit key survives.
+        static::assertNull(Cache::memo()->get($toolkitKey)); // @phpstan-ignore method.notFound
+        static::assertSame('keep-me', Cache::memo()->get($nonToolkitKey)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Determine whether the given event has a listener belonging to the given
+     * subscriber class.
+     *
+     * @param  class-string  $event
+     * @param  class-string  $subscriber
+     * @return bool
+     */
+    private function eventHasSubscriberListener(string $event, string $subscriber): bool
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $this->app->make('events');
+
+        $listeners = $events->getRawListeners()[$event] ?? [];
+
+        if (!is_iterable($listeners)) {
+            return false;
+        }
+
+        foreach ($listeners as $listener) {
+            if (is_array($listener) && ($listener[0] ?? null) instanceof $subscriber) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve the wired MetadataCacheWriter singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+     */
+    private function writer(): MetadataCacheWriter
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataCacheWriter */
+        return $this->app->make(MetadataCacheWriter::class);
+    }
+
+    /**
+     * Build an OctaneFlushListener backed by the wired CacheManager singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Listeners\OctaneFlushListener
+     */
+    private function octaneListener(): OctaneFlushListener
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->make(CacheManager::class);
+
+        return new OctaneFlushListener($cacheManager, new RuntimeContext);
+    }
+
+    /**
+     * Build a QueueFlushSubscriber backed by the wired CacheManager singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber
+     */
+    private function queueSubscriber(): QueueFlushSubscriber
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->make(CacheManager::class);
+
+        return new QueueFlushSubscriber($cacheManager, new RuntimeContext);
+    }
+}

--- a/tests/Integration/LifecycleFlushDefaultsTest.php
+++ b/tests/Integration/LifecycleFlushDefaultsTest.php
@@ -185,6 +185,10 @@ class LifecycleFlushDefaultsTest extends TestCase
      */
     public function testOptOutDisablesLifecycleFlushSubscription(): void
     {
+        // Reset the dispatcher so the boot-time wiring (now default-on) does not
+        // pollute the baseline being tested.
+        \Illuminate\Support\Facades\Event::swap(new \Illuminate\Events\Dispatcher($this->app));
+
         // Opt-out: the flag is off, so the registrar must not wire the subscriber.
         Config::set('api-toolkit.lifecycle.queue', false);
 

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -4,6 +4,7 @@ namespace Tests\Integration\Providers\Registrars;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
@@ -25,6 +26,39 @@ use Tests\TestCase;
 #[CoversClass(LifecycleRegistrar::class)]
 class LifecycleRegistrarTest extends TestCase
 {
+    /** @var bool Whether LARAVEL_OCTANE was set before each test. */
+    private bool $octaneWasSet;
+
+    /**
+     * Capture the initial LARAVEL_OCTANE state.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore the LARAVEL_OCTANE server variable after each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        } else {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+
+        parent::tearDown();
+    }
+
     /**
      * Test that the lifecycle subscribers are registered when the registrar
      * is invoked with the queue lifecycle enabled.
@@ -44,6 +78,71 @@ class LifecycleRegistrarTest extends TestCase
 
         static::assertTrue($this->eventHasSubscriberListener(RequestHandled::class, WritePoolFlushSubscriber::class));
         static::assertTrue($this->eventHasSubscriberListener(\Illuminate\Queue\Events\JobProcessed::class, QueueFlushSubscriber::class));
+    }
+
+    /**
+     * Test that an off-state diagnostic is logged when serving under Octane but
+     * the lifecycle flush is opted-out.
+     *
+     * @return void
+     */
+    public function testOffStateDiagnosticLogsWhenServingUnderOctaneButFlushOptedOut(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->getApplication()->make('config');
+        $config->set('api-toolkit.lifecycle.octane', false);
+
+        Log::shouldReceive('info')->once()->with(\Mockery::on(
+            fn (string $message): bool => str_contains($message, 'Octane') && str_contains($message, 'API_TOOLKIT_LIFECYCLE_OCTANE'),
+        ));
+
+        (new LifecycleRegistrar)->register();
+    }
+
+    /**
+     * Test that an off-state diagnostic is logged when serving as a queue
+     * worker but the lifecycle flush is opted-out.
+     *
+     * @return void
+     */
+    public function testOffStateDiagnosticLogsWhenServingAsQueueWorkerButFlushOptedOut(): void
+    {
+        unset($_SERVER['LARAVEL_OCTANE']);
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->getApplication()->make('config');
+        $config->set('queue.default', 'database');
+        $config->set('queue.connections.database.driver', 'database');
+        $config->set('api-toolkit.lifecycle.queue', false);
+
+        Log::shouldReceive('info')->once()->with(\Mockery::on(
+            fn (string $message): bool => str_contains($message, 'queue worker') && str_contains($message, 'API_TOOLKIT_LIFECYCLE_QUEUE'),
+        ));
+
+        (new LifecycleRegistrar)->register();
+    }
+
+    /**
+     * Test that no off-state diagnostic is logged under php-fpm (no serving
+     * runtime detected).
+     *
+     * @return void
+     */
+    public function testOffStateDiagnosticIsSilentUnderPhpFpm(): void
+    {
+        unset($_SERVER['LARAVEL_OCTANE']);
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->getApplication()->make('config');
+        $config->set('queue.default', 'sync');
+        $config->set('api-toolkit.lifecycle.octane', false);
+        $config->set('api-toolkit.lifecycle.queue', false);
+
+        Log::shouldReceive('info')->never();
+
+        (new LifecycleRegistrar)->register();
     }
 
     /**

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
@@ -29,7 +30,7 @@ class CacheManagerTest extends TestCase
     use InteractsWithNonPublicMembers;
 
     /**
-     * Test that flush clears the memo cache.
+     * Test that flush forgets a registered toolkit memo key.
      *
      * @return void
      */
@@ -40,16 +41,22 @@ class CacheManagerTest extends TestCase
 
         $key = 'test-memo-key';
 
-        Cache::memo()->rememberForever($key, fn () => 'cached-value');
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
 
-        static::assertSame('cached-value', Cache::memo()->get($key));
+        $registry->register($key);
+
+        Cache::memo()->rememberForever($key, fn () => 'cached-value'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached-value', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
 
         // Act
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $manager */
         $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
         $manager->flush();
 
         // Assert
-        static::assertNull(Cache::memo()->get($key));
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
     }
 
     /**
@@ -198,8 +205,62 @@ class CacheManagerTest extends TestCase
         $manager->flush();
 
         // Assert
-        static::assertNull(Cache::memo()->get('nonexistent'));
+        static::assertNull(Cache::memo()->get('nonexistent')); // @phpstan-ignore method.notFound
         static::assertSame([], $this->getStaticProperty(SchemaCompiler::class, 'cache'));
         Event::assertDispatched(CacheFlushed::class);
+    }
+
+    /**
+     * Test that flush leaves an unregistered non-toolkit key intact.
+     *
+     * Pins NFR-01/AC-08: keys written directly to the memo store without going
+     * through the MetadataKeyRegistry must survive the scoped flush.
+     *
+     * @return void
+     */
+    public function testFlushLeavesUnregisteredNonToolkitKeyIntact(): void
+    {
+        // Arrange
+        Event::fake();
+
+        Cache::memo()->rememberForever('non-toolkit-key', fn () => 'survivor'); // @phpstan-ignore method.notFound
+
+        // Act
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $manager */
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        static::assertSame('survivor', Cache::memo()->get('non-toolkit-key')); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that flush forgets all registered toolkit keys and empties the registry.
+     *
+     * @return void
+     */
+    public function testFlushForgetsRegisteredToolkitKeysAndClearsRegistry(): void
+    {
+        // Arrange
+        Event::fake();
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $registry->register('toolkit-key-one');
+        $registry->register('toolkit-key-two');
+
+        Cache::memo()->rememberForever('toolkit-key-one', fn () => 'value-one'); // @phpstan-ignore method.notFound
+        Cache::memo()->rememberForever('toolkit-key-two', fn () => 'value-two'); // @phpstan-ignore method.notFound
+
+        // Act
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $manager */
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        static::assertNull(Cache::memo()->get('toolkit-key-one')); // @phpstan-ignore method.notFound
+        static::assertNull(Cache::memo()->get('toolkit-key-two')); // @phpstan-ignore method.notFound
+        static::assertSame([], $registry->keys());
     }
 }

--- a/tests/Unit/Cache/MetadataCacheWriterTest.php
+++ b/tests/Unit/Cache/MetadataCacheWriterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Cache;
+
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
+use Tests\TestCase;
+
+/**
+ * Tests for the MetadataCacheWriter chokepoint.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(MetadataCacheWriter::class)]
+class MetadataCacheWriterTest extends TestCase
+{
+    /**
+     * Test that rememberMetadataForever returns the value produced by the callback.
+     *
+     * @return void
+     */
+    public function testRememberMetadataForeverReturnsTheCallbackValue(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+        $writer   = new MetadataCacheWriter($registry);
+
+        // Act
+        $value = $writer->rememberMetadataForever('test-key', fn () => 'expected-value');
+
+        // Assert
+        static::assertSame('expected-value', $value);
+    }
+
+    /**
+     * Test that rememberMetadataForever registers the key in the injected registry.
+     *
+     * @return void
+     */
+    public function testRememberMetadataForeverRegistersTheKey(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+        $writer   = new MetadataCacheWriter($registry);
+
+        // Act
+        $writer->rememberMetadataForever('my-metadata-key', fn () => 'value');
+
+        // Assert
+        static::assertContains('my-metadata-key', $registry->keys());
+    }
+
+    /**
+     * Test that rememberMetadataForever persists the value to the memo store.
+     *
+     * @return void
+     */
+    public function testRememberMetadataForeverWritesToTheMemoStore(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+        $writer   = new MetadataCacheWriter($registry);
+        $key      = 'memo-store-key';
+
+        // Act
+        $writer->rememberMetadataForever($key, fn () => 'stored-value');
+
+        // Assert
+        static::assertSame('stored-value', Cache::memo()->get($key));
+    }
+
+    /**
+     * Test that rememberMetadataForever registers the key even when the memo
+     * store already holds the value and the callback is never invoked.
+     *
+     * @return void
+     */
+    public function testRememberMetadataForeverRegistersKeyEvenOnWarmCache(): void
+    {
+        // Arrange
+        $key = 'warm-cache-key';
+
+        Cache::memo()->rememberForever($key, fn () => 'pre-warmed-value');
+
+        $registry = new MetadataKeyRegistry;
+        $writer   = new MetadataCacheWriter($registry);
+
+        // Act — callback would not be called because the key is already memoised
+        $writer->rememberMetadataForever($key, fn () => 'should-not-be-called');
+
+        // Assert
+        static::assertContains($key, $registry->keys());
+        static::assertSame('pre-warmed-value', Cache::memo()->get($key));
+    }
+}

--- a/tests/Unit/Cache/MetadataKeyRegistryTest.php
+++ b/tests/Unit/Cache/MetadataKeyRegistryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\Cache;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
+use Tests\TestCase;
+
+/**
+ * Tests for the MetadataKeyRegistry.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(MetadataKeyRegistry::class)]
+class MetadataKeyRegistryTest extends TestCase
+{
+    /**
+     * Test that register adds a key to the set.
+     *
+     * @return void
+     */
+    public function testRegisterAddsKeyToTheSet(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+
+        // Act
+        $registry->register('sm-api-toolkit:model-schema:User');
+
+        // Assert
+        static::assertSame(['sm-api-toolkit:model-schema:User'], $registry->keys());
+    }
+
+    /**
+     * Test that register is idempotent for repeated keys.
+     *
+     * @return void
+     */
+    public function testRegisterIsIdempotentForRepeatedKeys(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+
+        // Act
+        $registry->register('sm-api-toolkit:model-schema:User');
+        $registry->register('sm-api-toolkit:model-schema:User');
+        $registry->register('sm-api-toolkit:model-schema:User');
+
+        // Assert
+        static::assertSame(['sm-api-toolkit:model-schema:User'], $registry->keys());
+    }
+
+    /**
+     * Test that keys returns all distinct registered keys as an integer-indexed list.
+     *
+     * @return void
+     */
+    public function testKeysReturnsDistinctRegisteredKeysAsList(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+
+        // Act
+        $registry->register('sm-api-toolkit:model-schema:User');
+        $registry->register('sm-api-toolkit:model-resources:Post');
+        $registry->register('sm-api-toolkit:model-casts:Comment');
+
+        $keys = $registry->keys();
+
+        // Assert
+        static::assertCount(3, $keys);
+        static::assertContains('sm-api-toolkit:model-schema:User', $keys);
+        static::assertContains('sm-api-toolkit:model-resources:Post', $keys);
+        static::assertContains('sm-api-toolkit:model-casts:Comment', $keys);
+        static::assertSame(array_values($keys), $keys);
+    }
+
+    /**
+     * Test that keys returns an empty array before any registration.
+     *
+     * @return void
+     */
+    public function testKeysReturnsEmptyArrayBeforeAnyRegistration(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+
+        // Assert
+        static::assertSame([], $registry->keys());
+    }
+
+    /**
+     * Test that clear empties the registry.
+     *
+     * @return void
+     */
+    public function testClearEmptiesTheRegistry(): void
+    {
+        // Arrange
+        $registry = new MetadataKeyRegistry;
+        $registry->register('sm-api-toolkit:model-schema:User');
+        $registry->register('sm-api-toolkit:model-resources:Post');
+
+        // Act
+        $registry->clear();
+
+        // Assert
+        static::assertSame([], $registry->keys());
+    }
+}

--- a/tests/Unit/Listeners/OctaneFlushListenerTest.php
+++ b/tests/Unit/Listeners/OctaneFlushListenerTest.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 use Tests\TestCase;
 
 /**
@@ -22,34 +24,139 @@ use Tests\TestCase;
 #[CoversClass(OctaneFlushListener::class)]
 class OctaneFlushListenerTest extends TestCase
 {
+    /** @var bool Whether LARAVEL_OCTANE was set before each test. */
+    private bool $octaneWasSet;
+
     /**
-     * Test that handle delegates to CacheManager::flush.
+     * Capture the initial LARAVEL_OCTANE state before each test.
      *
      * @return void
      */
-    public function testHandleDelegatesToCacheManager(): void
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore the LARAVEL_OCTANE server variable after each test.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        } else {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that handle flushes toolkit caches when serving under Octane.
+     *
+     * @return void
+     */
+    public function testHandleEngagesFlushWhenServingUnderOctane(): void
     {
         // Arrange
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
         Event::fake();
 
         $this->mock(SchemaIntrospectionProvider::class)
             ->shouldReceive('flush')
             ->once();
 
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $key = 'octane-engage-test';
+        $registry->register($key);
+        Cache::memo()->rememberForever($key, fn () => 'cached'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
         $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
-        $listener     = new OctaneFlushListener($cacheManager);
-
-        $key = 'octane-flush-test';
-
-        Cache::memo()->rememberForever($key, fn () => 'cached');
-
-        static::assertSame('cached', Cache::memo()->get($key));
+        $listener     = new OctaneFlushListener($cacheManager, new RuntimeContext);
 
         // Act
         $listener->handle(new \stdClass);
 
         // Assert
-        static::assertNull(Cache::memo()->get($key));
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that handle does not flush when not serving under Octane (php-fpm).
+     *
+     * Pins AC-09: a php-fpm process with Octane installed must not flush on
+     * every request.
+     *
+     * @return void
+     */
+    public function testHandleDoesNotEngageFlushUnderPhpFpm(): void
+    {
+        // Arrange
+        unset($_SERVER['LARAVEL_OCTANE']);
+
+        Event::fake();
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $key = 'octane-no-flush-test';
+        $registry->register($key);
+        Cache::memo()->rememberForever($key, fn () => 'cached'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $listener     = new OctaneFlushListener($cacheManager, new RuntimeContext);
+
+        // Act
+        $listener->handle(new \stdClass);
+
+        // Assert
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that handle delegates to CacheManager::flush when serving under Octane.
+     *
+     * @return void
+     */
+    public function testHandleDelegatesToCacheManager(): void
+    {
+        // Arrange
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        Event::fake();
+
+        $this->mock(SchemaIntrospectionProvider::class)
+            ->shouldReceive('flush')
+            ->once();
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $key = 'octane-flush-test';
+        $registry->register($key);
+        Cache::memo()->rememberForever($key, fn () => 'cached'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $listener     = new OctaneFlushListener($cacheManager, new RuntimeContext);
+
+        // Act
+        $listener->handle(new \stdClass);
+
+        // Assert
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
     }
 
     /**
@@ -61,6 +168,8 @@ class OctaneFlushListenerTest extends TestCase
      */
     public function testHandleSwallowsAndLogsCacheFlushFailure(): void
     {
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
         Event::fake();
 
         $this->mock(SchemaIntrospectionProvider::class)
@@ -76,7 +185,7 @@ class OctaneFlushListenerTest extends TestCase
             ));
 
         $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
-        $listener     = new OctaneFlushListener($cacheManager);
+        $listener     = new OctaneFlushListener($cacheManager, new RuntimeContext);
 
         $listener->handle(new \stdClass);
     }

--- a/tests/Unit/Listeners/QueueFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/QueueFlushSubscriberTest.php
@@ -2,15 +2,19 @@
 
 namespace Tests\Unit\Listeners;
 
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 use Tests\TestCase;
 
 /**
@@ -34,7 +38,7 @@ class QueueFlushSubscriberTest extends TestCase
         // Arrange
         $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
         $dispatcher   = \Mockery::mock(Dispatcher::class);
-        $subscriber   = new QueueFlushSubscriber($cacheManager);
+        $subscriber   = new QueueFlushSubscriber($cacheManager, new RuntimeContext);
 
         $dispatcher->shouldReceive('listen')
             ->once()
@@ -49,32 +53,109 @@ class QueueFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that handleFlush delegates to CacheManager::flush.
+     * Test that handleFlush flushes toolkit caches for a real worker connection.
      *
      * @return void
      */
-    public function testHandleFlushDelegatesToCacheManager(): void
+    public function testHandleFlushEngagesOnRealWorkerConnection(): void
     {
         // Arrange
+        Config::set('queue.connections.database.driver', 'database');
+
         Event::fake();
 
         $this->mock(SchemaIntrospectionProvider::class)
             ->shouldReceive('flush')
             ->once();
 
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $key = 'queue-engage-test';
+        $registry->register($key);
+        Cache::memo()->rememberForever($key, fn () => 'cached'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
         $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
-        $subscriber   = new QueueFlushSubscriber($cacheManager);
-
-        $key = 'queue-flush-test';
-
-        Cache::memo()->rememberForever($key, fn () => 'cached');
-
-        static::assertSame('cached', Cache::memo()->get($key));
+        $subscriber   = new QueueFlushSubscriber($cacheManager, new RuntimeContext);
+        $event        = new JobProcessed('database', static::createStub(Job::class));
 
         // Act
-        $subscriber->handleFlush();
+        $subscriber->handleFlush($event);
 
         // Assert
-        static::assertNull(Cache::memo()->get($key));
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that handleFlush does not flush for a sync connection (in-request job).
+     *
+     * Pins AC-06: sync jobs run within the HTTP request and must not trigger
+     * a metadata flush at the job boundary.
+     *
+     * @return void
+     */
+    public function testHandleFlushDoesNotEngageOnSyncConnection(): void
+    {
+        // Arrange
+        Config::set('queue.connections.sync.driver', 'sync');
+
+        Event::fake();
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $key = 'queue-no-flush-test';
+        $registry->register($key);
+        Cache::memo()->rememberForever($key, fn () => 'cached'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $subscriber   = new QueueFlushSubscriber($cacheManager, new RuntimeContext);
+        $event        = new JobProcessed('sync', static::createStub(Job::class));
+
+        // Act
+        $subscriber->handleFlush($event);
+
+        // Assert
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that handleFlush delegates to CacheManager::flush for a non-sync connection.
+     *
+     * @return void
+     */
+    public function testHandleFlushDelegatesToCacheManager(): void
+    {
+        // Arrange
+        Config::set('queue.connections.database.driver', 'database');
+
+        Event::fake();
+
+        $this->mock(SchemaIntrospectionProvider::class)
+            ->shouldReceive('flush')
+            ->once();
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class); // @phpstan-ignore method.nonObject
+
+        $key = 'queue-flush-test';
+        $registry->register($key);
+        Cache::memo()->rememberForever($key, fn () => 'cached'); // @phpstan-ignore method.notFound
+
+        static::assertSame('cached', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $subscriber   = new QueueFlushSubscriber($cacheManager, new RuntimeContext);
+        $event        = new JobProcessed('database', static::createStub(Job::class));
+
+        // Act
+        $subscriber->handleFlush($event);
+
+        // Assert
+        static::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
     }
 }

--- a/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
+++ b/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Stub;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
@@ -758,5 +759,28 @@ class AttributeSetterTest extends TestCase
         $result = $this->invokeMethod($this->attributeSetter, 'resolveCastForAttribute', 'field', 'custom_type', null);
 
         static::assertSame('string', $result);
+    }
+
+    /**
+     * Test that persist registers the REPOSITORY_MODEL_CASTS key in the
+     * metadata key registry.
+     *
+     * @return void
+     */
+    public function testStoreCastsRegistersModelCastsKey(): void
+    {
+        // Arrange
+        $registry = app(MetadataKeyRegistry::class);
+        $user     = User::create(['name' => 'Alice', 'email' => self::ALICE_EMAIL]);
+
+        $this->setProperty($this->attributeSetter, 'casts', ['name' => 'string']);
+
+        // Act
+        $this->attributeSetter->persist($user, ['name' => 'Bob'], User::class);
+
+        // Assert
+        $expectedKey = CacheKeys::REPOSITORY_MODEL_CASTS->resolveKey([User::class]);
+
+        static::assertContains($expectedKey, $registry->keys());
     }
 }

--- a/tests/Unit/Repositories/Traits/ResolvesResourceTest.php
+++ b/tests/Unit/Repositories/Traits/ResolvesResourceTest.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
+use SineMacula\ApiToolkit\Enums\CacheKeys;
 use SineMacula\ApiToolkit\Repositories\Traits\ResolvesResource;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\Tag;
@@ -205,6 +207,28 @@ class ResolvesResourceTest extends TestCase
 
         static::assertSame(UserResource::class, $repository->exposeResolveResource(new User));
         static::assertSame(UserResource::class, $repository->exposeGetResourceFromModel(new User));
+    }
+
+    /**
+     * Test that resolving a model resource registers the MODEL_RESOURCES key
+     * in the MetadataKeyRegistry.
+     *
+     * @return void
+     */
+    public function testResolveResourceRegistersResourcesKey(): void
+    {
+        Config::set('api-toolkit.resources.resource_map.' . User::class, UserResource::class);
+
+        assert($this->app !== null);
+
+        $consumer = $this->createConsumer();
+
+        $this->invokeMethod($consumer, 'resolveResource', new User);
+
+        $registry    = $this->app->make(MetadataKeyRegistry::class);
+        $expectedKey = CacheKeys::MODEL_RESOURCES->resolveKey([User::class]);
+
+        static::assertContains($expectedKey, $registry->keys());
     }
 
     /**

--- a/tests/Unit/Runtime/RuntimeContextTest.php
+++ b/tests/Unit/Runtime/RuntimeContextTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit\Runtime;
+
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
+use Tests\TestCase;
+
+/**
+ * Tests for the RuntimeContext serving-runtime detector.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RuntimeContext::class)]
+class RuntimeContextTest extends TestCase
+{
+    /** @var bool|null Whether LARAVEL_OCTANE was set before each test ran. */
+    private ?bool $octaneWasSet = null;
+
+    /**
+     * Record the pre-test state of the Octane server global.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore the Octane server global to its pre-test state.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet === false) {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        } elseif ($this->octaneWasSet === true) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that isServingUnderOctane returns true when the Octane server global
+     * is set.
+     *
+     * @return void
+     */
+    public function testIsServingUnderOctaneReturnsTrueWhenOctaneServerGlobalSet(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        $context = new RuntimeContext;
+
+        static::assertTrue($context->isServingUnderOctane());
+    }
+
+    /**
+     * Test that isServingUnderOctane returns false when the Octane server
+     * global is absent (the php-fpm case).
+     *
+     * @return void
+     */
+    public function testIsServingUnderOctaneReturnsFalseWhenOctaneServerGlobalAbsent(): void
+    {
+        unset($_SERVER['LARAVEL_OCTANE']);
+
+        $context = new RuntimeContext;
+
+        static::assertFalse($context->isServingUnderOctane());
+    }
+
+    /**
+     * Test that isServingAsQueueWorker returns true for a non-sync driver.
+     *
+     * @return void
+     */
+    public function testIsServingAsQueueWorkerReturnsTrueForNonSyncDriver(): void
+    {
+        Config::set('queue.connections.database', ['driver' => 'database']);
+
+        $context = new RuntimeContext;
+
+        static::assertTrue($context->isServingAsQueueWorker('database'));
+    }
+
+    /**
+     * Test that isServingAsQueueWorker returns false for the sync driver.
+     *
+     * @return void
+     */
+    public function testIsServingAsQueueWorkerReturnsFalseForSyncDriver(): void
+    {
+        Config::set('queue.connections.sync', ['driver' => 'sync']);
+
+        $context = new RuntimeContext;
+
+        static::assertFalse($context->isServingAsQueueWorker('sync'));
+    }
+
+    /**
+     * Test that isServingAsQueueWorker resolves the default connection when
+     * called with null and that connection uses a non-sync driver.
+     *
+     * @return void
+     */
+    public function testIsServingAsQueueWorkerResolvesDefaultConnectionWhenNull(): void
+    {
+        Config::set('queue.default', 'redis');
+        Config::set('queue.connections.redis', ['driver' => 'redis']);
+
+        $context = new RuntimeContext;
+
+        static::assertTrue($context->isServingAsQueueWorker(null));
+    }
+
+    /**
+     * Test that isServingAsQueueWorker returns false when the connection driver
+     * cannot be resolved.
+     *
+     * @return void
+     */
+    public function testIsServingAsQueueWorkerReturnsFalseWhenDriverUnresolved(): void
+    {
+        $context = new RuntimeContext;
+
+        static::assertFalse($context->isServingAsQueueWorker('nonexistent-connection'));
+    }
+}

--- a/tests/Unit/Runtime/RuntimeContextTest.php
+++ b/tests/Unit/Runtime/RuntimeContextTest.php
@@ -135,4 +135,21 @@ class RuntimeContextTest extends TestCase
 
         static::assertFalse($context->isServingAsQueueWorker('nonexistent-connection'));
     }
+
+    /**
+     * Test that an empty default connection name is treated as not-a-worker,
+     * even when a connection registered under the empty name resolves a
+     * non-sync driver.
+     *
+     * @return void
+     */
+    public function testIsServingAsQueueWorkerReturnsFalseForEmptyDefaultConnection(): void
+    {
+        Config::set('queue.default', '');
+        Config::set('queue.connections..driver', 'database');
+
+        $context = new RuntimeContext;
+
+        static::assertFalse($context->isServingAsQueueWorker());
+    }
 }

--- a/tests/Unit/Services/SchemaIntrospectorTest.php
+++ b/tests/Unit/Services/SchemaIntrospectorTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 use SineMacula\ApiToolkit\Services\Introspection\ColumnDefinition;
@@ -988,5 +989,71 @@ class SchemaIntrospectorTest extends TestCase
         $introspector = new SchemaIntrospector;
 
         static::assertSame([], $introspector->parentKeysFor($unknown));
+    }
+
+    /**
+     * Test that getColumns registers the MODEL_SCHEMA_COLUMNS key in the
+     * metadata key registry.
+     *
+     * @return void
+     */
+    public function testGetColumnsRegistersSchemaColumnsKey(): void
+    {
+        // Arrange
+        $registry     = app(MetadataKeyRegistry::class);
+        $introspector = new SchemaIntrospector;
+        $model        = new User;
+
+        // Act
+        $introspector->getColumns($model);
+
+        // Assert
+        $expectedKey = CacheKeys::MODEL_SCHEMA_COLUMNS->resolveKey([User::class]);
+
+        static::assertContains($expectedKey, $registry->keys());
+    }
+
+    /**
+     * Test that getColumnDefinitions registers the MODEL_SCHEMA_COLUMN_DEFINITIONS
+     * key in the metadata key registry.
+     *
+     * @return void
+     */
+    public function testGetColumnDefinitionsRegistersColumnDefinitionsKey(): void
+    {
+        // Arrange
+        $registry     = app(MetadataKeyRegistry::class);
+        $introspector = new SchemaIntrospector;
+        $model        = new User;
+
+        // Act
+        $introspector->getColumnDefinitions($model);
+
+        // Assert
+        $expectedKey = CacheKeys::MODEL_SCHEMA_COLUMN_DEFINITIONS->resolveKey([User::class]);
+
+        static::assertContains($expectedKey, $registry->keys());
+    }
+
+    /**
+     * Test that isRelation registers the MODEL_RELATIONS key in the metadata
+     * key registry.
+     *
+     * @return void
+     */
+    public function testIsRelationRegistersRelationsKey(): void
+    {
+        // Arrange
+        $registry     = app(MetadataKeyRegistry::class);
+        $introspector = new SchemaIntrospector;
+        $model        = new User;
+
+        // Act
+        $introspector->isRelation('posts', $model);
+
+        // Assert
+        $expectedKey = CacheKeys::MODEL_RELATIONS->resolveKey([User::class, 'posts']);
+
+        static::assertContains($expectedKey, $registry->keys());
     }
 }

--- a/tests/Unit/Services/SchemaIntrospectorTest.php
+++ b/tests/Unit/Services/SchemaIntrospectorTest.php
@@ -461,6 +461,25 @@ class SchemaIntrospectorTest extends TestCase
     }
 
     /**
+     * Test that parentKeysFor returns the foreign key for a BelongsTo relation
+     * and the local key for a HasOneOrMany relation.
+     *
+     * @return void
+     */
+    public function testParentKeysForReturnsRelationParentKeys(): void
+    {
+        $introspector = new SchemaIntrospector;
+        $user         = new User;
+
+        // BelongsTo resolves to the owning foreign key on the child table.
+        static::assertSame(['organization_id'], $introspector->parentKeysFor($user->organization()));
+
+        // HasOne and HasMany (HasOneOrMany) resolve to the parent's local key.
+        static::assertSame([$user->getKeyName()], $introspector->parentKeysFor($user->posts()));
+        static::assertSame([$user->getKeyName()], $introspector->parentKeysFor($user->profile()));
+    }
+
+    /**
      * Test that isRelation returns false for a method with a non-relation
      * return type.
      *


### PR DESCRIPTION
## Summary

Ships the toolkit's cross-request metadata flush **on by default** for runtimes actually serving under Octane or as a queue worker, so a package that markets statelessness is stateless out of the box. php-fpm is left untouched, the flush is scoped to the toolkit's own keys, and a documented, tested opt-out is retained.

Resolves **BL-18**. Built via `/build:build` (spec → architecture → 12 tasks across 5 tiers → standards → verification), each tier reviewer-gated and SSH-signed.

## What changed (the gated bundle - flip is the last step)

**Serving-runtime detection (hard predecessor)**
- New `RuntimeContext` (`src/Runtime/`): `isServingUnderOctane()` reads `$_SERVER['LARAVEL_OCTANE']` (set by a booted worker, not by mere install); `isServingAsQueueWorker()` treats a `sync`-driver job as a non-worker boundary. The listeners gate engagement on it at handle time, so a php-fpm request with Octane merely installed performs zero flush work.

**Scoped flush (blast-radius / NFR-01)**
- New `MetadataKeyRegistry` + `MetadataCacheWriter` (`src/Cache/`): every toolkit metadata write (schema columns, column definitions, relations, resources, casts) goes through one chokepoint that records its key. `CacheManager::flush()` now forgets only those registered keys (per-key `Cache::memo()->forget()`) instead of clearing the whole store - non-toolkit application keys and repository result caches survive.

**The flip + diagnostics**
- `config/api-toolkit.php`: `lifecycle.octane`/`lifecycle.queue` defaults flipped `false → true` (opt-out via `API_TOOLKIT_LIFECYCLE_OCTANE=false` / `API_TOOLKIT_LIFECYCLE_QUEUE=false`).
- `LifecycleRegistrar`: emits a non-silent `Log::info` when a serving runtime is detected but the flush is opted-out (php-fpm-silent).

**Docs**
- `UPGRADE.md`: the single "what survives across requests" surface (all three caches + the flush surface), the scoped-flush guarantee, the re-warm trade-off, and the opt-out / restore path.
- `CHANGELOG.md`: the default flip, scoped flush, detection, and off-state diagnostic.

## Sequencing

The PRD gates the default flip behind three predecessors. Tasks land in that order: detector + scoped-flush primitives + write-routing + listener gating + the cross-request staleness regression harness (validated with explicit in-test config) all precede the Tier-4 default flip.

## Testing

- `composer test`: **1948 pass, 0 fail, 1 pre-existing skip**
- `composer check`: clean (only a pre-existing markdown line-length finding in an archived PRD, untouched here)
- `composer test:mutation`: passes the MSI gate (**Covered MSI 94%**)
- New `LifecycleFlushDefaultsTest` proves Octane/queue cross-request staleness clears at the boundary, php-fpm does not engage, the opt-out gate is honoured, and a non-toolkit shared-store key survives; `LifecycleDefaultEngagementTest` pins that the shipped default engages.

## Migration

No action needed for most apps. Adopters on long-lived workers get correct-after-deploy metadata with no config; php-fpm is unchanged. Opt out via the env flags. See `UPGRADE.md`.

Note: independent of #272 (BL-20) - branches cleanly off `2.x`.