### PR TITLE
perf: memoise the reference-cache snapshot and index by key (BL-27 P1)

### DIFF
--- a/src/Repositories/Concerns/ReferenceCache.php
+++ b/src/Repositories/Concerns/ReferenceCache.php
@@ -17,23 +17,31 @@ use SineMacula\ApiToolkit\Enums\CacheKeys;
  *
  * In reference mode the table is loaded once and served from memory: full
  * collection reads and single-record lookups by primary key resolve without
- * touching the database. This preserves the toolkit's historical whole-table
- * caching semantics, including cross-request persistence, as an explicit
- * opt-in.
+ * touching the database. The deserialized snapshot is memoised on the instance
+ * and indexed by key, so repeated reads within a request neither re-hydrate
+ * the cached payload nor scan it linearly. This preserves the toolkit's
+ * historical whole-table caching semantics, including cross-request
+ * persistence, as an explicit opt-in.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final readonly class ReferenceCache implements CacheInvalidator
+final class ReferenceCache implements CacheInvalidator
 {
     /** @var \Illuminate\Contracts\Cache\Repository The underlying cache store instance. */
-    private CacheContract $store;
+    private readonly CacheContract $store;
 
     /** @var string The resolved cache key for the whole-table snapshot. */
-    private string $cacheKey;
+    private readonly string $cacheKey;
 
     /** @var string The resolved cache key for the reference metadata. */
-    private string $metaKey;
+    private readonly string $metaKey;
+
+    /** @var \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>|null The request-local snapshot memo. */
+    private ?Collection $memo = null;
+
+    /** @var \Illuminate\Support\Collection<int|string, \Illuminate\Database\Eloquent\Model>|null The key-indexed snapshot for O(1) lookups. */
+    private ?Collection $index = null;
 
     /**
      * Create a new reference cache instance.
@@ -47,16 +55,16 @@ final readonly class ReferenceCache implements CacheInvalidator
     public function __construct(
 
         /** The name of the cache store to use. */
-        private string $cacheStore,
+        private readonly string $cacheStore,
 
         /** The database table the snapshot belongs to. */
-        private string $table,
+        private readonly string $table,
 
         /** The time-to-live, in seconds, for cached snapshots. */
-        private int $ttl,
+        private readonly int $ttl,
 
         /** The guard that limits the size of cached snapshots. */
-        private CacheSizeGuard $sizeGuard,
+        private readonly CacheSizeGuard $sizeGuard,
     ) {
         $this->store    = Cache::store($this->cacheStore);
         $this->cacheKey = CacheKeys::REPOSITORY_CACHE->resolveKey([$this->table]);
@@ -71,24 +79,15 @@ final readonly class ReferenceCache implements CacheInvalidator
      */
     public function all(Model $model): Collection
     {
+        if ($this->memo !== null) {
+            return $this->memo;
+        }
+
         $cached = $this->snapshot();
 
-        if ($cached !== null) {
-            return $cached;
-        }
-
-        /** @var \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model> $rows */
-        $rows = $model->newQuery()->get();
-
-        // Skip caching a table that exceeds the size guard, so reference
-        // mode on an unexpectedly large table falls back to querying rather
-        // than holding a huge serialized snapshot in the cache.
-        if ($this->sizeGuard->allows($rows, $rows->count())) {
-            $this->store->put($this->cacheKey, $rows, $this->ttl);
-            $this->store->put($this->metaKey, ['populated_at' => now()->timestamp], $this->ttl);
-        }
-
-        return $rows;
+        return $cached !== null
+            ? $this->remember($cached, $model)
+            : $this->load($model);
     }
 
     /**
@@ -100,7 +99,16 @@ final readonly class ReferenceCache implements CacheInvalidator
      */
     public function find(Model $model, int|string $id): ?Model
     {
-        return $this->all($model)->firstWhere($model->getKeyName(), $id);
+        $rows = $this->all($model);
+
+        // Over-large tables are not memoised, so there is no key index; fall
+        // back to scanning the freshly-queried collection.
+        if ($this->index === null) {
+            return $rows->firstWhere($model->getKeyName(), $id);
+        }
+
+        /** @var \Illuminate\Database\Eloquent\Model|null */
+        return $this->index->get($id);
     }
 
     /**
@@ -111,6 +119,10 @@ final readonly class ReferenceCache implements CacheInvalidator
     #[\Override]
     public function flushTable(): void
     {
+        // Clearing the memo is sufficient: the key index is derived from it and
+        // is rebuilt by the next load, so it is never read while stale.
+        $this->memo = null;
+
         $this->store->forget($this->cacheKey);
         $this->store->put($this->metaKey, ['invalidated_at' => now()->timestamp], $this->ttl);
     }
@@ -137,6 +149,47 @@ final readonly class ReferenceCache implements CacheInvalidator
     public function getStore(): CacheContract
     {
         return $this->store;
+    }
+
+    /**
+     * Load the whole-table snapshot from the database, caching and memoising
+     * it unless it exceeds the size guard.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    private function load(Model $model): Collection
+    {
+        /** @var \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model> $rows */
+        $rows = $model->newQuery()->get();
+
+        // Skip caching a table over the size guard: reference mode on an
+        // unexpectedly large table falls back to querying each read rather
+        // than holding (or memoising) a huge serialized snapshot.
+        if (!$this->sizeGuard->allows($rows, $rows->count())) {
+            return $rows;
+        }
+
+        $this->store->put($this->cacheKey, $rows, $this->ttl);
+        $this->store->put($this->metaKey, ['populated_at' => now()->timestamp], $this->ttl);
+
+        return $this->remember($rows, $model);
+    }
+
+    /**
+     * Memoise the snapshot on the instance and index it by key for O(1)
+     * lookups, returning the snapshot to the caller.
+     *
+     * @param  \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>  $rows
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    private function remember(Collection $rows, Model $model): Collection
+    {
+        $this->memo  = $rows;
+        $this->index = $rows->keyBy($model->getKeyName());
+
+        return $rows;
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/ReferenceCacheTest.php
+++ b/tests/Unit/Repositories/Concerns/ReferenceCacheTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Repositories\Concerns\CacheSizeGuard;
 use SineMacula\ApiToolkit\Repositories\Concerns\ReferenceCache;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\Tag;
 use Tests\TestCase;
 
@@ -24,6 +25,8 @@ use Tests\TestCase;
 #[CoversClass(ReferenceCache::class)]
 final class ReferenceCacheTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /** @var \SineMacula\ApiToolkit\Repositories\Concerns\ReferenceCache The reference cache under test. */
     private ReferenceCache $referenceCache;
 
@@ -88,6 +91,66 @@ final class ReferenceCacheTest extends TestCase
 
         self::assertInstanceOf(Collection::class, $result);
         self::assertCount(2, $result);
+    }
+
+    /**
+     * Test that repeated reads are served from the instance memo even after
+     * the backing store is evicted, proving the snapshot is deserialized once.
+     *
+     * @return void
+     */
+    public function testReusesInstanceMemoAfterBackingStoreEviction(): void
+    {
+        $first = $this->referenceCache->all(new Tag);
+
+        // Evict the backing store directly, bypassing flushTable (which would
+        // also clear the instance memo), so only the memo can serve the read.
+        $this->referenceCache->getStore()->forget('api-toolkit:repository-cache:tags');
+
+        DB::enableQueryLog();
+
+        $second = $this->referenceCache->all(new Tag);
+
+        self::assertSame($first, $second);
+        self::assertCount(0, DB::getQueryLog());
+
+        DB::disableQueryLog();
+    }
+
+    /**
+     * Test that loading the snapshot builds a key index for O(1) lookups,
+     * keyed by the model's primary key rather than collection position.
+     *
+     * @return void
+     */
+    public function testBuildsAKeyIndexForTheMemoisedSnapshot(): void
+    {
+        $this->referenceCache->all(new Tag);
+
+        $index = $this->getProperty($this->referenceCache, 'index');
+
+        self::assertInstanceOf(Collection::class, $index);
+
+        $tag = $index->get(1);
+
+        self::assertInstanceOf(Tag::class, $tag);
+        self::assertSame('php', $tag->getAttribute('name'));
+    }
+
+    /**
+     * Test that find resolves a record from an over-large (un-memoised) table
+     * by scanning the freshly-queried collection rather than a key index.
+     *
+     * @return void
+     */
+    public function testFindResolvesFromAnOverLargeTableWithoutAKeyIndex(): void
+    {
+        $reference = new ReferenceCache('array', 'tags', 3600, new CacheSizeGuard(1, null));
+
+        $tag = $reference->find(new Tag, 1);
+
+        self::assertInstanceOf(Tag::class, $tag);
+        self::assertSame('php', $tag->getAttribute('name'));
     }
 
     /**


### PR DESCRIPTION
## [BL-27 P1] Performance - memoise the reference-cache snapshot

`ReferenceCache` (whole-table reference mode) deserialized the entire snapshot from the backing store on **every** `all()`/`find()`, and `find()` was `all()->firstWhere()` - an O(R) scan. So M parent rows each resolving a reference relation cost **M store round-trips + M full hydrations + M*R scans**, despite the docblock advertising in-memory by-key lookups.

### Change
- Memoise the deserialized snapshot on the instance (`$memo`) so it hydrates **once** per request.
- Build a `keyName => model` index (`$index`) so `find()` is **O(1)**.
- `flushTable()` clears the memo (the index is derived and rebuilt on the next load, so it is never read while stale).

The class is no longer `readonly` (it now carries the lazy memo); the existing constructor-injected fields are individually `readonly`.

### Preserved semantics
- **Size-guard fallback**: an over-large table is still queried each read (not cached or memoised), and `find()` falls back to a fresh scan - so a runaway table never holds a huge snapshot.
- **Cross-request persistence** via the backing store is unchanged.

### Verification
- `composer test` 1903 pass (+3 new tests: memo reuse after a backing-store eviction, key index built, over-large `find` fallback).
- `qlty check` clean; scoped Infection on `ReferenceCache.php` = **100% MSI**.

This is the **P1** item from BL-27. P3 (per-item field/order recompute) and P4 (`EagerLoadPlanner` memo bound) are lower value and remain in the backlog.
