### PR TITLE
chore: adopt coding-standards v1.8.3 (single-line method signatures)

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -46,7 +46,7 @@ default = true
 [[source]]
 name = "sinemacula"
 repository = "https://github.com/sinemacula/coding-standards"
-tag = "v1.7.2"
+tag = "v1.8.3"
 
 [[plugin]]
 name = "actionlint"

--- a/src/Exceptions/ApiExceptionHandler.php
+++ b/src/Exceptions/ApiExceptionHandler.php
@@ -184,11 +184,8 @@ final class ApiExceptionHandler
      * @param  array<string, mixed>  $headers
      * @return \SineMacula\ApiToolkit\Exceptions\ApiException
      */
-    private static function mapGenericHttpException(
-        SymfonyHttpExceptionInterface $exception,
-        ?array $meta,
-        array $headers,
-    ): ApiException {
+    private static function mapGenericHttpException(SymfonyHttpExceptionInterface $exception, ?array $meta, array $headers): ApiException
+    {
         // Laravel's handler converts session token mismatches to a generic
         // 419 HttpException before render callbacks run; 419 has no
         // HttpStatus case, so map it back to the dedicated exception

--- a/src/Http/Concerns/RespondsWithExport.php
+++ b/src/Http/Concerns/RespondsWithExport.php
@@ -89,11 +89,8 @@ trait RespondsWithExport
      *
      * @throws \InvalidArgumentException
      */
-    public function exportFromCollection(
-        ResourceCollection $collection,
-        bool $download = true,
-        ?string $filename = null,
-    ): HttpResponse {
+    public function exportFromCollection(ResourceCollection $collection, bool $download = true, ?string $filename = null): HttpResponse
+    {
         $capabilities = RequestCapabilities::fromRequest(request());
 
         return match (true) {
@@ -111,11 +108,8 @@ trait RespondsWithExport
      * @param  string  $filename
      * @return \Illuminate\Http\Response
      */
-    public function exportCollectionToCsv(
-        ResourceCollection $collection,
-        bool $download = true,
-        string $filename = 'export.csv',
-    ): HttpResponse {
+    public function exportCollectionToCsv(ResourceCollection $collection, bool $download = true, string $filename = 'export.csv'): HttpResponse
+    {
         $csv = $this->buildExporter('csv')->exportCollection($collection);
 
         return $this->createExportResponse($csv, MediaType::TEXT_CSV->withCharset(Charset::UTF_8), $download, $filename);
@@ -129,11 +123,8 @@ trait RespondsWithExport
      * @param  string  $filename
      * @return \Illuminate\Http\Response
      */
-    public function exportCollectionToXml(
-        ResourceCollection $collection,
-        bool $download = true,
-        string $filename = 'export.xml',
-    ): HttpResponse {
+    public function exportCollectionToXml(ResourceCollection $collection, bool $download = true, string $filename = 'export.xml'): HttpResponse
+    {
         $xml = $this->buildExporter('xml')->exportCollection($collection);
 
         return $this->createExportResponse($xml, MediaType::APPLICATION_XML->getMimeType(), $download, $filename);
@@ -149,11 +140,8 @@ trait RespondsWithExport
      *
      * @throws \InvalidArgumentException
      */
-    public function exportFromItem(
-        JsonResource $resource,
-        bool $download = true,
-        ?string $filename = null,
-    ): HttpResponse {
+    public function exportFromItem(JsonResource $resource, bool $download = true, ?string $filename = null): HttpResponse
+    {
         $capabilities = RequestCapabilities::fromRequest(request());
 
         return match (true) {
@@ -171,11 +159,8 @@ trait RespondsWithExport
      * @param  string  $filename
      * @return \Illuminate\Http\Response
      */
-    public function exportItemToCsv(
-        JsonResource $resource,
-        bool $download = true,
-        string $filename = 'export.csv',
-    ): HttpResponse {
+    public function exportItemToCsv(JsonResource $resource, bool $download = true, string $filename = 'export.csv'): HttpResponse
+    {
         $csv = $this->buildExporter('csv')->exportItem($resource);
 
         return $this->createExportResponse($csv, MediaType::TEXT_CSV->withCharset(Charset::UTF_8), $download, $filename);
@@ -189,11 +174,8 @@ trait RespondsWithExport
      * @param  string  $filename
      * @return \Illuminate\Http\Response
      */
-    public function exportItemToXml(
-        JsonResource $resource,
-        bool $download = true,
-        string $filename = 'export.xml',
-    ): HttpResponse {
+    public function exportItemToXml(JsonResource $resource, bool $download = true, string $filename = 'export.xml'): HttpResponse
+    {
         $xml = $this->buildExporter('xml')->exportItem($resource);
 
         return $this->createExportResponse($xml, MediaType::APPLICATION_XML->getMimeType(), $download, $filename);
@@ -208,12 +190,8 @@ trait RespondsWithExport
      * @param  string  $filename
      * @return \Illuminate\Http\Response
      */
-    protected function createExportResponse(
-        string $data,
-        string $contentType,
-        bool $download,
-        string $filename,
-    ): HttpResponse {
+    protected function createExportResponse(string $data, string $contentType, bool $download, string $filename): HttpResponse
+    {
         $response = Response::make($data)
             ->header(HttpHeader::CONTENT_TYPE->getName(), $contentType)
             ->header(HttpHeader::CONTENT_LENGTH->getName(), strlen($data));

--- a/src/Http/Concerns/RespondsWithStream.php
+++ b/src/Http/Concerns/RespondsWithStream.php
@@ -31,11 +31,8 @@ trait RespondsWithStream
      * @param  string  $filename
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function streamRepositoryToCsv(
-        ApiRepository $repository,
-        int $chunkSize = 1500,
-        string $filename = 'export.csv',
-    ): StreamedResponse {
+    public function streamRepositoryToCsv(ApiRepository $repository, int $chunkSize = 1500, string $filename = 'export.csv'): StreamedResponse
+    {
         $limit = ApiQuery::getLimit();
 
         $transformer = $this->makeTransformer($repository);
@@ -128,11 +125,8 @@ trait RespondsWithStream
      * @param  string  $filename
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    protected function createStreamedResponse(
-        callable $callback,
-        string $contentType,
-        string $filename,
-    ): StreamedResponse {
+    protected function createStreamedResponse(callable $callback, string $contentType, string $filename): StreamedResponse
+    {
         return Response::streamDownload($callback, $filename, [
             HttpHeader::CONTENT_TYPE->getName() => $contentType,
         ]);

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -137,14 +137,8 @@ final class EagerLoadPlanner
      * @param  array<string, bool>  $visited
      * @return void
      */
-    private static function walkRelations(
-        string $resourceClass,
-        array $fields,
-        string $prefix,
-        array &$plain,
-        array &$scoped,
-        array &$visited,
-    ): void {
+    private static function walkRelations(string $resourceClass, array $fields, string $prefix, array &$plain, array &$scoped, array &$visited): void
+    {
 
         $schema = SchemaCompiler::compile($resourceClass);
 
@@ -204,12 +198,8 @@ final class EagerLoadPlanner
      * @param  array<string, mixed>  $scoped
      * @return void
      */
-    private static function addEagerLoadPath(
-        CompiledFieldDefinition $definition,
-        string $fullPath,
-        array &$plain,
-        array &$scoped,
-    ): void {
+    private static function addEagerLoadPath(CompiledFieldDefinition $definition, string $fullPath, array &$plain, array &$scoped): void
+    {
         $constraint = $definition->constraint;
 
         if (!($constraint instanceof \Closure)) {
@@ -258,13 +248,8 @@ final class EagerLoadPlanner
      * @param  array<string, bool>  $visited
      * @return void
      */
-    private static function recurseIntoChild(
-        CompiledFieldDefinition $definition,
-        string $fullPath,
-        array &$plain,
-        array &$scoped,
-        array &$visited,
-    ): void {
+    private static function recurseIntoChild(CompiledFieldDefinition $definition, string $fullPath, array &$plain, array &$scoped, array &$visited): void
+    {
         if (!self::shouldRecurseIntoChild($definition)) {
             return;
         }
@@ -394,11 +379,8 @@ final class EagerLoadPlanner
      * @param  \SineMacula\ApiToolkit\Schema\CompiledCountDefinition  $definition
      * @return bool
      */
-    private static function shouldIncludeCount(
-        string $presentKey,
-        ?array $requested,
-        CompiledCountDefinition $definition,
-    ): bool {
+    private static function shouldIncludeCount(string $presentKey, ?array $requested, CompiledCountDefinition $definition): bool
+    {
         if (is_array($requested) && $requested !== []) {
             return in_array($presentKey, $requested, true);
         }

--- a/src/Http/Resources/Concerns/FieldResolver.php
+++ b/src/Http/Resources/Concerns/FieldResolver.php
@@ -74,12 +74,8 @@ final class FieldResolver
      * @param  array<int, string>  $fixedFields
      * @return array<int, string>
      */
-    public function getFields(
-        CompiledSchema $schema,
-        string $resourceType,
-        array $defaultFields,
-        array $fixedFields,
-    ): array {
+    public function getFields(CompiledSchema $schema, string $resourceType, array $defaultFields, array $fixedFields): array
+    {
         $this->fields ??= $this->shouldRespondWithAll($resourceType)
             ? $schema->getFieldKeys()
             : (ApiQuery::getFields($resourceType) ?? $defaultFields);

--- a/src/Http/Resources/Concerns/ValueResolver.php
+++ b/src/Http/Resources/Concerns/ValueResolver.php
@@ -75,12 +75,8 @@ final class ValueResolver
      * @param  \Illuminate\Http\Request|null  $request
      * @return mixed
      */
-    public function resolveFieldValue(
-        string $field,
-        CompiledFieldDefinition $definition,
-        mixed $resource,
-        ?Request $request,
-    ): mixed {
+    public function resolveFieldValue(string $field, CompiledFieldDefinition $definition, mixed $resource, ?Request $request): mixed
+    {
         if (!$this->guardEvaluator->passesGuards($definition->guards, $resource, $request)) {
             return new MissingValue;
         }
@@ -112,12 +108,8 @@ final class ValueResolver
      * @param  \Illuminate\Http\Request|null  $request
      * @return array<string, int>
      */
-    public function resolveCountsPayload(
-        mixed $resource,
-        CompiledSchema $schema,
-        string $resourceType,
-        ?Request $request,
-    ): array {
+    public function resolveCountsPayload(mixed $resource, CompiledSchema $schema, string $resourceType, ?Request $request): array
+    {
         $owner = $this->unwrapResource($resource);
 
         if (!is_object($owner)) {
@@ -305,11 +297,8 @@ final class ValueResolver
      * @param  \Illuminate\Http\Request|null  $request
      * @return mixed
      */
-    private function resolveRelationValue(
-        CompiledFieldDefinition $definition,
-        mixed $resource,
-        ?Request $request,
-    ): mixed {
+    private function resolveRelationValue(CompiledFieldDefinition $definition, mixed $resource, ?Request $request): mixed
+    {
         $name  = $definition->relation;
         $owner = $this->unwrapResource($resource);
 
@@ -332,12 +321,8 @@ final class ValueResolver
      * @param  \Illuminate\Http\Request|null  $request
      * @return mixed
      */
-    private function resolveRelatedValue(
-        CompiledFieldDefinition $definition,
-        mixed $related,
-        mixed $resource,
-        ?Request $request,
-    ): mixed {
+    private function resolveRelatedValue(CompiledFieldDefinition $definition, mixed $related, mixed $resource, ?Request $request): mixed
+    {
         if ($definition->accessor !== null) {
             return match (true) {
                 is_string($definition->accessor)   => data_get($related, $definition->accessor),
@@ -458,11 +443,8 @@ final class ValueResolver
      * @param  \SineMacula\ApiToolkit\Schema\CompiledCountDefinition  $definition
      * @return bool
      */
-    private function shouldIncludeCount(
-        string $presentKey,
-        ?array $requested,
-        CompiledCountDefinition $definition,
-    ): bool {
+    private function shouldIncludeCount(string $presentKey, ?array $requested, CompiledCountDefinition $definition): bool
+    {
         if (is_array($requested) && $requested !== []) {
             return in_array($presentKey, $requested, true);
         }

--- a/src/Http/Routing/Controller.php
+++ b/src/Http/Routing/Controller.php
@@ -35,11 +35,8 @@ abstract class Controller extends LaravelController
      * @param  array<string, string>  $headers
      * @return \Illuminate\Http\JsonResponse
      */
-    protected function respondWithData(
-        array $data,
-        HttpStatus $status = HttpStatus::OK,
-        array $headers = [],
-    ): JsonResponse {
+    protected function respondWithData(array $data, HttpStatus $status = HttpStatus::OK, array $headers = []): JsonResponse
+    {
         return Response::json(['data' => $data], $status->getCode(), $headers);
     }
 
@@ -51,11 +48,8 @@ abstract class Controller extends LaravelController
      * @param  array<string, string>  $headers
      * @return \Illuminate\Http\JsonResponse
      */
-    protected function respondWithItem(
-        JsonResource $resource,
-        HttpStatus $status = HttpStatus::OK,
-        array $headers = [],
-    ): JsonResponse {
+    protected function respondWithItem(JsonResource $resource, HttpStatus $status = HttpStatus::OK, array $headers = []): JsonResponse
+    {
         return $resource->response()->setStatusCode($status->getCode())->withHeaders($headers);
     }
 
@@ -67,11 +61,8 @@ abstract class Controller extends LaravelController
      * @param  array<string, string>  $headers
      * @return \Illuminate\Http\JsonResponse
      */
-    protected function respondWithCollection(
-        ResourceCollection $collection,
-        HttpStatus $status = HttpStatus::OK,
-        array $headers = [],
-    ): JsonResponse {
+    protected function respondWithCollection(ResourceCollection $collection, HttpStatus $status = HttpStatus::OK, array $headers = []): JsonResponse
+    {
         return $collection->response()->setStatusCode($status->getCode())->withHeaders($headers);
     }
 
@@ -87,12 +78,8 @@ abstract class Controller extends LaravelController
      * @param  array<string, string>  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    protected function respondWithEventStream(
-        callable $callback,
-        int $interval = 1,
-        HttpStatus $status = HttpStatus::OK,
-        array $headers = [],
-    ): StreamedResponse {
+    protected function respondWithEventStream(callable $callback, int $interval = 1, HttpStatus $status = HttpStatus::OK, array $headers = []): StreamedResponse
+    {
         return (new EventStream(static::HEARTBEAT_INTERVAL))
             ->toResponse($callback, $interval, $status, $headers);
     }

--- a/src/Listeners/NotificationListener.php
+++ b/src/Listeners/NotificationListener.php
@@ -50,13 +50,8 @@ final class NotificationListener
      * @param  string  $channel
      * @return void
      */
-    private function log(
-        string $level,
-        string $message,
-        Notification $notification,
-        object $notifiable,
-        string $channel,
-    ): void {
+    private function log(string $level, string $message, Notification $notification, object $notifiable, string $channel): void
+    {
         $excludedClasses = config('api-toolkit.notifications.excluded_classes', []);
 
         if (in_array($notification::class, $excludedClasses, true)) {

--- a/src/Repositories/Concerns/WritePool.php
+++ b/src/Repositories/Concerns/WritePool.php
@@ -190,10 +190,8 @@ final class WritePool
      *
      * @throws \SineMacula\ApiToolkit\Exceptions\WritePoolFlushException
      */
-    private function flushTableTransactionally(
-        WritePoolFlushContext $context,
-        WritePoolFlushAccumulator $accumulator,
-    ): void {
+    private function flushTableTransactionally(WritePoolFlushContext $context, WritePoolFlushAccumulator $accumulator): void
+    {
         try {
             DB::transaction(function () use ($context): void {
 
@@ -234,11 +232,8 @@ final class WritePool
      *
      * @throws \SineMacula\ApiToolkit\Exceptions\WritePoolFlushException
      */
-    private function handleTableRollback(
-        WritePoolFlushContext $context,
-        WritePoolFlushAccumulator $accumulator,
-        \Throwable $exception,
-    ): void {
+    private function handleTableRollback(WritePoolFlushContext $context, WritePoolFlushAccumulator $accumulator, \Throwable $exception): void
+    {
 
         $records = array_merge(...$context->chunks());
 
@@ -301,12 +296,8 @@ final class WritePool
      *
      * @throws \SineMacula\ApiToolkit\Exceptions\WritePoolFlushException
      */
-    private function handleChunkFailure(
-        WritePoolFlushContext $context,
-        WritePoolFlushAccumulator $accumulator,
-        array $chunk,
-        \Throwable $exception,
-    ): void {
+    private function handleChunkFailure(WritePoolFlushContext $context, WritePoolFlushAccumulator $accumulator, array $chunk, \Throwable $exception): void
+    {
 
         $accumulator->recordFailure($context->table(), $chunk, $exception);
 

--- a/src/Repositories/Concerns/WritePoolFlushAccumulator.php
+++ b/src/Repositories/Concerns/WritePoolFlushAccumulator.php
@@ -130,11 +130,8 @@ final class WritePoolFlushAccumulator
      * @param  array<int, string>  $flushedTables
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult
      */
-    private function buildResult(
-        int $retainedRecordCount,
-        int $droppedRecordCount,
-        array $flushedTables = [],
-    ): WritePoolFlushResult {
+    private function buildResult(int $retainedRecordCount, int $droppedRecordCount, array $flushedTables = []): WritePoolFlushResult
+    {
         return new WritePoolFlushResult(
             successCount: $this->successCount,
             failureCount: $this->failureCount,

--- a/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
+++ b/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
@@ -47,12 +47,8 @@ final class ColumnProjectionApplier
      * @param  array<string, string>  $order
      * @return \Illuminate\Contracts\Database\Eloquent\Builder
      */
-    public function apply(
-        Builder $query,
-        ResourceMetadataProvider $metadataProvider,
-        ?string $resourceClass,
-        array $order,
-    ): Builder {
+    public function apply(Builder $query, ResourceMetadataProvider $metadataProvider, ?string $resourceClass, array $order): Builder
+    {
         if (
             !Config::get('api-toolkit.resources.narrow_columns', false)
             || $resourceClass === null

--- a/src/Repositories/Criteria/Concerns/EagerLoadApplier.php
+++ b/src/Repositories/Criteria/Concerns/EagerLoadApplier.php
@@ -30,12 +30,8 @@ final class EagerLoadApplier
      * @param  string|null  $resourceType
      * @return \Illuminate\Contracts\Database\Eloquent\Builder
      */
-    public function apply(
-        Builder $query,
-        ResourceMetadataProvider $metadataProvider,
-        ?string $resourceClass,
-        ?string $resourceType,
-    ): Builder {
+    public function apply(Builder $query, ResourceMetadataProvider $metadataProvider, ?string $resourceClass, ?string $resourceType): Builder
+    {
         if ($resourceClass === null || !is_subclass_of($resourceClass, ApiResourceInterface::class)) {
             return $query;
         }

--- a/src/Repositories/Criteria/Concerns/FilterApplier.php
+++ b/src/Repositories/Criteria/Concerns/FilterApplier.php
@@ -74,12 +74,8 @@ final class FilterApplier
      * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
      * @return \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>
      */
-    private function applyFilters(
-        Builder $query,
-        array|string|null $filters,
-        ?string $field,
-        FilterContext $context,
-    ): Builder {
+    private function applyFilters(Builder $query, array|string|null $filters, ?string $field, FilterContext $context): Builder
+    {
         if (empty($filters)) {
             return $query;
         }
@@ -105,13 +101,8 @@ final class FilterApplier
      * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
      * @return void
      */
-    private function applyFilterEntry(
-        Builder $query,
-        string $key,
-        mixed $value,
-        ?string $field,
-        FilterContext $context,
-    ): void {
+    private function applyFilterEntry(Builder $query, string $key, mixed $value, ?string $field, FilterContext $context): void
+    {
         if ($this->isConditionOperator($key)) {
             $this->applyConditionOperator($query, $key, $value, $field, $context);
             return;
@@ -176,13 +167,8 @@ final class FilterApplier
      * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
      * @return void
      */
-    private function applyConditionOperator(
-        Builder $query,
-        string $operator,
-        mixed $value,
-        ?string $field,
-        FilterContext $context,
-    ): void {
+    private function applyConditionOperator(Builder $query, string $operator, mixed $value, ?string $field, FilterContext $context): void
+    {
         if (in_array($operator, ['$has', self::OPERATOR_HASNT], true)) {
 
             $this->applyHasFilter($query, $value, $operator, $context);
@@ -292,12 +278,8 @@ final class FilterApplier
      * @param  \SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext  $context
      * @return void
      */
-    private function applyHasFilter(
-        Builder $query,
-        array|string $relations,
-        string $operator,
-        FilterContext $context,
-    ): void {
+    private function applyHasFilter(Builder $query, array|string $relations, string $operator, FilterContext $context): void
+    {
         $baseMethod = $this->relationalMethodMap[$operator];
         $method     = ($context->getLogicalOperator() === '$or' && $operator === '$has') ? 'orWhereHas' : $baseMethod;
 
@@ -324,12 +306,8 @@ final class FilterApplier
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null  $callback
      * @return void
      */
-    private function applyRelationalMethod(
-        Builder $query,
-        string $method,
-        string $relation,
-        ?\Closure $callback = null,
-    ): void {
+    private function applyRelationalMethod(Builder $query, string $method, string $relation, ?\Closure $callback = null): void
+    {
         match ($method) {
             'orWhereHas'      => $query->orWhereHas($relation, $callback),
             'whereDoesntHave' => $query->whereDoesntHave($relation, $callback),

--- a/src/Schema/SafetySetDeriver.php
+++ b/src/Schema/SafetySetDeriver.php
@@ -40,12 +40,8 @@ final class SafetySetDeriver
      * @param  array<int, string>  $orderColumns
      * @return array<int, string>
      */
-    public function derive(
-        Model $model,
-        array $eagerLoadedRelations,
-        array $aliasedScalarColumns,
-        array $orderColumns,
-    ): array {
+    public function derive(Model $model, array $eagerLoadedRelations, array $aliasedScalarColumns, array $orderColumns): array
+    {
         $columns = [$model->getKeyName()];
 
         $softDeleteColumn = $this->schemaIntrospector->getDeletedAtColumn($model);

--- a/src/Services/Validation/Rules/ValidateRelationMethods.php
+++ b/src/Services/Validation/Rules/ValidateRelationMethods.php
@@ -75,12 +75,8 @@ final class ValidateRelationMethods implements SchemaValidationRule
      * @param  string  $relationMethod
      * @return \SineMacula\ApiToolkit\Services\Validation\SchemaValidationError|null
      */
-    private function validateRelationMethod(
-        string $resourceClass,
-        string $fieldKey,
-        string $modelClass,
-        string $relationMethod,
-    ): ?SchemaValidationError {
+    private function validateRelationMethod(string $resourceClass, string $fieldKey, string $modelClass, string $relationMethod): ?SchemaValidationError
+    {
         if (!method_exists($modelClass, $relationMethod)) {
             return new SchemaValidationError(
                 resourceClass: $resourceClass,
@@ -133,11 +129,8 @@ final class ValidateRelationMethods implements SchemaValidationRule
      * @param  string  $modelClass
      * @return string
      */
-    private function describeReturnTypeDefect(
-        ?\ReflectionType $returnType,
-        string $relationMethod,
-        string $modelClass,
-    ): string {
+    private function describeReturnTypeDefect(?\ReflectionType $returnType, string $relationMethod, string $modelClass): string
+    {
         if ($returnType === null) {
             return sprintf('Relation method "%s" on model "%s" has no return type hint', $relationMethod, $modelClass);
         }

--- a/src/Sse/EventStream.php
+++ b/src/Sse/EventStream.php
@@ -58,12 +58,8 @@ class EventStream
      * @param  array<string, string>  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function toResponse(
-        callable $callback,
-        int $interval = 1,
-        HttpStatus $status = HttpStatus::OK,
-        array $headers = [],
-    ): StreamedResponse {
+    public function toResponse(callable $callback, int $interval = 1, HttpStatus $status = HttpStatus::OK, array $headers = []): StreamedResponse
+    {
         $headers = array_merge($headers, [
             HttpHeader::CONTENT_TYPE->getName()      => MediaType::TEXT_EVENT_STREAM->getMimeType(),
             HttpHeader::CACHE_CONTROL->getName()     => CacheDirective::NO_CACHE->value . ', ' . CacheDirective::NO_TRANSFORM->value,

--- a/tests/Unit/Exceptions/ApiExceptionHandlerTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionHandlerTest.php
@@ -226,11 +226,8 @@ final class ApiExceptionHandlerTest extends TestCase
      * @return void
      */
     #[DataProvider('exceptionMappingProvider')]
-    public function testRenderMapsExceptionsCorrectly(
-        \Throwable $inputException,
-        int $expectedHttpCode,
-        int $expectedErrorCode,
-    ): void {
+    public function testRenderMapsExceptionsCorrectly(\Throwable $inputException, int $expectedHttpCode, int $expectedErrorCode): void
+    {
         $request = Request::create(self::API_PATH, HttpMethod::GET->getVerb());
         $request->headers->set('Accept', self::ACCEPT_JSON);
 

--- a/tests/Unit/Exceptions/ConcreteExceptionsTest.php
+++ b/tests/Unit/Exceptions/ConcreteExceptionsTest.php
@@ -110,11 +110,8 @@ final class ConcreteExceptionsTest extends TestCase
      * @return void
      */
     #[DataProvider('exceptionProvider')]
-    public function testGetInternalErrorCodeReturnsExpectedCode(
-        string $class,
-        int $expectedInternalCode,
-        int $expectedHttpCode,
-    ): void {
+    public function testGetInternalErrorCodeReturnsExpectedCode(string $class, int $expectedInternalCode, int $expectedHttpCode): void
+    {
         self::assertSame($expectedInternalCode, $class::getInternalErrorCode());
     }
 
@@ -127,11 +124,8 @@ final class ConcreteExceptionsTest extends TestCase
      * @return void
      */
     #[DataProvider('exceptionProvider')]
-    public function testGetHttpStatusCodeReturnsExpectedStatus(
-        string $class,
-        int $expectedInternalCode,
-        int $expectedHttpCode,
-    ): void {
+    public function testGetHttpStatusCodeReturnsExpectedStatus(string $class, int $expectedInternalCode, int $expectedHttpCode): void
+    {
         self::assertSame($expectedHttpCode, $class::getHttpStatusCode());
     }
 }

--- a/tests/Unit/Http/Concerns/RespondsWithExportTest.php
+++ b/tests/Unit/Http/Concerns/RespondsWithExportTest.php
@@ -699,12 +699,8 @@ final class RespondsWithExportTest extends TestCase
              * @param  string  $filename
              * @return \Illuminate\Http\Response
              */
-            public function callCreateExportResponse(
-                string $data,
-                string $contentType,
-                bool $download,
-                string $filename,
-            ): HttpResponse {
+            public function callCreateExportResponse(string $data, string $contentType, bool $download, string $filename): HttpResponse
+            {
                 return $this->createExportResponse($data, $contentType, $download, $filename);
             }
         };

--- a/tests/Unit/Http/Concerns/RespondsWithStreamTest.php
+++ b/tests/Unit/Http/Concerns/RespondsWithStreamTest.php
@@ -657,11 +657,8 @@ final class RespondsWithStreamTest extends TestCase
              * @param  string  $filename
              * @return \Symfony\Component\HttpFoundation\StreamedResponse
              */
-            public function callCreateStreamedResponse(
-                callable $callback,
-                string $contentType,
-                string $filename,
-            ): StreamedResponse {
+            public function callCreateStreamedResponse(callable $callback, string $contentType, string $filename): StreamedResponse
+            {
                 return $this->createStreamedResponse($callback, $contentType, $filename);
             }
         };

--- a/tests/Unit/Http/Resources/Concerns/FieldColumnMapperTest.php
+++ b/tests/Unit/Http/Resources/Concerns/FieldColumnMapperTest.php
@@ -189,13 +189,8 @@ final class FieldColumnMapperTest extends TestCase
      * @param  array<int, callable(mixed, mixed): bool>  $guards
      * @return \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition
      */
-    private function makeDefinition(
-        mixed $accessor = null,
-        mixed $compute = null,
-        ?string $relation = null,
-        array $needs = [],
-        array $guards = [],
-    ): CompiledFieldDefinition {
+    private function makeDefinition(mixed $accessor = null, mixed $compute = null, ?string $relation = null, array $needs = [], array $guards = []): CompiledFieldDefinition
+    {
         return new CompiledFieldDefinition(
             accessor    : $accessor,
             compute     : $compute,

--- a/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
+++ b/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
@@ -142,12 +142,8 @@ final class ApiCriteriaTest extends TestCase
      * @return void
      */
     #[DataProvider('conditionOperatorProvider')]
-    public function testApplyWithConditionOperator(
-        string $operator,
-        string $expectedSqlOperator,
-        mixed $value,
-        string $expectedType,
-    ): void {
+    public function testApplyWithConditionOperator(string $operator, string $expectedSqlOperator, mixed $value, string $expectedType): void
+    {
         $filter = ['name' => [$operator => $value]];
 
         $this->parseRequest(new Request([

--- a/tests/Unit/Traits/OrdersFieldsTest.php
+++ b/tests/Unit/Traits/OrdersFieldsTest.php
@@ -156,11 +156,8 @@ final class OrdersFieldsTest extends TestCase
      * @return void
      */
     #[DataProvider('requestedFieldsOrderingProvider')]
-    public function testOrderByRequestedFieldsMaintainsRequestedOrder(
-        array $requestedFields,
-        array $data,
-        array $expectedKeyOrder,
-    ): void {
+    public function testOrderByRequestedFieldsMaintainsRequestedOrder(array $requestedFields, array $data, array $expectedKeyOrder): void
+    {
         $consumer = $this->createConsumer(FieldOrderingStrategy::BY_REQUESTED_FIELDS, $requestedFields);
 
         $result = $this->invokeMethod($consumer, 'orderByRequestedFields', $data);


### PR DESCRIPTION
Bumps the qlty source pin to **v1.8.3**, which adds `RequireSingleLineMethodSignature`: short method signatures spanning multiple lines must collapse to one line.

## Changes
- `.qlty/qlty.toml`: source pin `v1.7.2` → `v1.8.3`
- Collapse the 48 flagged multi-line signatures to a single line across `src` + `tests` (formatting only, no behaviour change)

## Verification
- `qlty check --all` → ✔ No issues
- 1995 tests pass
- Mutation gate (covered MSI ≥ 94%) green

Pure standards conformance; no logic touched. Separate from the log/SSE extraction work.