### PR TITLE
feat: invalidate per-query cache on deferred write-pool boundary flush [BL-11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - Extensible filter operator registry
 - Schema introspection service and boot-time schema validation
 - Opt-in deferred repository writes with a write pool, and opt-in transparent repository caching
+- Deferred write-pool flushes now invalidate the per-query repository cache for every table they
+  persist at the lifecycle boundary, so a deferred insert no longer leaves a stale cached collection
+  behind. Best-effort: it covers default-config `Cacheable` repositories; a repository on a custom
+  cache store or key prefix invalidates manually. Toggle with
+  `DEFERRED_WRITES_INVALIDATE_QUERY_CACHE` (`true` default)
 - Exception handler coverage for all HTTP-layer exceptions, preserving `abort()` status codes
 - Configurable middleware registration and notification logging exclusions
 
@@ -92,8 +97,9 @@ Version 2.0 is in development on the `2.x` branch. See [UPGRADE.md](UPGRADE.md) 
 - The `Cacheable` and `Deferrable` repository concerns can now be used on the same repository.
   Both previously declared `boot()`, so combining them raised a fatal trait-method collision; each
   now boots through a dedicated `bootCacheable()` / `bootDeferrable()` hook invoked by the base
-  repository. (Deferred writes still bypass the per-query cache - flush it manually or rely on its
-  TTL; this is documented on the `Deferrable` trait.)
+  repository. (Deferred writes bypass the per-query cache invalidation that fires on the repository's
+  own write verbs, but the lifecycle-boundary flush now compensates by invalidating the per-query
+  cache for each persisted table; see the Added entry below.)
 - The whole-table reference cache now applies the configured size guard before caching the table
   snapshot, so reference mode on an unexpectedly large table returns the rows but falls back to
   querying rather than serialising a huge snapshot into the cache

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -575,8 +575,23 @@ use `log` for fire-and-forget writes that must never be retained.
 
 **New observability on `WritePoolFlushResult`.** The result now exposes record-level counts --
 `flushedRecordCount()`, `failedRecordCount()`, `retainedRecordCount()`, and `droppedRecordCount()` --
-alongside the existing chunk counters. Subscribe to the `WritePoolFlushFailed` event to escalate
-retained failures to a dead-letter sink, alerting, or metrics.
+alongside the existing chunk counters, plus `flushedTables()` listing every table the flush attempted
+to persist. Subscribe to the `WritePoolFlushFailed` event to escalate retained failures to a
+dead-letter sink, alerting, or metrics.
+
+**Per-query cache invalidation at the boundary (on by default).** A deferred insert is persisted
+through the write pool's bulk INSERT, which bypasses the per-query cache invalidation that fires on a
+repository's own write verbs. To keep read-after-deferred-write consistent, the lifecycle-boundary
+flush now invalidates the per-query repository cache for every table it persisted, mirroring what an
+immediate write does. This is **best-effort**: it covers `Cacheable` repositories on the default cache
+configuration (the configured repository cache store, keyed by table name). A repository on a custom
+cache store (`cacheStoreName`) or key prefix (`cacheKeyPrefix`) is not reached and must invalidate
+manually -- call `flushCache()` after the boundary flush, or rely on the cache TTL.
+
+Disable the automatic invalidation (for example if every Cacheable repository invalidates manually, or
+none of the deferred tables are cached) with:
+
+    DEFERRED_WRITES_INVALIDATE_QUERY_CACHE=false
 
 ### Changed: Lifecycle metadata flush is now on by default on serving runtimes
 

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -330,6 +330,12 @@ return [
     | it at the lifecycle boundary. Only applies under the 'throw' strategy and
     | is disabled by default so the boundary is never hard-crashed.
     |
+    | `invalidate_query_cache` invalidates the per-query repository cache for
+    | every table the boundary flush touched, so a deferred insert never leaves
+    | a stale cached collection behind. Best-effort: it covers default-config
+    | Cacheable repositories; a repository on a custom cache store or key prefix
+    | must invalidate manually. Enabled by default.
+    |
     | Durability window: buffered writes live only in PHP memory until the
     | boundary flush. A crash, out-of-memory condition, or SIGKILL before the
     | flush loses any unflushed records. For true durability use a real queue.
@@ -347,6 +353,8 @@ return [
         'transactional' => (bool) env('DEFERRED_WRITES_TRANSACTIONAL', false),
 
         'rethrow_at_boundary' => (bool) env('DEFERRED_WRITES_RETHROW_AT_BOUNDARY', false),
+
+        'invalidate_query_cache' => (bool) env('DEFERRED_WRITES_INVALIDATE_QUERY_CACHE', true),
 
     ],
 

--- a/docs/prd/.archived/01-apiresource-decomposition.md
+++ b/docs/prd/.archived/01-apiresource-decomposition.md
@@ -100,8 +100,8 @@ class.
 
 **Evidence:**
 
-- [Spike: Responsibility Mapping](.blueprint/workflows/apiresource-decomposition/spikes/spike-responsibility-mapping.md) --
-  Finding 7: line budget distribution across five groups; Findings 1-5: individual group mappings
+- [Spike: Responsibility Mapping](.blueprint/workflows/apiresource-decomposition/spikes/spike-responsibility-mapping.md)
+  -- Finding 7: line budget distribution across five groups; Findings 1-5: individual group mappings
 - [Spike: Dependency Analysis](.blueprint/workflows/apiresource-decomposition/spikes/spike-dependency-analysis.md) --
   Finding 2: compiled schema as central untyped hub; Finding 8: no circular dependencies (DAG); Finding 10: implicit
   schema contract

--- a/src/Listeners/WritePoolFlushSubscriber.php
+++ b/src/Listeners/WritePoolFlushSubscriber.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Events\WritePoolFlushFailed;
 use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
+use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
 
@@ -64,6 +65,10 @@ final class WritePoolFlushSubscriber
      * boundary is never hard-crashed by default. Any other throwable is
      * unexpected and logged at error level.
      *
+     * Regardless of outcome, the per-query cache for every table the flush
+     * attempted is invalidated so a deferred insert never leaves a stale
+     * cached collection behind.
+     *
      * @return void
      *
      * @throws \SineMacula\ApiToolkit\Exceptions\WritePoolFlushException
@@ -74,6 +79,8 @@ final class WritePoolFlushSubscriber
 
             $flushResult = $this->container->make(WritePool::class)->flush();
 
+            $this->invalidateQueryCache($flushResult);
+
             if ($flushResult->isSuccessful()) {
                 return;
             }
@@ -81,6 +88,7 @@ final class WritePoolFlushSubscriber
             $this->escalate($flushResult);
         } catch (WritePoolFlushException $exception) {
 
+            $this->invalidateQueryCache($exception->flushResult());
             $this->escalate($exception->flushResult());
 
             if (Config::get('api-toolkit.deferred_writes.rethrow_at_boundary', false)) {
@@ -90,6 +98,28 @@ final class WritePoolFlushSubscriber
 
             Log::error('WritePool flush subscriber failed', ['error' => $e->getMessage(), 'exception' => $e]);
         }
+    }
+
+    /**
+     * Invalidate the per-query cache for every table this flush attempted to
+     * persist.
+     *
+     * Best-effort and gated by the invalidate_query_cache config flag: it
+     * covers default-config Cacheable repositories, mirroring what an
+     * immediate write does. A repository on a custom cache store or key prefix
+     * is not covered and must invalidate manually.
+     *
+     * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult  $flushResult
+     * @return void
+     */
+    private function invalidateQueryCache(WritePoolFlushResult $flushResult): void
+    {
+        if (!Config::get('api-toolkit.deferred_writes.invalidate_query_cache', true)) {
+            return;
+        }
+
+        $this->container->make(DeferredWriteCacheInvalidator::class)
+            ->invalidate($flushResult->flushedTables());
     }
 
     /**

--- a/src/Repositories/Concerns/CacheStore.php
+++ b/src/Repositories/Concerns/CacheStore.php
@@ -59,9 +59,40 @@ final class CacheStore
 
         $this->store         = $store;
         $this->taggableStore = $store instanceof ConcreteRepository && $store->supportsTags() ? $store : null;
-        $this->tag           = 'repo-table:' . $this->table;
+        $this->tag           = self::tagFor($this->table);
         $this->metaKey       = CacheKeys::REPOSITORY_CACHE_META->resolveKey([$this->table]);
-        $this->versionKey    = CacheKeys::REPOSITORY_CACHE_VERSION->resolveKey([$this->table]);
+        $this->versionKey    = self::versionKeyFor($this->table);
+    }
+
+    /**
+     * Invalidate every per-query cache entry for a table without a configured
+     * store instance, for cross-cutting callers (such as the deferred-write
+     * boundary flush) that only need to drop a table's cache.
+     *
+     * This is the invalidation half of flushTable(): it flushes the table tag
+     * on a taggable store, or bumps the generational version on a non-taggable
+     * store when the registry is enabled. It deliberately omits the metadata
+     * write flushTable() performs, because the caller is not the owning
+     * repository and does not track that table's cache status.
+     *
+     * @param  string  $cacheStore
+     * @param  string  $table
+     * @param  bool  $registryEnabled
+     * @return void
+     */
+    public static function invalidateTable(string $cacheStore, string $table, bool $registryEnabled): void
+    {
+        $store = Cache::store($cacheStore);
+
+        if ($store instanceof ConcreteRepository && $store->supportsTags()) {
+            $store->tags([self::tagFor($table)])->flush();
+
+            return;
+        }
+
+        if ($registryEnabled) {
+            $store->increment(self::versionKeyFor($table));
+        }
     }
 
     /**
@@ -228,5 +259,27 @@ final class CacheStore
         $bumped = $this->store->increment($this->versionKey);
 
         $this->version = is_int($bumped) ? $bumped : $this->tableVersion() + 1;
+    }
+
+    /**
+     * Resolve the cache tag scoping all per-query entries for a table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    private static function tagFor(string $table): string
+    {
+        return 'repo-table:' . $table;
+    }
+
+    /**
+     * Resolve the cache key holding a table's generational version.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    private static function versionKeyFor(string $table): string
+    {
+        return CacheKeys::REPOSITORY_CACHE_VERSION->resolveKey([$table]);
     }
 }

--- a/src/Repositories/Concerns/Deferrable.php
+++ b/src/Repositories/Concerns/Deferrable.php
@@ -19,13 +19,16 @@ namespace SineMacula\ApiToolkit\Repositories\Concerns;
  * pool for the next boundary; use the log strategy for fire-and-forget
  * writes that may be dropped.
  *
- * Cache interaction: this concern now coexists with Cacheable on the same
- * repository (each boots via its own boot{Concern} hook). Note, however, that
- * deferred writes are persisted through the write pool's bulk INSERT, which
- * bypasses the per-query cache invalidation that fires only on the repository's
- * own write verbs. A deferred write therefore leaves any per-query cache for
- * that table stale until its TTL; call flushCache() after the boundary flush,
- * or rely on the TTL, when read-after-deferred-write consistency is required.
+ * Cache interaction: this concern coexists with Cacheable on the same
+ * repository (each boots via its own boot{Concern} hook). Deferred writes are
+ * persisted through the write pool's bulk INSERT, which bypasses the per-query
+ * cache invalidation that fires on the repository's own write verbs. The
+ * lifecycle-boundary flush compensates: it invalidates the per-query cache for
+ * every persisted table (controlled by
+ * `api-toolkit.deferred_writes.invalidate_query_cache`, on by default). This is
+ * best-effort and covers default-config Cacheable repositories; a repository on
+ * a custom cache store or key prefix is not reached, so call flushCache() after
+ * the boundary flush, or rely on the TTL, for those.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Repositories/Concerns/DeferredWriteCacheInvalidator.php
+++ b/src/Repositories/Concerns/DeferredWriteCacheInvalidator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SineMacula\ApiToolkit\Repositories\Concerns;
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Invalidates the per-query repository cache for tables persisted by a deferred
+ * write-pool flush.
+ *
+ * A deferred insert is persisted at the lifecycle boundary, outside the
+ * Cacheable read path, so the per-query cache for that table would otherwise
+ * serve a stale collection until its TTL expired. This best-effort invalidator
+ * bumps each flushed table's generational cache version (or flushes its tag)
+ * using the default repository-cache configuration, mirroring what an immediate
+ * write does. Repositories on a custom cache store or key prefix are not
+ * covered and must invalidate manually.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class DeferredWriteCacheInvalidator
+{
+    /**
+     * Invalidate the per-query cache for each of the given tables.
+     *
+     * @param  array<int, string>  $tables
+     * @return void
+     */
+    public function invalidate(array $tables): void
+    {
+        $store    = $this->resolveStore();
+        $registry = (bool) Config::get('api-toolkit.repositories.cache.registry_enabled', true);
+
+        foreach ($tables as $table) {
+            CacheStore::invalidateTable($store, $table, $registry);
+        }
+    }
+
+    /**
+     * Resolve the cache store name shared by default-config Cacheable
+     * repositories.
+     *
+     * @return string
+     */
+    private function resolveStore(): string
+    {
+        $store = Config::get('api-toolkit.repositories.cache.store') ?? Config::get('cache.default');
+
+        return is_string($store) ? $store : 'array';
+    }
+}

--- a/src/Repositories/Concerns/WritePool.php
+++ b/src/Repositories/Concerns/WritePool.php
@@ -145,7 +145,7 @@ final class WritePool
             ? $accumulator->failedRecords()
             : [];
 
-        return $accumulator->toResult($strategy);
+        return $accumulator->toResult($strategy, $tables);
     }
 
     /**
@@ -240,7 +240,7 @@ final class WritePool
             }
             $this->buffer = $retainedBuffer;
 
-            throw new WritePoolFlushException($accumulator->toThrowResult($this->count()), $exception);
+            throw new WritePoolFlushException($accumulator->toThrowResult($this->count(), $context->tables()), $exception);
         }
 
         if ($context->strategy() === FlushStrategy::LOG) {
@@ -300,7 +300,7 @@ final class WritePool
             // Mirror of whole-table retain in handleTableRollback — keep in sync if either path changes.
             $this->retainUnprocessedRecords($context, $chunk);
 
-            throw new WritePoolFlushException($accumulator->toThrowResult($this->count()), $exception);
+            throw new WritePoolFlushException($accumulator->toThrowResult($this->count(), $context->tables()), $exception);
         }
 
         if ($context->strategy() === FlushStrategy::LOG) {

--- a/src/Repositories/Concerns/WritePoolFlushAccumulator.php
+++ b/src/Repositories/Concerns/WritePoolFlushAccumulator.php
@@ -95,14 +95,15 @@ final class WritePoolFlushAccumulator
      * for LOG every failed record is dropped instead of retained.
      *
      * @param  \SineMacula\ApiToolkit\Enums\FlushStrategy  $strategy
+     * @param  array<int, string>  $flushedTables
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult
      */
-    public function toResult(FlushStrategy $strategy): WritePoolFlushResult
+    public function toResult(FlushStrategy $strategy, array $flushedTables = []): WritePoolFlushResult
     {
         $retained = $strategy === FlushStrategy::LOG ? 0 : $this->failedRecordCount;
         $dropped  = $strategy === FlushStrategy::LOG ? $this->failedRecordCount : 0;
 
-        return $this->buildResult($retained, $dropped);
+        return $this->buildResult($retained, $dropped, $flushedTables);
     }
 
     /**
@@ -110,11 +111,12 @@ final class WritePoolFlushAccumulator
      * where retained records include both failed and unprocessed rows.
      *
      * @param  int  $retainedRecordCount
+     * @param  array<int, string>  $flushedTables
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult
      */
-    public function toThrowResult(int $retainedRecordCount): WritePoolFlushResult
+    public function toThrowResult(int $retainedRecordCount, array $flushedTables = []): WritePoolFlushResult
     {
-        return $this->buildResult($retainedRecordCount, 0);
+        return $this->buildResult($retainedRecordCount, 0, $flushedTables);
     }
 
     /**
@@ -123,9 +125,10 @@ final class WritePoolFlushAccumulator
      *
      * @param  int  $retainedRecordCount
      * @param  int  $droppedRecordCount
+     * @param  array<int, string>  $flushedTables
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult
      */
-    private function buildResult(int $retainedRecordCount, int $droppedRecordCount): WritePoolFlushResult
+    private function buildResult(int $retainedRecordCount, int $droppedRecordCount, array $flushedTables = []): WritePoolFlushResult
     {
         return new WritePoolFlushResult(
             successCount: $this->successCount,
@@ -135,6 +138,7 @@ final class WritePoolFlushAccumulator
             failedRecordCount: $this->failedRecordCount,
             retainedRecordCount: $retainedRecordCount,
             droppedRecordCount: $droppedRecordCount,
+            flushedTables: $flushedTables,
         );
     }
 }

--- a/src/Repositories/Concerns/WritePoolFlushResult.php
+++ b/src/Repositories/Concerns/WritePoolFlushResult.php
@@ -21,6 +21,7 @@ final class WritePoolFlushResult
      * @param  int  $failedRecordCount
      * @param  int  $retainedRecordCount
      * @param  int  $droppedRecordCount
+     * @param  array<int, string>  $flushedTables
      * @return void
      */
     public function __construct(
@@ -31,7 +32,19 @@ final class WritePoolFlushResult
         private readonly int $failedRecordCount = 0,
         private readonly int $retainedRecordCount = 0,
         private readonly int $droppedRecordCount = 0,
+        private readonly array $flushedTables = [],
     ) {}
+
+    /**
+     * Get the distinct tables whose buffered records this flush attempted to
+     * persist. Used to invalidate each table's downstream per-query cache.
+     *
+     * @return array<int, string>
+     */
+    public function flushedTables(): array
+    {
+        return $this->flushedTables;
+    }
 
     /**
      * Determine whether the flush completed without any failures.

--- a/tests/Integration/Repositories/DeferredWriteCacheInvalidationTest.php
+++ b/tests/Integration/Repositories/DeferredWriteCacheInvalidationTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Integration\Repositories;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use Tests\Fixtures\Models\Tag;
+use Tests\Fixtures\Repositories\CacheableTagRepository;
+use Tests\TestCase;
+
+/**
+ * Integration tests for per-query cache invalidation triggered by a
+ * deferred write-pool flush at the lifecycle boundary.
+ *
+ * Warms a Cacheable repository's per-query cache, defers a write to the
+ * same table, completes the boundary flush through the subscriber, then
+ * asserts the next read observes the freshly persisted row rather than a
+ * stale cached collection.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(DeferredWriteCacheInvalidator::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+class DeferredWriteCacheInvalidationTest extends TestCase
+{
+    /**
+     * Set up the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Tag::create(['name' => 'php']);
+        Tag::create(['name' => 'laravel']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the boundary flush invalidates the per-query cache for the
+     * deferred table, so the next read re-queries and reflects the row the
+     * flush persisted.
+     *
+     * @return void
+     */
+    public function testBoundaryFlushInvalidatesPerQueryCacheForDeferredTable(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        $this->warmTagCache();
+
+        $this->deferTagAndCompleteBoundary('vue');
+
+        DB::enableQueryLog();
+
+        $result = $this->freshTagRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+        static::assertCount(1, DB::getQueryLog());
+        static::assertCount(3, $result);
+    }
+
+    /**
+     * Test that, with invalidation disabled, the boundary flush still
+     * persists the deferred row but leaves the stale cached collection in
+     * place until its TTL expires.
+     *
+     * @return void
+     */
+    public function testBoundaryFlushSkipsInvalidationWhenDisabledYetStillPersists(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', false);
+
+        $this->warmTagCache();
+
+        $this->deferTagAndCompleteBoundary('vue');
+
+        DB::enableQueryLog();
+
+        $result = $this->freshTagRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+        // The cache was not invalidated: the stale two-row collection is
+        // served straight from cache without touching the database.
+        static::assertCount(0, DB::getQueryLog());
+        static::assertCount(2, $result);
+
+        // The deferred write itself still reached the database; only the
+        // downstream invalidation was skipped.
+        static::assertSame(3, DB::table('tags')->count());
+    }
+
+    /**
+     * Warm the per-query cache for the tags table.
+     *
+     * @return void
+     */
+    private function warmTagCache(): void
+    {
+        $this->freshTagRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
+    }
+
+    /**
+     * Defer a tag insert through the scoped write pool and run the
+     * lifecycle-boundary flush via the subscriber.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    private function deferTagAndCompleteBoundary(string $name): void
+    {
+        assert($this->app !== null);
+
+        $pool = $this->app->make(WritePool::class);
+        $pool->add('tags', ['name' => $name]);
+
+        (new WritePoolFlushSubscriber($this->app))->handleFlush();
+    }
+
+    /**
+     * Resolve a fresh cacheable tag repository from the container.
+     *
+     * @return \Tests\Fixtures\Repositories\CacheableTagRepository
+     */
+    private function freshTagRepository(): CacheableTagRepository
+    {
+        assert($this->app !== null);
+
+        return $this->app->make(CacheableTagRepository::class);
+    }
+}

--- a/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
@@ -19,6 +19,7 @@ use SineMacula\ApiToolkit\Enums\FlushStrategy;
 use SineMacula\ApiToolkit\Events\WritePoolFlushFailed;
 use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -35,6 +36,24 @@ use Tests\TestCase;
 #[CoversClass(WritePoolFlushSubscriber::class)]
 class WritePoolFlushSubscriberTest extends TestCase
 {
+    /**
+     * Set up the test environment.
+     *
+     * The per-query cache invalidation path is covered by its own
+     * dedicated tests below; disable it here so the flush and escalation
+     * assertions observe the subscriber in isolation without the
+     * container being asked for the invalidator.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', false);
+    }
+
     /**
      * Test that subscribe registers a listener for RequestHandled.
      *
@@ -422,6 +441,114 @@ class WritePoolFlushSubscriberTest extends TestCase
         $this->expectException(WritePoolFlushException::class);
 
         $subscriber->handleFlush();
+    }
+
+    /**
+     * Test that, when invalidation is enabled, the subscriber invalidates
+     * the per-query cache for every table the flush persisted.
+     *
+     * @return void
+     */
+    public function testHandleFlushInvalidatesQueryCacheForFlushedTables(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        $pool = new WritePool(500, 10000);
+        $pool->add('users', ['name' => 'Alice', 'email' => 'alice@example.com', 'password' => 'secret']);
+
+        $invalidator = new class {
+            /** @var list<array<int, string>> The arguments of each invalidate() call. */
+            public array $calls = [];
+
+            /**
+             * @param  array<int, string>  $tables
+             * @return void
+             */
+            public function invalidate(array $tables): void
+            {
+                $this->calls[] = $tables;
+            }
+        };
+
+        $container = \Mockery::mock(Container::class);
+        $container->shouldReceive('make')->with(WritePool::class)->andReturn($pool);
+        $container->shouldReceive('make')->with(DeferredWriteCacheInvalidator::class)->andReturn($invalidator);
+
+        $subscriber = new WritePoolFlushSubscriber($container);
+
+        $subscriber->handleFlush();
+
+        static::assertTrue($pool->isEmpty());
+        static::assertSame([['users']], $invalidator->calls);
+    }
+
+    /**
+     * Test that, when invalidation is disabled, the subscriber never
+     * resolves the invalidator from the container.
+     *
+     * @return void
+     */
+    public function testHandleFlushDoesNotInvalidateQueryCacheWhenDisabled(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', false);
+
+        $pool = new WritePool(500, 10000);
+        $pool->add('users', ['name' => 'Bob', 'email' => 'bob@example.com', 'password' => 'secret']);
+
+        $container = \Mockery::mock(Container::class);
+        $container->shouldReceive('make')->with(WritePool::class)->andReturn($pool);
+        $container->shouldReceive('make')->with(DeferredWriteCacheInvalidator::class)->never();
+
+        $subscriber = new WritePoolFlushSubscriber($container);
+
+        $subscriber->handleFlush();
+
+        static::assertTrue($pool->isEmpty());
+    }
+
+    /**
+     * Test that a throw-strategy failure still invalidates the per-query
+     * cache for every attempted table before the failure is escalated.
+     *
+     * @return void
+     */
+    public function testHandleFlushInvalidatesQueryCacheOnFlushException(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+        Config::set('api-toolkit.deferred_writes.rethrow_at_boundary', false);
+
+        $pool = new WritePool(500, 10000, FlushStrategy::THROW);
+        $pool->add('users', ['name' => 'Carol', 'email' => 'carol@example.com', 'password' => 'secret']);
+        $pool->add('nonexistent_table', ['col' => 'val']);
+
+        $invalidator = new class {
+            /** @var list<array<int, string>> The arguments of each invalidate() call. */
+            public array $calls = [];
+
+            /**
+             * @param  array<int, string>  $tables
+             * @return void
+             */
+            public function invalidate(array $tables): void
+            {
+                $this->calls[] = $tables;
+            }
+        };
+
+        $container = \Mockery::mock(Container::class);
+        $container->shouldReceive('make')->with(WritePool::class)->andReturn($pool);
+        $container->shouldReceive('make')->with(DeferredWriteCacheInvalidator::class)->andReturn($invalidator);
+
+        Log::shouldReceive('warning')->once();
+
+        Event::fake([WritePoolFlushFailed::class]);
+
+        $subscriber = new WritePoolFlushSubscriber($container);
+
+        $subscriber->handleFlush();
+
+        Event::assertDispatched(WritePoolFlushFailed::class);
+        static::assertSame([['users', 'nonexistent_table']], $invalidator->calls);
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/CacheStoreTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheStoreTest.php
@@ -5,7 +5,9 @@ namespace Tests\Unit\Repositories\Concerns;
 use Carbon\Carbon;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Enums\CacheKeys;
 use SineMacula\ApiToolkit\Repositories\Concerns\CacheSizeGuard;
 use SineMacula\ApiToolkit\Repositories\Concerns\CacheStore;
 use SineMacula\ApiToolkit\Repositories\Concerns\CacheStoreOptions;
@@ -404,5 +406,55 @@ class CacheStoreTest extends TestCase
 
         static::assertNull($tableA->get(self::HASH));
         static::assertNotNull($tableB->get(self::HASH));
+    }
+
+    /**
+     * Test that invalidateTable flushes a taggable store's table tag and,
+     * because the taggable path returns early, never bumps the generational
+     * version.
+     *
+     * @return void
+     */
+    public function testInvalidateTableFlushesTaggableStoreWithoutBumpingVersion(): void
+    {
+        $this->cacheStore->put(self::HASH, collect(['a', 'b']), 2);
+
+        CacheStore::invalidateTable('array', 'test-table', true);
+
+        static::assertNull($this->cacheStore->get(self::HASH));
+        static::assertNull(Cache::store('array')->get(CacheKeys::REPOSITORY_CACHE_VERSION->resolveKey(['test-table'])));
+    }
+
+    /**
+     * Test that invalidateTable bumps the generational version on a
+     * non-taggable store when the registry is enabled, so a previously
+     * cached entry reads back as a miss.
+     *
+     * @return void
+     */
+    public function testInvalidateTableBumpsVersionOnNonTaggableStoreWhenRegistryEnabled(): void
+    {
+        $options = new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10);
+        (new CacheStore('file', 'file-table', $options))->put(self::HASH, collect(['a']), 1);
+
+        CacheStore::invalidateTable('file', 'file-table', true);
+
+        static::assertNull((new CacheStore('file', 'file-table', $options))->get(self::HASH));
+    }
+
+    /**
+     * Test that invalidateTable leaves a non-taggable store's entry intact
+     * when the registry is disabled, because it cannot bump the version.
+     *
+     * @return void
+     */
+    public function testInvalidateTableLeavesEntryOnNonTaggableStoreWhenRegistryDisabled(): void
+    {
+        $options = new CacheStoreOptions(3600, new CacheSizeGuard(1000, 262144), true, 10);
+        (new CacheStore('file', 'file-table', $options))->put(self::HASH, collect(['a']), 1);
+
+        CacheStore::invalidateTable('file', 'file-table', false);
+
+        static::assertNotNull((new CacheStore('file', 'file-table', $options))->get(self::HASH));
     }
 }

--- a/tests/Unit/Repositories/Concerns/DeferredWriteCacheInvalidatorTest.php
+++ b/tests/Unit/Repositories/Concerns/DeferredWriteCacheInvalidatorTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Unit\Repositories\Concerns;
+
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Repositories\Concerns\CacheSizeGuard;
+use SineMacula\ApiToolkit\Repositories\Concerns\CacheStore;
+use SineMacula\ApiToolkit\Repositories\Concerns\CacheStoreOptions;
+use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
+use Tests\TestCase;
+
+/**
+ * Tests for the DeferredWriteCacheInvalidator.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(DeferredWriteCacheInvalidator::class)]
+class DeferredWriteCacheInvalidatorTest extends TestCase
+{
+    /** @var string A representative query fingerprint. */
+    private const string HASH = 'abc123';
+
+    /**
+     * Set up the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+    }
+
+    /**
+     * Test that invalidating a table on a taggable store flushes the
+     * table tag, so a previously cached entry reads back as a miss.
+     *
+     * @return void
+     */
+    public function testInvalidateFlushesTaggableStore(): void
+    {
+        $warm = $this->cacheStore('widgets');
+        $warm->put(self::HASH, collect(['a', 'b']), 2);
+
+        static::assertNotNull($warm->get(self::HASH));
+
+        (new DeferredWriteCacheInvalidator)->invalidate(['widgets']);
+
+        static::assertNull($this->cacheStore('widgets')->get(self::HASH));
+    }
+
+    /**
+     * Test that, on a non-taggable store with the registry enabled,
+     * invalidation bumps the generational version so the entry misses.
+     *
+     * @return void
+     */
+    public function testInvalidateBumpsVersionOnNonTaggableStoreWhenRegistryEnabled(): void
+    {
+        Config::set('api-toolkit.repositories.cache.store', 'file');
+
+        $warm = $this->cacheStore('widgets', 'file');
+        $warm->put(self::HASH, collect(['a', 'b']), 2);
+
+        (new DeferredWriteCacheInvalidator)->invalidate(['widgets']);
+
+        static::assertNull($this->cacheStore('widgets', 'file')->get(self::HASH));
+    }
+
+    /**
+     * Test that, on a non-taggable store with the registry disabled,
+     * invalidation cannot bump the version, so the stale entry survives
+     * until its TTL expires.
+     *
+     * @return void
+     */
+    public function testInvalidateLeavesStaleEntryWhenRegistryDisabledOnNonTaggableStore(): void
+    {
+        Config::set('api-toolkit.repositories.cache.store', 'file');
+        Config::set('api-toolkit.repositories.cache.registry_enabled', false);
+
+        $warm = $this->cacheStore('widgets', 'file');
+        $warm->put(self::HASH, collect(['a', 'b']), 2);
+
+        (new DeferredWriteCacheInvalidator)->invalidate(['widgets']);
+
+        static::assertNotNull($this->cacheStore('widgets', 'file')->get(self::HASH));
+    }
+
+    /**
+     * Test that every table in the list is invalidated, not just the
+     * first.
+     *
+     * @return void
+     */
+    public function testInvalidateInvalidatesEachOfMultipleTables(): void
+    {
+        $this->cacheStore('widgets')->put(self::HASH, collect(['a']), 1);
+        $this->cacheStore('gadgets')->put(self::HASH, collect(['b']), 1);
+
+        (new DeferredWriteCacheInvalidator)->invalidate(['widgets', 'gadgets']);
+
+        static::assertNull($this->cacheStore('widgets')->get(self::HASH));
+        static::assertNull($this->cacheStore('gadgets')->get(self::HASH));
+    }
+
+    /**
+     * Test that an empty table list is a no-op that leaves existing
+     * cache entries untouched.
+     *
+     * @return void
+     */
+    public function testInvalidateWithEmptyTableListLeavesEntryIntact(): void
+    {
+        $this->cacheStore('widgets')->put(self::HASH, collect(['a']), 1);
+
+        (new DeferredWriteCacheInvalidator)->invalidate([]);
+
+        static::assertNotNull($this->cacheStore('widgets')->get(self::HASH));
+    }
+
+    /**
+     * Test that invalidation targets the configured repository cache
+     * store rather than only the framework default.
+     *
+     * @return void
+     */
+    public function testInvalidateUsesConfiguredRepositoryStore(): void
+    {
+        Config::set('cache.stores.repo-cache', ['driver' => 'array']);
+        Config::set('api-toolkit.repositories.cache.store', 'repo-cache');
+
+        $options = new CacheStoreOptions(3600, new CacheSizeGuard(null, null), true, 0);
+
+        (new CacheStore('repo-cache', 'widgets', $options))->put(self::HASH, collect(['a']), 1);
+
+        (new DeferredWriteCacheInvalidator)->invalidate(['widgets']);
+
+        static::assertNull((new CacheStore('repo-cache', 'widgets', $options))->get(self::HASH));
+    }
+
+    /**
+     * Test that a non-string store configuration falls back to the array
+     * driver rather than passing a non-string to the cache manager.
+     *
+     * @return void
+     */
+    public function testInvalidateFallsBackToArrayStoreForNonStringStoreConfig(): void
+    {
+        Config::set('api-toolkit.repositories.cache.store', null);
+        Config::set('cache.default', 123);
+
+        $this->cacheStore('widgets')->put(self::HASH, collect(['a']), 1);
+
+        (new DeferredWriteCacheInvalidator)->invalidate(['widgets']);
+
+        static::assertNull($this->cacheStore('widgets')->get(self::HASH));
+    }
+
+    /**
+     * Build a CacheStore on the given driver for the given table.
+     *
+     * @param  string  $table
+     * @param  string  $store
+     * @return \SineMacula\ApiToolkit\Repositories\Concerns\CacheStore
+     */
+    private function cacheStore(string $table, string $store = 'array'): CacheStore
+    {
+        return new CacheStore($store, $table, new CacheStoreOptions(3600, new CacheSizeGuard(null, null), true, 0));
+    }
+}

--- a/tests/Unit/Repositories/Concerns/WritePoolFlushResultTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolFlushResultTest.php
@@ -190,4 +190,34 @@ class WritePoolFlushResultTest extends TestCase
         static::assertSame(3, $result->retainedRecordCount());
         static::assertSame(0, $result->droppedRecordCount());
     }
+
+    /**
+     * Test that flushedTables defaults to an empty array when no tables
+     * are provided.
+     *
+     * @return void
+     */
+    public function testFlushedTablesDefaultsToEmptyArray(): void
+    {
+        $result = new WritePoolFlushResult(successCount: 1, failureCount: 0);
+
+        static::assertSame([], $result->flushedTables());
+    }
+
+    /**
+     * Test that flushedTables returns the table list provided to the
+     * constructor.
+     *
+     * @return void
+     */
+    public function testFlushedTablesReturnsConstructorValue(): void
+    {
+        $result = new WritePoolFlushResult(
+            successCount: 2,
+            failureCount: 0,
+            flushedTables: ['orders', 'payments'],
+        );
+
+        static::assertSame(['orders', 'payments'], $result->flushedTables());
+    }
 }

--- a/tests/Unit/Repositories/Concerns/WritePoolTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolTest.php
@@ -870,6 +870,57 @@ class WritePoolTest extends TestCase
     }
 
     /**
+     * Test that a successful flush reports every table it attempted to
+     * persist, so the boundary can invalidate each table's downstream
+     * per-query cache.
+     *
+     * @return void
+     */
+    public function testFlushResultReportsEveryAttemptedTable(): void
+    {
+        $this->pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $this->pool->add('test_other', ['label' => 'baz']);
+
+        $flushResult = $this->pool->flush();
+
+        static::assertSame(['test_records', 'test_other'], $flushResult->flushedTables());
+    }
+
+    /**
+     * Test that an empty flush reports no attempted tables.
+     *
+     * @return void
+     */
+    public function testEmptyFlushReportsNoAttemptedTables(): void
+    {
+        $flushResult = $this->pool->flush();
+
+        static::assertSame([], $flushResult->flushedTables());
+    }
+
+    /**
+     * Test that the partial result carried by the throw exception reports
+     * every attempted table, so the boundary still invalidates the cache
+     * for tables that persisted before the failure.
+     *
+     * @return void
+     */
+    public function testThrowResultReportsEveryAttemptedTable(): void
+    {
+        $pool = new WritePool(chunkSize: 1, poolLimit: 10000, strategy: FlushStrategy::THROW);
+
+        $pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $pool->add('nonexistent_table', ['col' => 'val']);
+
+        try {
+            $pool->flush();
+            static::fail('Expected WritePoolFlushException was not thrown');
+        } catch (WritePoolFlushException $exception) {
+            static::assertSame(['test_records', 'nonexistent_table'], $exception->flushResult()->flushedTables());
+        }
+    }
+
+    /**
      * Define the database migrations.
      *
      * @return void


### PR DESCRIPTION
## Summary

Closes the read-after-deferred-write staleness gap (BL-11). The deferred write pool persists buffered inserts via bulk `INSERT` at the lifecycle boundary, which bypasses the per-query cache invalidation that fires on a repository's own write verbs. A deferred insert therefore left any cached collection for that table stale until its TTL expired.

The boundary flush now invalidates the per-query cache for every table it persisted, mirroring what an immediate write does.

## What changed

- **`WritePoolFlushResult::flushedTables()`** - the result now reports every table the flush attempted to persist, threaded through `WritePoolFlushAccumulator` (both the normal and throw paths).
- **`DeferredWriteCacheInvalidator`** (new) - resolves the default repository cache store and invalidates each flushed table.
- **`WritePoolFlushSubscriber`** - invalidates `flushedTables()` after every boundary flush (success path and `WritePoolFlushException` path), gated by a new flag.
- **`CacheStore::invalidateTable()`** (new, static) - a lean invalidation primitive that flushes the table tag (taggable stores) or bumps the generational version (non-taggable stores with the registry enabled), without constructing throwaway cache options. The tag/version-key derivation is shared with the constructor via new `tagFor()` / `versionKeyFor()` helpers, so there is no duplicated key knowledge.
- **Config** - `api-toolkit.deferred_writes.invalidate_query_cache` (default `true`, env `DEFERRED_WRITES_INVALIDATE_QUERY_CACHE`).

## Scope / limitations

Best-effort by design: it covers default-config `Cacheable` repositories (the configured repository cache store, keyed by table name). A repository on a custom cache store (`cacheStoreName`) or key prefix (`cacheKeyPrefix`) is not reached and must invalidate manually - documented on the `Deferrable` trait and in UPGRADE.md. Disable with `DEFERRED_WRITES_INVALIDATE_QUERY_CACHE=false`.

## Tests / gates

- `composer test` - 1994 pass (1 pre-existing skip)
- `composer check` - clean (PHPStan L8 + formatting)
- `composer test:mutation` - 94% MSI / 94% covered MSI (gate met)

New coverage: unit tests for the invalidator (taggable flush, non-taggable registry on/off, multi-table, empty list, configured store, non-string-store fallback), `CacheStore::invalidateTable` tests, subscriber wiring tests (enabled / disabled / throw-path), `flushedTables()` on the result and pool, and an end-to-end integration test (warm cache -> defer write -> boundary flush -> cache invalidated; and the disabled-flag path that still persists but serves stale).

## Note

The second commit (`style:`) wraps one overlong line in an archived planning doc - a pre-existing markdownlint MD013 violation surfaced by `composer check` on this branch. No content change.