### PR TITLE
fix: Review 3 small fixes (BL-23, BL-24, BL-26, BL-31)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/database": "*",
-        "illuminate/http": "*",
-        "illuminate/notifications": "*",
-        "illuminate/routing": "*",
+        "illuminate/database": "^12.0",
+        "illuminate/http": "^12.0",
+        "illuminate/notifications": "^12.0",
+        "illuminate/routing": "^12.0",
         "illuminate/support": "^12.9",
-        "illuminate/validation": "*",
+        "illuminate/validation": "^12.0",
         "sinemacula/http-primitives-php": "^2.0",
         "sinemacula/laravel-repositories": "^2.0",
         "sinemacula/laravel-resource-exporter": "^2.0"

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -11,6 +11,7 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
+use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 
 /**
@@ -56,6 +57,7 @@ final class CacheManager
         SchemaCompiler::clearCache();
         ValueResolver::clearCache();
         EagerLoadPlanner::clearCache();
+        FieldColumnMapper::clearCache();
 
         $this->container->make(SchemaIntrospectionProvider::class)->flush();
 

--- a/src/Listeners/QueueFlushSubscriber.php
+++ b/src/Listeners/QueueFlushSubscriber.php
@@ -7,6 +7,7 @@ namespace SineMacula\ApiToolkit\Listeners;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Cache\CacheManager;
 use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 
@@ -66,6 +67,10 @@ final class QueueFlushSubscriber
             return;
         }
 
-        $this->cacheManager->flush();
+        try {
+            $this->cacheManager->flush();
+        } catch (\Throwable $exception) {
+            Log::error('Queue worker cache flush failed', ['exception' => $exception]);
+        }
     }
 }

--- a/src/Repositories/Concerns/Cacheable.php
+++ b/src/Repositories/Concerns/Cacheable.php
@@ -7,6 +7,7 @@ namespace SineMacula\ApiToolkit\Repositories\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Contracts\CacheInvalidator;
 
 /**
@@ -179,7 +180,14 @@ trait Cacheable
     {
         $result = parent::__call($method, $arguments);
 
-        $this->activeStore()->flushTable();
+        try {
+            $this->activeStore()->flushTable();
+        } catch (\Throwable $exception) {
+            // Best-effort: the write is already committed, so a cache-store
+            // outage must not surface as a write failure (the caller could
+            // retry and duplicate). Stale-until-TTL is the safe degraded state.
+            Log::error('Cache flush after write failed', ['exception' => $exception]);
+        }
 
         return $result;
     }

--- a/src/Repositories/Criteria/Operators/ContainsOperator.php
+++ b/src/Repositories/Criteria/Operators/ContainsOperator.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Repositories\Criteria\Operators;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Contracts\FilterOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
 
@@ -102,8 +103,8 @@ final class ContainsOperator implements FilterOperator
     }
 
     /**
-     * Apply a JSON containment constraint, silently discarding values that
-     * are not JSON-compatible scalars (e.g. null).
+     * Apply a JSON containment constraint, logging and discarding values that
+     * the active grammar rejects (e.g. non-JSON-compatible scalars like null).
      *
      * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
      * @param  string  $column
@@ -114,9 +115,16 @@ final class ContainsOperator implements FilterOperator
     {
         try {
             $query->getQuery()->whereJsonContains($column, $value);
-        } catch (\RuntimeException) { // @codeCoverageIgnore
-            // Silently discard: the active grammar may reject a JSON-contains
-            // clause for non-JSON-compatible scalar values (e.g. null)
-        } // @codeCoverageIgnore
+        } catch (\RuntimeException $exception) {
+            // Drop the constraint: the grammar may reject a JSON-containment
+            // clause for non-JSON scalars (e.g. null). Log it so a recurring
+            // rejection is diagnosable rather than silently widening results.
+            Log::debug('Dropped unsupported $contains filter constraint', [
+                'table'      => $query->getModel()->getTable(),
+                'column'     => $column,
+                'value_type' => get_debug_type($value),
+                'reason'     => $exception->getMessage(),
+            ]);
+        }
     }
 }

--- a/src/Services/SchemaIntrospector.php
+++ b/src/Services/SchemaIntrospector.php
@@ -81,7 +81,7 @@ final class SchemaIntrospector implements SchemaIntrospectionProvider
 
         $columns = Schema::getColumnListing($model->getTable());
 
-        $this->metadataCacheWriter()->rememberMetadataForever($cacheKey, fn () => $columns);
+        $this->metadataCacheWriter->rememberMetadataForever($cacheKey, fn () => $columns);
 
         $this->columns[$model::class] = $columns;
 
@@ -117,7 +117,7 @@ final class SchemaIntrospector implements SchemaIntrospectionProvider
 
         $definitions = $this->mapColumnDefinitions(Schema::getColumns($model->getTable()));
 
-        $this->metadataCacheWriter()->rememberMetadataForever($cacheKey, fn () => $definitions);
+        $this->metadataCacheWriter->rememberMetadataForever($cacheKey, fn () => $definitions);
 
         $this->columnDefinitions[$model::class] = $definitions;
 
@@ -184,7 +184,7 @@ final class SchemaIntrospector implements SchemaIntrospectionProvider
     #[\Override]
     public function isRelation(string $key, Model $model): bool
     {
-        return $this->metadataCacheWriter()->rememberMetadataForever(CacheKeys::MODEL_RELATIONS->resolveKey([
+        return $this->metadataCacheWriter->rememberMetadataForever(CacheKeys::MODEL_RELATIONS->resolveKey([
             $model::class,
             $key,
         ]), function () use ($key, $model): bool {
@@ -273,16 +273,6 @@ final class SchemaIntrospector implements SchemaIntrospectionProvider
         $this->columns           = [];
         $this->columnDefinitions = [];
         $this->searchable        = [];
-    }
-
-    /**
-     * Get the injected metadata cache writer.
-     *
-     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
-     */
-    private function metadataCacheWriter(): MetadataCacheWriter
-    {
-        return $this->metadataCacheWriter;
     }
 
     /**

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -14,6 +14,7 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
+use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\TestCase;
@@ -125,6 +126,28 @@ final class CacheManagerTest extends TestCase
 
         // Assert
         self::assertSame([], $this->getStaticProperty(EagerLoadPlanner::class, 'eagerLoadCache'));
+    }
+
+    /**
+     * Test that flush clears the FieldColumnMapper static cache.
+     *
+     * @return void
+     */
+    public function testFlushClearsFieldColumnMapperCache(): void
+    {
+        // Arrange
+        Event::fake();
+
+        $this->setStaticProperty(FieldColumnMapper::class, 'cache', ['FakeResource' => 'map']);
+
+        self::assertNotEmpty($this->getStaticProperty(FieldColumnMapper::class, 'cache'));
+
+        // Act
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        self::assertSame([], $this->getStaticProperty(FieldColumnMapper::class, 'cache'));
     }
 
     /**

--- a/tests/Unit/Listeners/QueueFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/QueueFlushSubscriberTest.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Cache\CacheManager;
 use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
@@ -162,5 +163,39 @@ final class QueueFlushSubscriberTest extends TestCase
 
         // Assert
         self::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Test that a CacheManager flush failure inside a queue worker is caught
+     * and logged with the full throwable rather than propagating and failing
+     * the job boundary.
+     *
+     * @return void
+     */
+    public function testHandleFlushSwallowsAndLogsCacheFlushFailure(): void
+    {
+        // Arrange
+        Config::set('queue.connections.database.driver', 'database');
+
+        Event::fake();
+
+        $this->mock(SchemaIntrospectionProvider::class)
+            ->shouldReceive('flush')
+            ->once()
+            ->andThrow(new \RuntimeException('flush boom'));
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Queue worker cache flush failed', \Mockery::on(
+                static fn (array $context): bool => $context['exception'] instanceof \RuntimeException
+                    && $context['exception']->getMessage() === 'flush boom',
+            ));
+
+        $cacheManager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $subscriber   = new QueueFlushSubscriber($cacheManager, new RuntimeContext);
+        $event        = new JobProcessed('database', self::createStub(Job::class));
+
+        // Act
+        $subscriber->handleFlush($event);
     }
 }

--- a/tests/Unit/Repositories/Concerns/CacheableTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheableTest.php
@@ -4,15 +4,21 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\Repositories\Concerns;
 
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use SineMacula\ApiToolkit\Repositories\ApiRepository;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
 use SineMacula\ApiToolkit\Repositories\Concerns\Cacheable;
 use SineMacula\ApiToolkit\Repositories\Concerns\CacheSizeGuard;
+use SineMacula\ApiToolkit\Repositories\Concerns\CacheStore;
 use SineMacula\ApiToolkit\Repositories\Concerns\CacheStoreOptions;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\Tag;
 use Tests\Fixtures\Repositories\CacheableTagRepository;
 use Tests\Fixtures\Repositories\CustomPrefixCacheableTagRepository;
@@ -32,6 +38,8 @@ use Tests\TestCase;
 #[CoversTrait(Cacheable::class)]
 final class CacheableTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /** @var \Tests\Fixtures\Repositories\CacheableTagRepository The repository under test. */
     private CacheableTagRepository $repository;
 
@@ -101,6 +109,42 @@ final class CacheableTest extends TestCase
         $this->repository->scopeById(1)->update(['name' => 'updated']); // @phpstan-ignore staticMethod.dynamicCall
 
         self::assertFalse($this->repository->getCacheStatus()->isPopulated());
+    }
+
+    /**
+     * Test that a cache-store failure during the post-write flush is swallowed
+     * and logged, and the already-committed write still returns its result
+     * rather than surfacing the flush error to the caller (who could retry and
+     * duplicate the record).
+     *
+     * @return void
+     */
+    public function testWriteSwallowsAndLogsAPostWriteFlushFailure(): void
+    {
+        // Arrange - a store whose flush write blows up (e.g. a Redis outage
+        // after the DB mutation has already committed).
+        $store = \Mockery::mock(Store::class)->shouldIgnoreMissing();
+        $store->shouldReceive('put')->andThrow(new \RuntimeException('redis down'));
+
+        Cache::extend('throwing', fn (): Repository => new Repository($store));
+        Config::set('cache.stores.throwing', ['driver' => 'throwing']);
+
+        $failing = new CacheStore('throwing', 'tags', new CacheStoreOptions(3600, new CacheSizeGuard(null, null), false, 0));
+        $this->setProperty($this->repository, 'cacheStore', $failing);
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Cache flush after write failed', \Mockery::on(
+                static fn (array $context): bool => $context['exception'] instanceof \RuntimeException
+                    && $context['exception']->getMessage() === 'redis down',
+            ));
+
+        // Act - the write commits; the flush throws but must not surface.
+        $created = $this->repository->create(['name' => 'vue']); // @phpstan-ignore staticMethod.dynamicCall
+
+        // Assert - the committed write returns its result despite the failure.
+        self::assertInstanceOf(Tag::class, $created);
+        self::assertSame('vue', $created->getAttribute('name'));
     }
 
     /**

--- a/tests/Unit/Repositories/Criteria/Operators/ContainsOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/ContainsOperatorTest.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Tests\Unit\Repositories\Criteria\Operators;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\ContainsOperator;
@@ -219,7 +221,38 @@ final class ContainsOperatorTest extends TestCase
 
         $this->operator->apply($query, 'tags', null, FilterContext::root());
 
-        self::assertIsArray($query->getQuery()->wheres);
+        $wheres = $query->getQuery()->wheres;
+
+        self::assertCount(1, $wheres);
+        self::assertSame(self::TYPE_JSON_CONTAINS, $wheres[0]['type']);
+    }
+
+    /**
+     * Test that a grammar rejection of the JSON-contains clause is logged
+     * with diagnostic context rather than dropped without a trace.
+     *
+     * @return void
+     */
+    public function testApplyLogsWhenTheGrammarRejectsTheJsonContainsConstraint(): void
+    {
+        $base = \Mockery::mock(QueryBuilder::class);
+        $base->shouldReceive('whereJsonContains')
+            ->once()
+            ->andThrow(new \RuntimeException('grammar rejects json-contains'));
+
+        $query = \Mockery::mock(Builder::class);
+        $query->shouldReceive('getQuery')->andReturn($base);
+        $query->shouldReceive('getModel')->andReturn(new User);
+
+        Log::shouldReceive('debug')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Dropped unsupported $contains filter constraint'
+                && $context['table']                                          === (new User)->getTable()
+                && $context['column']                                         === 'tags'
+                && $context['value_type']                                     === 'null'
+                && $context['reason']                                         === 'grammar rejects json-contains');
+
+        $this->operator->apply($query, 'tags', null, FilterContext::root());
     }
 
     /**


### PR DESCRIPTION
## Review 3 - small fixes

Addresses the low-severity, well-scoped findings from **Review 3 (2026-06-26)**. Each fix has a red-green regression test. `composer test` (1904 pass), `qlty check` (phpstan L8 + phpcs), and a scoped Infection run are clean - the changed lines add **no** escaped mutants.

### [BL-23] `fix(cache)` - flush `FieldColumnMapper`
`CacheManager::flush()` cleared three of the four `@managed-static` caches exposing `clearCache()` but skipped `FieldColumnMapper`, leaving stale column-narrowing maps after a schema/config change under Octane/queue. All four are now flushed, with a test asserting every `clearCache()` cache is reachable from `flush()`. (Audited `ApiResource::$default` as the finding asked - it is per-subclass static *config* with no runtime writer, so it correctly needs no flushing.)

### [BL-24] `fix(cache)` - best-effort cache flushes
`Cacheable::forwardAndFlush()` and `QueueFlushSubscriber::handleFlush()` ran the flush bare, so a cache-store outage surfaced as a write/job failure - a committed write could look failed and invite a duplicate retry. Both now wrap the flush in `try/catch (\Throwable)` + `Log::error` and continue, mirroring `OctaneFlushListener`; the committed write still returns its result.

### [BL-26] `fix(repositories)` - log dropped `$contains` constraints
`ContainsOperator::applyJsonContainsSafely()` silently dropped a JSON-contains clause the grammar rejected, widening the result set with no trace. It now logs table/column/value-type at debug; the swallow itself is kept (and the catch is now covered by a test).

### [BL-31] `chore` - minor cleanups
Inlined `SchemaIntrospector::metadataCacheWriter()` (a private getter over a readonly injected property), and pinned `illuminate/{database,http,notifications,routing,validation}` from `"*"` to `"^12.0"` for consistency with `illuminate/support` and to prevent an incoherent cross-major install.

### Deliberately out of scope
The remaining Review 3 items need a decision, are larger, or are deliberate trade-offs and are tracked separately: BL-25, BL-28, BL-29, BL-30, the BL-31 public-API removals (`PureEnumInterface`/`ServiceInterface`), BL-32 throttle keys, and BL-27 (performance - its own PR).
