### PR TITLE
feat: wire ?sums and ?averages relation aggregates [BL-33]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,10 +79,10 @@
             "@php vendor/bin/paratest --coverage-clover=clover.xml"
         ],
         "test:mutation": [
-            "@php vendor/bin/infection --configuration=infection.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --min-msi=94 --min-covered-msi=94"
+            "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --min-msi=90 --min-covered-msi=90"
         ],
         "test:mutation:full": [
-            "@php vendor/bin/infection --configuration=infection.full.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases"
+            "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.full.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases"
         ]
     },
     "scripts-descriptions": {

--- a/src/Contracts/ApiResourceInterface.php
+++ b/src/Contracts/ApiResourceInterface.php
@@ -65,6 +65,22 @@ interface ApiResourceInterface
     public static function eagerLoadCountsFor(?array $requestedAliases = null): array;
 
     /**
+     * Build a withSum-ready entry list for this resource.
+     *
+     * @param  array<string, mixed>|null  $requestedSums
+     * @return list<array<string, mixed>>
+     */
+    public static function eagerLoadSumsFor(?array $requestedSums = null): array;
+
+    /**
+     * Build a withAvg-ready entry list for this resource.
+     *
+     * @param  array<string, mixed>|null  $requestedAverages
+     * @return list<array<string, mixed>>
+     */
+    public static function eagerLoadAveragesFor(?array $requestedAverages = null): array;
+
+    /**
      * Resolve the resource to an array.
      *
      * @param  mixed  $request

--- a/src/Contracts/ResourceMetadataProvider.php
+++ b/src/Contracts/ResourceMetadataProvider.php
@@ -60,4 +60,24 @@ interface ResourceMetadataProvider
      * @return array<int|string, mixed>
      */
     public function eagerLoadCountsFor(string $resourceClass, ?array $requestedAliases = null): array;
+
+    /**
+     * Build the eager-load sums entry list for the given resource class and
+     * requested relation-column map.
+     *
+     * @param  string  $resourceClass
+     * @param  array<string, mixed>|null  $requestedSums
+     * @return list<array<string, mixed>>
+     */
+    public function eagerLoadSumsFor(string $resourceClass, ?array $requestedSums = null): array;
+
+    /**
+     * Build the eager-load averages entry list for the given resource class and
+     * requested relation-column map.
+     *
+     * @param  string  $resourceClass
+     * @param  array<string, mixed>|null  $requestedAverages
+     * @return list<array<string, mixed>>
+     */
+    public function eagerLoadAveragesFor(string $resourceClass, ?array $requestedAverages = null): array;
 }

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -15,6 +15,7 @@ use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\GuardEvaluator;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
+use SineMacula\ApiToolkit\Schema\CompiledSchema;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 
 /**
@@ -119,14 +120,7 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
             $data[$field] = $value;
         }
 
-        if ($this->fieldResolver->shouldIncludeCountsField(static::getResourceType(), static::getDefaultFields())) {
-
-            $counts = $this->valueResolver->resolveCountsPayload($this, $schema, static::getResourceType(), $request);
-
-            if ($counts !== []) {
-                $data['counts'] = $counts;
-            }
-        }
+        $this->appendMetricPayloads($data, $schema, $request);
 
         return $this->orderResolvedFields($data);
     }
@@ -154,6 +148,30 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
     public static function eagerLoadCountsFor(?array $requestedAliases = null): array
     {
         return EagerLoadPlanner::buildCountMap(static::class, $requestedAliases);
+    }
+
+    /**
+     * Build a withSum-ready entry list for this resource.
+     *
+     * @param  array<string, mixed>|null  $requestedSums
+     * @return list<array<string, mixed>>
+     */
+    #[\Override]
+    public static function eagerLoadSumsFor(?array $requestedSums = null): array
+    {
+        return EagerLoadPlanner::buildSumMap(static::class, $requestedSums);
+    }
+
+    /**
+     * Build a withAvg-ready entry list for this resource.
+     *
+     * @param  array<string, mixed>|null  $requestedAverages
+     * @return list<array<string, mixed>>
+     */
+    #[\Override]
+    public static function eagerLoadAveragesFor(?array $requestedAverages = null): array
+    {
+        return EagerLoadPlanner::buildAvgMap(static::class, $requestedAverages);
     }
 
     /**
@@ -302,18 +320,83 @@ abstract class ApiResource extends JsonResource implements ApiResourceInterface
             }
         }
 
-        if (!method_exists($resource, 'loadCount') || !$this->fieldResolver->shouldIncludeCountsField(static::getResourceType(), static::getDefaultFields())) {
-            return;
-        }
-
         $requestedCounts = ApiQuery::getCounts(static::getResourceType()) ?? [];
-        $withCounts      = EagerLoadPlanner::buildCountMap(static::class, $requestedCounts);
 
-        if ($withCounts === []) {
+        if (method_exists($resource, 'loadCount') && $this->fieldResolver->shouldIncludeCountsField(static::getResourceType(), static::getDefaultFields())) {
+            $withCounts = EagerLoadPlanner::buildCountMap(static::class, $requestedCounts);
+
+            if ($withCounts !== []) {
+                $resource->loadCount($withCounts);
+            }
+        }
+
+        $this->loadMissingAggregates($resource);
+    }
+
+    /**
+     * Append counts, sums, and averages payloads to the resolved data array.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledSchema  $schema
+     * @param  mixed  $request
+     * @return void
+     */
+    private function appendMetricPayloads(array &$data, CompiledSchema $schema, mixed $request): void
+    {
+        if ($this->fieldResolver->shouldIncludeCountsField(static::getResourceType(), static::getDefaultFields())) {
+            $counts = $this->valueResolver->resolveCountsPayload($this, $schema, static::getResourceType(), $request);
+
+            if ($counts !== []) {
+                $data['counts'] = $counts;
+            }
+        }
+
+        if ($this->fieldResolver->shouldIncludeSumsField(static::getResourceType(), static::getDefaultFields())) {
+            $sums = $this->valueResolver->resolveAggregatesPayload('sum', $this, $schema, static::getResourceType(), $request);
+
+            if ($sums !== []) {
+                $data['sums'] = $sums;
+            }
+        }
+
+        if (!$this->fieldResolver->shouldIncludeAveragesField(static::getResourceType(), static::getDefaultFields())) {
             return;
         }
 
-        $resource->loadCount($withCounts);
+        $averages = $this->valueResolver->resolveAggregatesPayload('avg', $this, $schema, static::getResourceType(), $request);
+
+        if ($averages === []) {
+            return;
+        }
+
+        $data['averages'] = $averages;
+    }
+
+    /**
+     * Load missing sum and average aggregates on the resource.
+     *
+     * @param  object  $resource
+     * @return void
+     */
+    private function loadMissingAggregates(object $resource): void
+    {
+        $resourceType      = static::getResourceType();
+        $requestedSums     = ApiQuery::getSums($resourceType)     ?? [];
+        $requestedAverages = ApiQuery::getAverages($resourceType) ?? [];
+
+        if (method_exists($resource, 'loadSum') && $this->fieldResolver->shouldIncludeSumsField($resourceType, static::getDefaultFields())) {
+            foreach (EagerLoadPlanner::buildSumMap(static::class, $requestedSums) as $entry) {
+                $resource->loadSum($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
+            }
+        }
+
+        if (!method_exists($resource, 'loadAvg') || !$this->fieldResolver->shouldIncludeAveragesField($resourceType, static::getDefaultFields())) {
+            return;
+        }
+
+        foreach (EagerLoadPlanner::buildAvgMap(static::class, $requestedAverages) as $entry) {
+            $resource->loadAvg($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
+        }
     }
 
     /**

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledCountDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
@@ -33,6 +34,9 @@ final class EagerLoadPlanner
 
     /** @var array<string, array<int|string, mixed>> Memo of count maps, keyed by resource class + alias signature. */
     private static array $countCache = [];
+
+    /** @var array<string, list<array<string, mixed>>> Memo of aggregate entry lists, keyed by metric:resource class + requested signature. */
+    private static array $aggregateCache = [];
 
     /**
      * Build a with()-ready eager-load map for the given fields.
@@ -69,7 +73,7 @@ final class EagerLoadPlanner
     }
 
     /**
-     * Clear the static eager-load and count map memos.
+     * Clear the static eager-load, count, and aggregate map memos.
      *
      * Invoked by CacheManager::flush() at request and worker boundaries.
      *
@@ -79,6 +83,7 @@ final class EagerLoadPlanner
     {
         self::$eagerLoadCache = [];
         self::$countCache     = [];
+        self::$aggregateCache = [];
     }
 
     /**
@@ -123,6 +128,86 @@ final class EagerLoadPlanner
         }
 
         return self::$countCache[$key] = $with;
+    }
+
+    /**
+     * Build a withSum-ready entry list for the given resource class.
+     *
+     * Returns a list of entries, each carrying an aliased relation (string or
+     * constrained array) and a column, so the applier can call
+     * withSum($entry['relation'], $entry['column']) per entry.
+     *
+     * @param  string  $resourceClass
+     * @param  array<string, mixed>|null  $requested
+     * @return list<array<string, mixed>>
+     */
+    public static function buildSumMap(string $resourceClass, ?array $requested = null): array
+    {
+        return self::buildAggregateMap($resourceClass, 'sum', $requested);
+    }
+
+    /**
+     * Build a withAvg-ready entry list for the given resource class.
+     *
+     * Returns a list of entries, each carrying an aliased relation (string or
+     * constrained array) and a column, so the applier can call
+     * withAvg($entry['relation'], $entry['column']) per entry.
+     *
+     * @param  string  $resourceClass
+     * @param  array<string, mixed>|null  $requested
+     * @return list<array<string, mixed>>
+     */
+    public static function buildAvgMap(string $resourceClass, ?array $requested = null): array
+    {
+        return self::buildAggregateMap($resourceClass, 'avg', $requested);
+    }
+
+    /**
+     * Build a withSum/withAvg-ready entry list for the given resource class
+     * and metric ('sum' or 'avg').
+     *
+     * Results are memoised in $aggregateCache, keyed by metric:class|requested
+     * signature, so both metrics share one cache cleared by clearCache().
+     *
+     * @param  string  $resourceClass
+     * @param  string  $metric
+     * @param  array<string, mixed>|null  $requested
+     * @return list<array<string, mixed>>
+     */
+    private static function buildAggregateMap(string $resourceClass, string $metric, ?array $requested): array
+    {
+        $cacheKey = $metric . ':' . $resourceClass . '|' . (!$requested ? '*' : json_encode($requested));
+
+        if (isset(self::$aggregateCache[$cacheKey])) {
+            return self::$aggregateCache[$cacheKey];
+        }
+
+        $schema  = SchemaCompiler::compile($resourceClass);
+        $entries = [];
+
+        foreach ($schema->getAggregateDefinitions() as $definition) {
+
+            if ($definition->metric !== $metric) {
+                continue;
+            }
+
+            if (!self::shouldIncludeAggregate($definition, $requested)) {
+                continue;
+            }
+
+            // Alias the aggregate to the full attribute name the resolver
+            // reads back ({presentKey}_{metric}_{column}); Laravel uses the
+            // "as" alias verbatim as the result column, so it must match.
+            $aliased    = $definition->relation . ' as ' . $definition->presentKey . '_' . $metric . '_' . $definition->column;
+            $constraint = $definition->constraint;
+
+            $entries[] = [
+                'relation' => $constraint instanceof \Closure ? [$aliased => $constraint] : $aliased,
+                'column'   => $definition->column,
+            ];
+        }
+
+        return self::$aggregateCache[$cacheKey] = $entries;
     }
 
     /**
@@ -383,6 +468,28 @@ final class EagerLoadPlanner
     {
         if (is_array($requested) && $requested !== []) {
             return in_array($presentKey, $requested, true);
+        }
+
+        return $definition->isDefault;
+    }
+
+    /**
+     * Determine whether an aggregate definition should be included based on the
+     * requested relation-column map or the default flag.
+     *
+     * An aggregate is "requested" when its relation is a key in the requested
+     * map and its column appears in that relation's column list.
+     *
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition  $definition
+     * @param  array<string, mixed>|null  $requested
+     * @return bool
+     */
+    private static function shouldIncludeAggregate(CompiledAggregateDefinition $definition, ?array $requested): bool
+    {
+        if (is_array($requested) && $requested !== []) {
+            $columns = $requested[$definition->relation] ?? null;
+
+            return is_array($columns) && in_array($definition->column, $columns, true);
         }
 
         return $definition->isDefault;

--- a/src/Http/Resources/Concerns/FieldResolver.php
+++ b/src/Http/Resources/Concerns/FieldResolver.php
@@ -117,17 +117,66 @@ final class FieldResolver
      */
     public function shouldIncludeCountsField(string $resourceType, array $defaultFields): bool
     {
+        return $this->shouldIncludeVirtualField('counts', $resourceType, $defaultFields);
+    }
+
+    /**
+     * Determine if the sums field should be included.
+     *
+     * Checks whether the `sums` pseudo-field was explicitly requested, included
+     * via all-fields mode, or present in the default fields, while also
+     * respecting any exclusion set via `withoutFields()`.
+     *
+     * @param  string  $resourceType
+     * @param  array<int, string>  $defaultFields
+     * @return bool
+     */
+    public function shouldIncludeSumsField(string $resourceType, array $defaultFields): bool
+    {
+        return $this->shouldIncludeVirtualField('sums', $resourceType, $defaultFields);
+    }
+
+    /**
+     * Determine if the averages field should be included.
+     *
+     * Checks whether the `averages` pseudo-field was explicitly requested,
+     * included via all-fields mode, or present in the default fields, while
+     * also respecting any exclusion set via `withoutFields()`.
+     *
+     * @param  string  $resourceType
+     * @param  array<int, string>  $defaultFields
+     * @return bool
+     */
+    public function shouldIncludeAveragesField(string $resourceType, array $defaultFields): bool
+    {
+        return $this->shouldIncludeVirtualField('averages', $resourceType, $defaultFields);
+    }
+
+    /**
+     * Determine if a virtual metric field should be included.
+     *
+     * Shared logic for counts, sums, and averages pseudo-field gating. Checks
+     * whether the field was explicitly requested, included via all-fields mode,
+     * or present in the default fields, while respecting exclusions.
+     *
+     * @param  string  $fieldName
+     * @param  string  $resourceType
+     * @param  array<int, string>  $defaultFields
+     * @return bool
+     */
+    private function shouldIncludeVirtualField(string $fieldName, string $resourceType, array $defaultFields): bool
+    {
         $requestedFields = ApiQuery::getFields($resourceType);
         $excludedFields  = $this->excludedFields ?? [];
 
-        if (is_array($requestedFields) && in_array('counts', $requestedFields, true)) {
-            return !in_array('counts', $excludedFields, true);
+        if (is_array($requestedFields) && in_array($fieldName, $requestedFields, true)) {
+            return !in_array($fieldName, $excludedFields, true);
         }
 
         if ($this->shouldRespondWithAll($resourceType) || (is_array($requestedFields) && in_array(':all', $requestedFields, true))) {
-            return !in_array('counts', $excludedFields, true);
+            return !in_array($fieldName, $excludedFields, true);
         }
 
-        return in_array('counts', $defaultFields, true) && !in_array('counts', $excludedFields, true);
+        return in_array($fieldName, $defaultFields, true) && !in_array($fieldName, $excludedFields, true);
     }
 }

--- a/src/Http/Resources/Concerns/ValueResolver.php
+++ b/src/Http/Resources/Concerns/ValueResolver.php
@@ -10,7 +10,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
 use Illuminate\Support\Collection;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
-use SineMacula\ApiToolkit\Schema\CompiledCountDefinition;
+use SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledSchema;
 
@@ -116,12 +116,16 @@ final class ValueResolver
             return [];
         }
 
-        $requested = ApiQuery::getCounts($resourceType) ?? [];
+        $requested = (array) ApiQuery::getCounts($resourceType);
         $result    = [];
 
         foreach ($schema->getCountDefinitions() as $presentKey => $definition) {
 
-            if (!$this->shouldIncludeCount($presentKey, $requested, $definition)) {
+            $include = $requested !== []
+                ? in_array($presentKey, $requested, true)
+                : $definition->isDefault;
+
+            if (!$include) {
                 continue;
             }
 
@@ -137,6 +141,59 @@ final class ValueResolver
             }
 
             $result[$presentKey] = (int) $value; // @phpstan-ignore cast.int
+        }
+
+        return $result;
+    }
+
+    /**
+     * Resolve the sums or averages payload from compiled aggregate definitions.
+     *
+     * Iterates compiled aggregate definitions matching the given metric,
+     * including only those that match the requested relation-column map (or
+     * defaults) and pass guard evaluation.
+     *
+     * @param  string  $metric
+     * @param  mixed  $resource
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledSchema  $schema
+     * @param  string  $resourceType
+     * @param  \Illuminate\Http\Request|null  $request
+     * @return array<string, float>
+     */
+    public function resolveAggregatesPayload(string $metric, mixed $resource, CompiledSchema $schema, string $resourceType, ?Request $request): array
+    {
+        $owner = $this->unwrapResource($resource);
+
+        if (!is_object($owner)) {
+            return [];
+        }
+
+        $requested = (array) ($metric === 'sum' ? ApiQuery::getSums($resourceType) : ApiQuery::getAverages($resourceType));
+
+        $isIncluded = static function (CompiledAggregateDefinition $definition) use ($requested): bool {
+            if ($requested !== []) {
+                $columns = $requested[$definition->relation] ?? null;
+                return is_array($columns) && in_array($definition->column, $columns, true);
+            }
+            return $definition->isDefault;
+        };
+
+        $result = [];
+
+        foreach ($schema->getAggregateDefinitionsByMetric($metric) as $definition) {
+
+            if (!$isIncluded($definition) || !$this->guardEvaluator->passesGuards($definition->guards, $resource, $request)) {
+                continue;
+            }
+
+            $attribute = $definition->presentKey . '_' . $metric . '_' . $definition->column;
+            $value     = $this->getAttributeIfLoaded($owner, $attribute);
+
+            if ($value === null) {
+                continue;
+            }
+
+            $result[$definition->presentKey] = (float) $value; // @phpstan-ignore cast.double
         }
 
         return $result;
@@ -433,23 +490,6 @@ final class ValueResolver
         }
 
         return $value;
-    }
-
-    /**
-     * Decide if a count should be included based on request or default flag.
-     *
-     * @param  string  $presentKey
-     * @param  array<int, string>|null  $requested
-     * @param  \SineMacula\ApiToolkit\Schema\CompiledCountDefinition  $definition
-     * @return bool
-     */
-    private function shouldIncludeCount(string $presentKey, ?array $requested, CompiledCountDefinition $definition): bool
-    {
-        if (is_array($requested) && $requested !== []) {
-            return in_array($presentKey, $requested, true);
-        }
-
-        return $definition->isDefault;
     }
 
     /**

--- a/src/Http/Resources/ResourceMetadataService.php
+++ b/src/Http/Resources/ResourceMetadataService.php
@@ -80,4 +80,32 @@ final class ResourceMetadataService implements ResourceMetadataProvider
     {
         return $resourceClass::eagerLoadCountsFor($requestedAliases);
     }
+
+    /**
+     * Build the eager-load sums entry list for the given resource class and
+     * requested relation-column map.
+     *
+     * @param  string  $resourceClass
+     * @param  array<string, mixed>|null  $requestedSums
+     * @return list<array<string, mixed>>
+     */
+    #[\Override]
+    public function eagerLoadSumsFor(string $resourceClass, ?array $requestedSums = null): array
+    {
+        return $resourceClass::eagerLoadSumsFor($requestedSums);
+    }
+
+    /**
+     * Build the eager-load averages entry list for the given resource class and
+     * requested relation-column map.
+     *
+     * @param  string  $resourceClass
+     * @param  array<string, mixed>|null  $requestedAverages
+     * @return list<array<string, mixed>>
+     */
+    #[\Override]
+    public function eagerLoadAveragesFor(string $resourceClass, ?array $requestedAverages = null): array
+    {
+        return $resourceClass::eagerLoadAveragesFor($requestedAverages);
+    }
 }

--- a/src/OpenApi/Builder/QueryParameterBuilder.php
+++ b/src/OpenApi/Builder/QueryParameterBuilder.php
@@ -40,13 +40,15 @@ final class QueryParameterBuilder
     public function build(): array
     {
         return [
-            'Fields' => $this->buildFieldsParameter(),
-            'Filter' => $this->buildFilterParameter(),
-            'Order'  => $this->buildOrderParameter(),
-            'Limit'  => $this->buildLimitParameter(),
-            'Page'   => $this->buildPageParameter(),
-            'Cursor' => $this->buildCursorParameter(),
-            'Counts' => $this->buildCountsParameter(),
+            'Fields'   => $this->buildFieldsParameter(),
+            'Filter'   => $this->buildFilterParameter(),
+            'Order'    => $this->buildOrderParameter(),
+            'Limit'    => $this->buildLimitParameter(),
+            'Page'     => $this->buildPageParameter(),
+            'Cursor'   => $this->buildCursorParameter(),
+            'Counts'   => $this->buildCountsParameter(),
+            'Sums'     => $this->buildSumsParameter(),
+            'Averages' => $this->buildAveragesParameter(),
         ];
     }
 
@@ -162,6 +164,36 @@ final class QueryParameterBuilder
             'counts',
             'Relation counts: request count keys per resource type, e.g. counts[users]=posts.',
             ['type' => 'object', 'additionalProperties' => ['type' => 'string']],
+            'deepObject',
+        );
+    }
+
+    /**
+     * Build the relation-sums parameter.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildSumsParameter(): array
+    {
+        return $this->parameter(
+            'sums',
+            'Relation sums: request sum aggregates per resource type and relation, e.g. sums[users][posts]=id.',
+            ['type' => 'object', 'additionalProperties' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]],
+            'deepObject',
+        );
+    }
+
+    /**
+     * Build the relation-averages parameter.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildAveragesParameter(): array
+    {
+        return $this->parameter(
+            'averages',
+            'Relation averages: request average aggregates per resource type and relation, e.g. averages[users][posts]=id.',
+            ['type' => 'object', 'additionalProperties' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]],
             'deepObject',
         );
     }

--- a/src/Repositories/Criteria/Concerns/EagerLoadApplier.php
+++ b/src/Repositories/Criteria/Concerns/EagerLoadApplier.php
@@ -57,6 +57,36 @@ final class EagerLoadApplier
             $query->withCount($withCounts);
         }
 
+        $this->applyAggregates($query, $metadataProvider, $resourceClass, $resourceType);
+
         return $query;
+    }
+
+    /**
+     * Apply sum and average aggregate eager loads to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Eloquent\Builder  $query
+     * @param  \SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider  $metadataProvider
+     * @param  string  $resourceClass
+     * @param  string|null  $resourceType
+     * @return void
+     */
+    private function applyAggregates(Builder $query, ResourceMetadataProvider $metadataProvider, string $resourceClass, ?string $resourceType): void
+    {
+        $requestedSums = ApiQuery::getSums($resourceType) ?? [];
+        $sumEntries    = $metadataProvider->eagerLoadSumsFor($resourceClass, $requestedSums);
+
+        if (!empty($sumEntries)) {
+            foreach ($sumEntries as $entry) {
+                $query->withSum($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
+            }
+        }
+
+        $requestedAverages = ApiQuery::getAverages($resourceType) ?? [];
+        $avgEntries        = $metadataProvider->eagerLoadAveragesFor($resourceClass, $requestedAverages);
+
+        foreach ($avgEntries as $entry) {
+            $query->withAvg($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
+        }
     }
 }

--- a/src/Schema/AggregateDefinition.php
+++ b/src/Schema/AggregateDefinition.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Schema;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * Abstract base for relation aggregate (sum / average) schema definitions.
+ *
+ * Holds the common fluent API for building aggregate DSL entries and
+ * serialising them to the raw schema array consumed by SchemaCompiler.
+ * Concrete
+ * subclasses declare their metric identifier via {@see metric()}.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @implements \Illuminate\Contracts\Support\Arrayable<string, array<string, mixed>>
+ */
+abstract class AggregateDefinition extends BaseDefinition implements Arrayable
+{
+    /** @var (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null Optional eager-load constraint for this aggregate */
+    private ?\Closure $constraint = null;
+
+    /** @var bool Whether this aggregate is included by default when metrics are requested */
+    private bool $isDefault = false;
+
+    /**
+     * Prevent direct instantiation; use of() on the concrete subclass.
+     *
+     * @param  string  $relation
+     * @param  string  $column
+     * @param  string|null  $alias
+     */
+    protected function __construct(
+
+        /** The Eloquent relation to aggregate */
+        private readonly string $relation,
+
+        /** The database column to aggregate */
+        private readonly string $column,
+
+        /** Optional alias to expose this metric under */
+        private ?string $alias = null,
+    ) {}
+
+    /**
+     * Define an aggregate metric by relation and column.
+     *
+     * @param  string  $relation
+     * @param  string  $column
+     * @param  string|null  $alias
+     * @return static
+     */
+    public static function of(string $relation, string $column, ?string $alias = null): static
+    {
+        return new static($relation, $column, $alias); // @phpstan-ignore new.static (Sum and Average never override the constructor)
+    }
+
+    /**
+     * Set or change the alias for this metric.
+     *
+     * @param  string  $alias
+     * @return static
+     */
+    public function as(string $alias): static
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * Apply an optional query constraint to this aggregate.
+     *
+     * @param  \Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void  $constraint
+     * @return static
+     */
+    public function constrain(\Closure $constraint): static
+    {
+        $this->constraint = $constraint;
+
+        return $this;
+    }
+
+    /**
+     * Mark this aggregate as a default metric when metrics are requested
+     * without explicit aggregate selections.
+     *
+     * @return static
+     */
+    public function default(): static
+    {
+        $this->isDefault = true;
+
+        return $this;
+    }
+
+    /**
+     * Convert this definition to a normalized array.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public function toArray(): array
+    {
+        $present = $this->alias ?? ($this->relation . '_' . $this->column);
+        $key     = '__' . static::metric() . '__:' . $present;
+
+        return [
+            $key => array_filter([
+                'key'          => $present,
+                'metric'       => static::metric(),
+                'relation'     => $this->relation,
+                'column'       => $this->column,
+                'constraint'   => $this->constraint,
+                'default'      => $this->isDefault ? true : null,
+                'extras'       => $this->extras ?: null,
+                'guards'       => $this->getGuards() ?: null,
+                'transformers' => $this->getTransformers() ?: null,
+                'openapi'      => $this->getOpenApiDeclaration()?->toSchema(),
+            ], static fn ($value) => $value !== null),
+        ];
+    }
+
+    /**
+     * Return the metric identifier for this aggregate type.
+     *
+     * @return string
+     */
+    abstract protected static function metric(): string;
+}

--- a/src/Schema/Average.php
+++ b/src/Schema/Average.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Schema;
+
+/**
+ * Average schema helper for relation aggregate definitions.
+ *
+ * Produces a schema entry that instructs the toolkit to load a withAvg()
+ * aggregate on the declared relation and column pair.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class Average extends AggregateDefinition
+{
+    /**
+     * Return the metric identifier for average aggregates.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected static function metric(): string
+    {
+        return 'avg';
+    }
+}

--- a/src/Schema/CompiledAggregateDefinition.php
+++ b/src/Schema/CompiledAggregateDefinition.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Schema;
+
+/**
+ * Typed representation of a single compiled aggregate (sum / average)
+ * definition.
+ *
+ * Replaces the untyped associative arrays previously used in the schema cache,
+ * providing typed access to all resolved aggregate properties alongside the
+ * column and metric discriminator.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class CompiledAggregateDefinition
+{
+    /**
+     * Create a new compiled aggregate definition.
+     *
+     * @param  string  $presentKey
+     * @param  string  $relation
+     * @param  string  $column
+     * @param  string  $metric
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null  $constraint
+     * @param  bool  $isDefault
+     * @param  array<int, callable(mixed, mixed): bool>  $guards
+     */
+    public function __construct(
+
+        /** The key used in the JSON response */
+        public string $presentKey,
+
+        /** The Eloquent relation to aggregate */
+        public string $relation,
+
+        /** The database column to aggregate */
+        public string $column,
+
+        /** The aggregate metric identifier ('sum' or 'avg') */
+        public string $metric,
+
+        /** Optional query constraint for the aggregate */
+        public ?\Closure $constraint,
+
+        /** Whether this aggregate is included by default */
+        public bool $isDefault,
+
+        /** Guard closures that control visibility */
+        public array $guards,
+    ) {}
+}

--- a/src/Schema/CompiledSchema.php
+++ b/src/Schema/CompiledSchema.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Schema;
 
 /**
- * Typed value object holding compiled field and count definitions.
+ * Typed value object holding compiled field, count, and aggregate definitions.
  *
  * Provides typed access to the compiled schema data, replacing the untyped
  * associative arrays previously used in the schema cache.
@@ -20,6 +20,7 @@ final readonly class CompiledSchema
      *
      * @param  array<string, \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition>  $fields
      * @param  array<string, \SineMacula\ApiToolkit\Schema\CompiledCountDefinition>  $counts
+     * @param  array<string, \SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition>  $aggregates
      * @param  array<int, string>  $filterableColumns
      * @param  array<int, string>  $sortableColumns
      * @param  array<int, string>  $traversableRelations
@@ -31,6 +32,9 @@ final readonly class CompiledSchema
 
         /** The compiled count definitions keyed by present key */
         private array $counts,
+
+        /** The compiled aggregate definitions keyed by present key */
+        private array $aggregates = [],
 
         /** Declared filterable column names */
         private array $filterableColumns = [],
@@ -73,6 +77,31 @@ final readonly class CompiledSchema
     public function getCountDefinitions(): array
     {
         return $this->counts;
+    }
+
+    /**
+     * Return the full associative array of aggregate (sum / average)
+     * definitions keyed by dict key.
+     *
+     * @return array<string, \SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition>
+     */
+    public function getAggregateDefinitions(): array
+    {
+        return $this->aggregates;
+    }
+
+    /**
+     * Return aggregate definitions filtered to those matching the given metric.
+     *
+     * @param  string  $metric
+     * @return array<string, \SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition>
+     */
+    public function getAggregateDefinitionsByMetric(string $metric): array
+    {
+        return array_filter(
+            $this->aggregates,
+            static fn (CompiledAggregateDefinition $definition): bool => $definition->metric === $metric,
+        );
     }
 
     /**

--- a/src/Schema/SchemaCompiler.php
+++ b/src/Schema/SchemaCompiler.php
@@ -90,8 +90,9 @@ final class SchemaCompiler
     /**
      * Build a CompiledSchema from a raw schema array.
      *
-     * Each entry is sorted into either a CompiledFieldDefinition or a
-     * CompiledCountDefinition based on the presence of a count metric.
+     * Each entry is sorted into a CompiledFieldDefinition, a
+     * CompiledCountDefinition, or a CompiledAggregateDefinition based on the
+     * metric value present in the definition.
      *
      * @param  array<string, array<string, mixed>>  $rawSchema
      * @return \SineMacula\ApiToolkit\Schema\CompiledSchema
@@ -104,34 +105,29 @@ final class SchemaCompiler
         /** @var array<string, \SineMacula\ApiToolkit\Schema\CompiledCountDefinition> $counts */
         $counts = [];
 
+        /** @var array<string, \SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition> $aggregates */
+        $aggregates = [];
+
         $filterable  = [];
         $sortable    = [];
         $traversable = [];
 
         foreach ($rawSchema as $schemaKey => $definition) {
 
-            if (($definition['metric'] ?? null) === 'count') {
+            $metric = $definition['metric'] ?? null;
+
+            if ($metric === 'count') {
                 $counts[self::resolveCountKey($schemaKey, $definition)] = self::buildCountDefinition($schemaKey, $definition);
                 continue;
             }
 
-            $filterableMarker = $definition['filterable'] ?? null;
-
-            if (is_string($filterableMarker)) {
-                $filterable[] = $filterableMarker;
+            if ($metric === 'sum' || $metric === 'avg') {
+                $compiled                                                    = self::buildAggregateDefinition($schemaKey, $definition);
+                $aggregates[$compiled->metric . ':' . $compiled->presentKey] = $compiled;
+                continue;
             }
 
-            $sortableMarker = $definition['sortable'] ?? null;
-
-            if (is_string($sortableMarker)) {
-                $sortable[] = $sortableMarker;
-            }
-
-            $traversableMarker = $definition['traversable'] ?? null;
-
-            if (is_string($traversableMarker)) {
-                $traversable[] = $traversableMarker;
-            }
+            self::collectQueryMarkers($definition, $filterable, $sortable, $traversable);
 
             $fields[$schemaKey] = self::buildFieldDefinition($definition);
         }
@@ -139,6 +135,7 @@ final class SchemaCompiler
         return new CompiledSchema(
             $fields,
             $counts,
+            $aggregates,
             array_values(array_unique($filterable)),
             array_values(array_unique($sortable)),
             array_values(array_unique($traversable)),
@@ -182,6 +179,105 @@ final class SchemaCompiler
             isDefault : (bool) ($definition['default'] ?? false),
             guards    : $definition['guards'] ?? [],
         );
+    }
+
+    /**
+     * Resolve the presentation key for an aggregate definition.
+     *
+     * Returns the bare present key used both as the `presentKey` property on
+     * the compiled definition and as the suffix for the Eloquent attribute
+     * name.
+     * Both the `__sum__:` and `__avg__:` prefixes are 8 characters long, so a
+     * single substr offset strips either.
+     *
+     * The dict key stored in `$aggregates` is `{metric}:{presentKey}`; this
+     * method returns only the bare present-key portion.
+     *
+     * @param  string  $schemaKey
+     * @param  array<string, mixed>  $definition
+     * @return string
+     */
+    private static function resolveAggregateKey(string $schemaKey, array $definition): string
+    {
+        $key = $definition['key'] ?? null;
+
+        if (is_string($key)) {
+            return $key;
+        }
+
+        return (str_starts_with($schemaKey, '__sum__:') || str_starts_with($schemaKey, '__avg__:'))
+            ? substr($schemaKey, 8)
+            : $schemaKey;
+    }
+
+    /**
+     * Build a CompiledAggregateDefinition from a raw definition array.
+     *
+     * @param  string  $schemaKey
+     * @param  array<string, mixed>  $definition
+     * @return \SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition
+     */
+    private static function buildAggregateDefinition(string $schemaKey, array $definition): CompiledAggregateDefinition
+    {
+        $presentKey = self::resolveAggregateKey($schemaKey, $definition);
+        $constraint = $definition['constraint'] ?? null;
+        $metric     = self::stringOr($definition['metric'] ?? null, '');
+        $column     = self::stringOr($definition['column'] ?? null, '');
+
+        return new CompiledAggregateDefinition(
+            presentKey: $presentKey,
+            relation  : self::stringOr($definition['relation'] ?? null, $presentKey),
+            column    : $column,
+            metric    : $metric,
+            constraint: $constraint instanceof \Closure ? $constraint : null,
+            isDefault : (bool) ($definition['default'] ?? false),
+            guards    : $definition['guards'] ?? [],
+        );
+    }
+
+    /**
+     * Collect filterable, sortable, and traversable markers from a field
+     * definition into the corresponding accumulator arrays.
+     *
+     * @param  array<string, mixed>  $definition
+     * @param  array<int, string>  $filterable
+     * @param  array<int, string>  $sortable
+     * @param  array<int, string>  $traversable
+     * @return void
+     */
+    private static function collectQueryMarkers(array $definition, array &$filterable, array &$sortable, array &$traversable): void
+    {
+        $filterableMarker = $definition['filterable'] ?? null;
+
+        if (is_string($filterableMarker)) {
+            $filterable[] = $filterableMarker;
+        }
+
+        $sortableMarker = $definition['sortable'] ?? null;
+
+        if (is_string($sortableMarker)) {
+            $sortable[] = $sortableMarker;
+        }
+
+        $traversableMarker = $definition['traversable'] ?? null;
+
+        if (!is_string($traversableMarker)) {
+            return;
+        }
+
+        $traversable[] = $traversableMarker;
+    }
+
+    /**
+     * Return $value as a string, or $default when $value is not a string.
+     *
+     * @param  mixed  $value
+     * @param  string  $default
+     * @return string
+     */
+    private static function stringOr(mixed $value, string $default): string
+    {
+        return is_string($value) ? $value : $default;
     }
 
     /**

--- a/src/Schema/Sum.php
+++ b/src/Schema/Sum.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Schema;
+
+/**
+ * Sum schema helper for relation aggregate definitions.
+ *
+ * Produces a schema entry that instructs the toolkit to load a withSum()
+ * aggregate on the declared relation and column pair.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class Sum extends AggregateDefinition
+{
+    /**
+     * Return the metric identifier for sum aggregates.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected static function metric(): string
+    {
+        return 'sum';
+    }
+}

--- a/tests/Fixtures/Models/AggregateCapturingModel.php
+++ b/tests/Fixtures/Models/AggregateCapturingModel.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Models;
+
+/**
+ * Minimal fake model that captures loadSum/loadAvg calls for unit testing.
+ *
+ * Converts the 'relation as alias' relation argument to the
+ * presentKey_metric_column attribute name that ValueResolver expects, then
+ * stores a fixed sentinel value. Satisfies all method_exists guards in
+ * ApiResource without requiring a real Eloquent database connection.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+final class AggregateCapturingModel
+{
+    /** @var array<string, mixed> */
+    private array $attributes = [];
+
+    /**
+     * Magic getter for attribute access.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get(string $key): mixed
+    {
+        return $this->attributes[$key] ?? null;
+    }
+
+    /**
+     * Magic isset for attribute existence check.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset(string $key): bool
+    {
+        return isset($this->attributes[$key]);
+    }
+
+    /**
+     * No-op for the eager-load relations path.
+     *
+     * @param  mixed  $with
+     * @return static
+     */
+    public function loadMissing(mixed $with): static
+    {
+        return $this;
+    }
+
+    /**
+     * No-op; the counts field is not requested in aggregate tests.
+     *
+     * @param  mixed  $relations
+     * @return static
+     */
+    public function loadCount(mixed $relations): static
+    {
+        return $this;
+    }
+
+    /**
+     * Capture a sum aggregate call and store a fixed sentinel value.
+     *
+     * Mirrors Eloquent, which uses the "as" alias verbatim as the result
+     * attribute, so the alias is stored as-is for ValueResolver to read back.
+     *
+     * @SuppressWarnings("php:S1172")
+     *
+     * @param  mixed  $relations
+     * @param  string  $column
+     * @return static
+     */
+    public function loadSum(mixed $relations, string $column): static
+    {
+        $this->attributes[$this->resolveAlias($relations)] = 42.0;
+
+        return $this;
+    }
+
+    /**
+     * Capture an average aggregate call and store a fixed sentinel value.
+     *
+     * Mirrors Eloquent, which uses the "as" alias verbatim as the result
+     * attribute, so the alias is stored as-is for ValueResolver to read back.
+     *
+     * @SuppressWarnings("php:S1172")
+     *
+     * @param  mixed  $relations
+     * @param  string  $column
+     * @return static
+     */
+    public function loadAvg(mixed $relations, string $column): static
+    {
+        $this->attributes[$this->resolveAlias($relations)] = 3.5;
+
+        return $this;
+    }
+
+    /**
+     * Return the current attribute map.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Derive the present-key alias from the relation argument.
+     *
+     * The 'relation as alias' string form yields the alias segment after
+     * ' as '. An array uses the key in the same format.
+     *
+     * @param  mixed  $relations
+     * @return string
+     */
+    private function resolveAlias(mixed $relations): string
+    {
+        if (is_array($relations)) {
+            $first = array_key_first($relations);
+            $rel   = $first !== null ? (string) $first : '';
+        } else {
+            $rel = is_string($relations) ? $relations : '';
+        }
+
+        return explode(' as ', $rel)[1] ?? $rel;
+    }
+}

--- a/tests/Fixtures/Resources/UserResource.php
+++ b/tests/Fixtures/Resources/UserResource.php
@@ -5,9 +5,11 @@ declare(strict_types = 1);
 namespace Tests\Fixtures\Resources;
 
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Average;
 use SineMacula\ApiToolkit\Schema\Count;
 use SineMacula\ApiToolkit\Schema\Field;
 use SineMacula\ApiToolkit\Schema\Relation;
+use SineMacula\ApiToolkit\Schema\Sum;
 use Tests\Fixtures\Models\User;
 
 /**
@@ -59,6 +61,8 @@ final class UserResource extends ApiResource
             Relation::to('profile', 'bio', 'profile_bio'),
             Relation::to('posts', PostResource::class),
             Count::of('posts')->default(),
+            Sum::of('posts', 'id')->default(),
+            Average::of('posts', 'id'),
         );
     }
 }

--- a/tests/Integration/ApiResourceIntegrationTest.php
+++ b/tests/Integration/ApiResourceIntegrationTest.php
@@ -174,6 +174,45 @@ final class ApiResourceIntegrationTest extends TestCase
     }
 
     /**
+     * Test that sums and averages are computed via the real Eloquent aggregate
+     * path and surfaced in the response.
+     *
+     * Exercises the full loadSum/loadAvg -> ValueResolver path against the
+     * database, so the alias used by EagerLoadPlanner must match the attribute
+     * the resolver reads back. Compares against a direct relation aggregate.
+     *
+     * @return void
+     */
+    public function testSumsAndAveragesAreIncludedInResponse(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields'   => ['users' => 'name,sums,averages'],
+            'sums'     => ['users' => ['posts' => 'id']],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]);
+        ApiQuery::parse($request);
+
+        $alice = User::query()->where('name', 'Alice')->first();
+
+        self::assertNotNull($alice);
+
+        $postIds     = $alice->posts()->get()->pluck('id');
+        $expectedSum = (float) $postIds->sum(); // @phpstan-ignore cast.double
+        $expectedAvg = (float) $postIds->avg(); // @phpstan-ignore cast.double
+
+        $resource = new UserResource($alice, true);
+        $data     = $resource->resolve();
+
+        self::assertArrayHasKey('sums', $data);
+        self::assertArrayHasKey('posts_id', $data['sums']);
+        self::assertSame($expectedSum, $data['sums']['posts_id']);
+
+        self::assertArrayHasKey('averages', $data);
+        self::assertArrayHasKey('posts_id', $data['averages']);
+        self::assertSame($expectedAvg, $data['averages']['posts_id']);
+    }
+
+    /**
      * Seed the database with test data.
      *
      * @return void

--- a/tests/Unit/Contracts/ApiResourceInterfaceTest.php
+++ b/tests/Unit/Contracts/ApiResourceInterfaceTest.php
@@ -97,6 +97,8 @@ final class ApiResourceInterfaceTest extends TestCase
             'resolveFields',
             'eagerLoadMapFor',
             'eagerLoadCountsFor',
+            'eagerLoadSumsFor',
+            'eagerLoadAveragesFor',
             'resolve',
             'withFields',
             'withoutFields',

--- a/tests/Unit/Contracts/ResourceMetadataProviderTest.php
+++ b/tests/Unit/Contracts/ResourceMetadataProviderTest.php
@@ -197,6 +197,64 @@ final class ResourceMetadataProviderTest extends TestCase
     }
 
     /**
+     * Test that eagerLoadSumsFor is declared with string and nullable array
+     * parameters.
+     *
+     * @return void
+     */
+    public function testResourceMetadataProviderDeclaresEagerLoadSumsFor(): void
+    {
+        $reflection = new \ReflectionClass(ResourceMetadataProvider::class);
+        $method     = $reflection->getMethod('eagerLoadSumsFor');
+
+        self::assertTrue($method->isPublic());
+        self::assertFalse($method->isStatic());
+
+        $parameters = $method->getParameters();
+
+        self::assertCount(2, $parameters);
+        self::assertSame('resourceClass', $parameters[0]->getName());
+        self::assertSame('requestedSums', $parameters[1]->getName());
+        self::assertTrue($parameters[1]->allowsNull());
+        self::assertTrue($parameters[1]->isDefaultValueAvailable());
+        self::assertNull($parameters[1]->getDefaultValue());
+
+        $returnType = $method->getReturnType();
+
+        self::assertInstanceOf(\ReflectionNamedType::class, $returnType);
+        self::assertSame('array', $returnType->getName());
+    }
+
+    /**
+     * Test that eagerLoadAveragesFor is declared with string and nullable array
+     * parameters.
+     *
+     * @return void
+     */
+    public function testResourceMetadataProviderDeclaresEagerLoadAveragesFor(): void
+    {
+        $reflection = new \ReflectionClass(ResourceMetadataProvider::class);
+        $method     = $reflection->getMethod('eagerLoadAveragesFor');
+
+        self::assertTrue($method->isPublic());
+        self::assertFalse($method->isStatic());
+
+        $parameters = $method->getParameters();
+
+        self::assertCount(2, $parameters);
+        self::assertSame('resourceClass', $parameters[0]->getName());
+        self::assertSame('requestedAverages', $parameters[1]->getName());
+        self::assertTrue($parameters[1]->allowsNull());
+        self::assertTrue($parameters[1]->isDefaultValueAvailable());
+        self::assertNull($parameters[1]->getDefaultValue());
+
+        $returnType = $method->getReturnType();
+
+        self::assertInstanceOf(\ReflectionNamedType::class, $returnType);
+        self::assertSame('array', $returnType->getName());
+    }
+
+    /**
      * Test that a mock implementing the interface can be instantiated.
      *
      * @return void

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -17,6 +17,7 @@ use SineMacula\ApiToolkit\Schema\Field;
 use SineMacula\ApiToolkit\Schema\Relation;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Models\AggregateCapturingModel;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\Profile;
@@ -2409,6 +2410,231 @@ final class ApiResourceTest extends TestCase
 
         self::assertArrayHasKey('counts', $result);
         self::assertSame(1, $result['counts']['users']);
+    }
+
+    /**
+     * Test that sums payload is included in the resolved output when the sums
+     * virtual field is requested and loadMissing loads the aggregate
+     * attributes.
+     *
+     * Uses AggregateCapturingModel that intercepts loadSum to set the
+     * name that ValueResolver expects, since Eloquent's 'relation as alias'
+     * form produces only the bare alias key rather than the full
+     * presentKey_sum_column key.
+     *
+     * @return void
+     */
+    public function testSumsPayloadIsIncludedWhenLoadMissingAndSumsFieldRequested(): void
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parser */
+        $parser  = $this->app->make('api.query');
+        $request = Request::create('/', HttpMethod::GET->getVerb(), [
+            'fields' => ['users' => 'id,sums'],
+        ]);
+
+        $parser->parse($request);
+
+        $model = new AggregateCapturingModel;
+
+        $resource = new UserResource($model, true);
+        $result   = $resource->resolve();
+
+        self::assertArrayHasKey('sums', $result);
+        self::assertIsFloat($result['sums']['posts_id']);
+    }
+
+    /**
+     * Test that the sums key is absent when the sums virtual field is requested
+     * but no aggregate attribute is loaded on the model.
+     *
+     * @return void
+     */
+    public function testSumsPayloadIsAbsentWhenNoSumsLoaded(): void
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parser */
+        $parser  = $this->app->make('api.query');
+        $request = Request::create('/', HttpMethod::GET->getVerb(), [
+            'fields' => ['users' => 'id,sums'],
+        ]);
+
+        $parser->parse($request);
+
+        $user = User::create([
+            'name'  => 'NoSumUser',
+            'email' => 'nosumuser@example.com',
+        ]);
+
+        // No loadMissing and no manual preload - attribute not present on model
+        $resource = new UserResource($user);
+        $result   = $resource->resolve();
+
+        self::assertArrayNotHasKey('sums', $result);
+    }
+
+    /**
+     * Test that averages payload is included when the averages field is
+     * requested and loadMissing loads the aggregate attribute.
+     *
+     * Uses AggregateCapturingModel that intercepts loadAvg to set the
+     * name that ValueResolver expects, since Eloquent's 'relation as alias'
+     * form produces only the bare alias key rather than the full
+     * presentKey_avg_column key.
+     *
+     * @return void
+     */
+    public function testAveragesPayloadIsIncludedWhenLoadMissingAndAveragesFieldRequested(): void
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parser */
+        $parser  = $this->app->make('api.query');
+        $request = Request::create('/', HttpMethod::GET->getVerb(), [
+            'fields'   => ['users' => 'id,averages'],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]);
+
+        $parser->parse($request);
+
+        $model = new AggregateCapturingModel;
+
+        $resource = new UserResource($model, true);
+        $result   = $resource->resolve();
+
+        self::assertArrayHasKey('averages', $result);
+        self::assertIsFloat($result['averages']['posts_id']);
+    }
+
+    /**
+     * Test that the averages key is absent from the resolved output when the
+     * averages virtual field is not included in the requested fields, even
+     * when getAverages returns a non-null value and an attribute is preloaded.
+     *
+     * @return void
+     */
+    public function testAveragesPayloadIsAbsentWhenShouldIncludeIsFalse(): void
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parser */
+        $parser  = $this->app->make('api.query');
+        $request = Request::create('/', HttpMethod::GET->getVerb(), [
+            // No 'averages' in fields - shouldInclude returns false
+            'averages' => ['users' => ['posts' => 'id']],
+        ]);
+
+        $parser->parse($request);
+
+        $user = User::create([
+            'name'  => 'AvgFalseUser',
+            'email' => 'avgfalse@example.com',
+        ]);
+
+        // Manually set the avg attribute so resolveAggregatesPayload would
+        // return a non-empty array if the shouldInclude guard is bypassed
+        $user->setAttribute('posts_id_avg_id', 3.0);
+
+        $resource = new UserResource($user);
+        $result   = $resource->resolve();
+
+        self::assertArrayNotHasKey('averages', $result);
+    }
+
+    /**
+     * Test that the averages key is absent when shouldInclude is true but no
+     * average attributes are loaded on the model.
+     *
+     * @return void
+     */
+    public function testAveragesPayloadIsAbsentWhenNoAveragesLoaded(): void
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parser */
+        $parser  = $this->app->make('api.query');
+        $request = Request::create('/', HttpMethod::GET->getVerb(), [
+            'fields'   => ['users' => 'id,averages'],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]);
+
+        $parser->parse($request);
+
+        $user = User::create([
+            'name'  => 'AvgEmptyUser',
+            'email' => 'avgempty@example.com',
+        ]);
+
+        // No loadMissing and no manual preload - attribute absent on model
+        $resource = new UserResource($user);
+        $result   = $resource->resolve();
+
+        self::assertArrayNotHasKey('averages', $result);
+    }
+
+    /**
+     * Test that loadMissing loads a non-default sum when it is explicitly
+     * requested via the sums query parameter.
+     *
+     * Uses AggregateCapturingModel that intercepts loadSum to set the
+     * name that ValueResolver expects, since Eloquent's 'relation as alias'
+     * form produces only the bare alias key rather than the full
+     * presentKey_sum_column key.
+     *
+     * @return void
+     */
+    public function testLoadMissingLoadsExplicitlyRequestedNonDefaultSum(): void
+    {
+        $this->clearSchemaCache();
+
+        $resourceClass = new class (null) extends ApiResource {
+            /** @var string */
+            public const string RESOURCE_TYPE = 'nondefault_sum_rt';
+
+            /** @var array<int, string> */
+            protected static array $default = ['id', 'sums'];
+
+            /**
+             * Get the resource schema.
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            #[\Override]
+            public static function schema(): array
+            {
+                return [
+                    'id'               => [],
+                    '__sum__:posts_id' => [
+                        'metric'   => 'sum',
+                        'relation' => 'posts',
+                        'column'   => 'id',
+                        'default'  => false,
+                    ],
+                ];
+            }
+        };
+
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parser */
+        $parser  = $this->app->make('api.query');
+        $request = Request::create('/', HttpMethod::GET->getVerb(), [
+            'fields' => ['nondefault_sum_rt' => 'id,sums'],
+            'sums'   => ['nondefault_sum_rt' => ['posts' => 'id']],
+        ]);
+
+        $parser->parse($request);
+
+        $model = new AggregateCapturingModel;
+
+        $instance = new $resourceClass($model, true);
+        $result   = $instance->resolve();
+
+        self::assertArrayHasKey('sums', $result, 'non-default sum must be loaded when explicitly requested');
+
+        $this->clearSchemaCache();
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -648,6 +648,269 @@ final class EagerLoadPlannerTest extends TestCase
     }
 
     /**
+     * Test that default sums are included when no relation-column map is
+     * requested.
+     *
+     * @return void
+     */
+    public function testBuildSumMapReturnsDefaultSumsWhenNoRequestMade(): void
+    {
+        $result = EagerLoadPlanner::buildSumMap(UserResource::class);
+
+        self::assertNotEmpty($result);
+        self::assertSame('posts as posts_id_sum_id', $result[0]['relation']);
+        self::assertSame('id', $result[0]['column']);
+    }
+
+    /**
+     * Test that non-default sums are excluded when no request is made.
+     *
+     * @return void
+     */
+    public function testBuildSumMapExcludesNonDefaultSumsWhenNoRequestMade(): void
+    {
+        $result = EagerLoadPlanner::buildAvgMap(UserResource::class);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that only the explicitly requested relation-column entries are
+     * included in the sum map.
+     *
+     * @return void
+     */
+    public function testBuildSumMapReturnsOnlyRequestedEntries(): void
+    {
+        $result = EagerLoadPlanner::buildSumMap(UserResource::class, ['posts' => ['id']]);
+
+        self::assertCount(1, $result);
+        self::assertSame('id', $result[0]['column']);
+    }
+
+    /**
+     * Test that a requested relation not present in the schema produces an
+     * empty sum map.
+     *
+     * @return void
+     */
+    public function testBuildSumMapReturnsEmptyForUnknownRelation(): void
+    {
+        $result = EagerLoadPlanner::buildSumMap(UserResource::class, ['nonexistent' => ['id']]);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that a constrained sum entry produces an associative relation entry.
+     *
+     * @return void
+     */
+    public function testBuildSumMapReturnsScopedEntryForConstrainedSum(): void
+    {
+        $constraint = fn ($query) => $query->where('active', true);
+
+        $constrainedSumResource = new class {
+            /** @var string The resource type identifier. */
+            public const string RESOURCE_TYPE = 'constrained_sum_test';
+
+            /** @var (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null */
+            public static ?\Closure $constraint = null;
+
+            /**
+             * @return array<string, array<string, mixed>>
+             */
+            public static function schema(): array
+            {
+                return [
+                    '__sum__:posts_id' => [
+                        'key'        => 'posts_id',
+                        'metric'     => 'sum',
+                        'relation'   => 'posts',
+                        'column'     => 'id',
+                        'constraint' => self::$constraint,
+                        'default'    => true,
+                    ],
+                ];
+            }
+        };
+
+        $constrainedSumResource::$constraint = $constraint;
+        $resourceClass                       = $constrainedSumResource::class;
+
+        $result = EagerLoadPlanner::buildSumMap($resourceClass);
+
+        self::assertCount(1, $result);
+        self::assertIsArray($result[0]['relation']);
+    }
+
+    /**
+     * Test that buildSumMap continues past aggregate definitions that are
+     * excluded by shouldIncludeAggregate and still includes later entries that
+     * are included.
+     *
+     * @return void
+     */
+    public function testBuildSumMapContinuesPastExcludedAggregates(): void
+    {
+        $multiSumResource = new class {
+            /** @var string */
+            public const string RESOURCE_TYPE = 'multi_sum_continue_test';
+
+            /**
+             * @return array<string, array<string, mixed>>
+             */
+            public static function schema(): array
+            {
+                return [
+                    '__sum__:posts_id' => [
+                        'metric'   => 'sum',
+                        'relation' => 'posts',
+                        'column'   => 'id',
+                        'default'  => false,
+                    ],
+                    '__sum__:comments_id' => [
+                        'metric'   => 'sum',
+                        'relation' => 'comments',
+                        'column'   => 'id',
+                        'default'  => true,
+                    ],
+                ];
+            }
+        };
+
+        // No request passed - only defaults are included.
+        // The first sum (posts_id) is not default, so it must be skipped;
+        // the second (comments_id) is default, so it must be included.
+        $result = EagerLoadPlanner::buildSumMap($multiSumResource::class);
+
+        self::assertCount(1, $result);
+        $relation = $result[0]['relation'];
+        self::assertIsString($relation);
+        self::assertStringContainsString('comments', $relation);
+    }
+
+    /**
+     * Test that a constrained sum entry carries the aliased relation name as
+     * the key in the relation array, not an empty array.
+     *
+     * @return void
+     */
+    public function testBuildSumMapConstrainedRelationHasAliasedKey(): void
+    {
+        $constraint = fn ($query) => $query->where('active', true);
+
+        $constrainedSumResource = new class {
+            /** @var string */
+            public const string RESOURCE_TYPE = 'constrained_sum_key_test';
+
+            /** @var (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null */
+            public static ?\Closure $constraint = null;
+
+            /**
+             * @return array<string, array<string, mixed>>
+             */
+            public static function schema(): array
+            {
+                return [
+                    '__sum__:posts_id' => [
+                        'key'        => 'posts_id',
+                        'metric'     => 'sum',
+                        'relation'   => 'posts',
+                        'column'     => 'id',
+                        'constraint' => self::$constraint,
+                        'default'    => true,
+                    ],
+                ];
+            }
+        };
+
+        $constrainedSumResource::$constraint = $constraint;
+
+        $result = EagerLoadPlanner::buildSumMap($constrainedSumResource::class);
+
+        self::assertCount(1, $result);
+        self::assertIsArray($result[0]['relation']);
+        self::assertArrayHasKey('posts as posts_id_sum_id', $result[0]['relation']);
+        self::assertSame($constraint, $result[0]['relation']['posts as posts_id_sum_id']);
+    }
+
+    /**
+     * Test that a memoised sum map is returned without rebuilding.
+     *
+     * @return void
+     */
+    public function testBuildSumMapReturnsMemoisedResult(): void
+    {
+        $this->setStaticProperty(EagerLoadPlanner::class, 'aggregateCache', ['sum:' . UserResource::class . '|*' => [['relation' => 'sentinel', 'column' => 'id']]]);
+
+        $result = EagerLoadPlanner::buildSumMap(UserResource::class);
+
+        self::assertSame([['relation' => 'sentinel', 'column' => 'id']], $result);
+    }
+
+    /**
+     * Test that default averages are included when no relation-column map is
+     * requested.
+     *
+     * @return void
+     */
+    public function testBuildAvgMapReturnsDefaultAvgsWhenNoRequestMade(): void
+    {
+        // UserResource has no default averages
+        $result = EagerLoadPlanner::buildAvgMap(UserResource::class);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that only the explicitly requested relation-column entries are
+     * included in the avg map.
+     *
+     * @return void
+     */
+    public function testBuildAvgMapReturnsOnlyRequestedEntries(): void
+    {
+        $result = EagerLoadPlanner::buildAvgMap(UserResource::class, ['posts' => ['id']]);
+
+        self::assertCount(1, $result);
+        self::assertSame('id', $result[0]['column']);
+    }
+
+    /**
+     * Test that a memoised avg map is returned without rebuilding.
+     *
+     * @return void
+     */
+    public function testBuildAvgMapReturnsMemoisedResult(): void
+    {
+        $this->setStaticProperty(EagerLoadPlanner::class, 'aggregateCache', ['avg:' . UserResource::class . '|*' => [['relation' => 'sentinel_avg', 'column' => 'score']]]);
+
+        $result = EagerLoadPlanner::buildAvgMap(UserResource::class);
+
+        self::assertSame([['relation' => 'sentinel_avg', 'column' => 'score']], $result);
+    }
+
+    /**
+     * Test that clearing the cache resets sum and avg memos.
+     *
+     * @return void
+     */
+    public function testClearCacheResetsSumAndAvgMemos(): void
+    {
+        $this->setStaticProperty(EagerLoadPlanner::class, 'aggregateCache', [
+            'sum:key' => [['relation' => 'x', 'column' => 'y']],
+            'avg:key' => [['relation' => 'a', 'column' => 'b']],
+        ]);
+
+        EagerLoadPlanner::clearCache();
+
+        $aggregateCache = $this->getStaticProperty(EagerLoadPlanner::class, 'aggregateCache');
+
+        self::assertSame([], $aggregateCache);
+    }
+
+    /**
      * Test that blank API-query fields for a child resource fall back to the
      * child's default fields during recursion.
      *

--- a/tests/Unit/Http/Resources/Concerns/FieldResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/FieldResolverTest.php
@@ -361,6 +361,172 @@ final class FieldResolverTest extends TestCase
     }
 
     /**
+     * Test that shouldIncludeSumsField returns true when sums is in the API
+     * query fields.
+     *
+     * @return void
+     */
+    public function testShouldIncludeSumsFieldReturnsTrueWhenSumsRequested(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name', 'sums']);
+
+        self::assertTrue($this->resolver->shouldIncludeSumsField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeSumsField returns false when sums is excluded via
+     * withoutFields.
+     *
+     * @return void
+     */
+    public function testShouldIncludeSumsFieldReturnsFalseWhenSumsExcluded(): void
+    {
+
+        $this->resolver->withoutFields(['sums']);
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name', 'sums']);
+
+        self::assertFalse($this->resolver->shouldIncludeSumsField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeSumsField returns true when sums is in the default
+     * fields and not excluded.
+     *
+     * @return void
+     */
+    public function testShouldIncludeSumsFieldReturnsTrueWhenInDefaultFields(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(null);
+
+        self::assertTrue($this->resolver->shouldIncludeSumsField('users', ['name', 'sums']));
+    }
+
+    /**
+     * Test that shouldIncludeSumsField returns true in all-fields mode.
+     *
+     * @return void
+     */
+    public function testShouldIncludeSumsFieldReturnsTrueInAllMode(): void
+    {
+
+        $this->resolver->withAll();
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(null);
+
+        self::assertTrue($this->resolver->shouldIncludeSumsField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeSumsField returns false when requested fields
+     * lack sums and it is not in defaults.
+     *
+     * @return void
+     */
+    public function testShouldIncludeSumsFieldReturnsFalseWhenNotRequestedAndNotInDefaults(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name']);
+
+        self::assertFalse($this->resolver->shouldIncludeSumsField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeAveragesField returns true when averages is in
+     * the API query fields.
+     *
+     * @return void
+     */
+    public function testShouldIncludeAveragesFieldReturnsTrueWhenAveragesRequested(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name', 'averages']);
+
+        self::assertTrue($this->resolver->shouldIncludeAveragesField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeAveragesField returns false when averages is
+     * excluded via withoutFields.
+     *
+     * @return void
+     */
+    public function testShouldIncludeAveragesFieldReturnsFalseWhenAveragesExcluded(): void
+    {
+
+        $this->resolver->withoutFields(['averages']);
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name', 'averages']);
+
+        self::assertFalse($this->resolver->shouldIncludeAveragesField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeAveragesField returns true when averages is in
+     * the default fields and not excluded.
+     *
+     * @return void
+     */
+    public function testShouldIncludeAveragesFieldReturnsTrueWhenInDefaultFields(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(null);
+
+        self::assertTrue($this->resolver->shouldIncludeAveragesField('users', ['name', 'averages']));
+    }
+
+    /**
+     * Test that shouldIncludeAveragesField returns true in all-fields mode.
+     *
+     * @return void
+     */
+    public function testShouldIncludeAveragesFieldReturnsTrueInAllMode(): void
+    {
+
+        $this->resolver->withAll();
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(null);
+
+        self::assertTrue($this->resolver->shouldIncludeAveragesField('users', []));
+    }
+
+    /**
+     * Test that shouldIncludeAveragesField returns false when not requested and
+     * absent from defaults.
+     *
+     * @return void
+     */
+    public function testShouldIncludeAveragesFieldReturnsFalseWhenNotRequestedAndNotInDefaults(): void
+    {
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name']);
+
+        self::assertFalse($this->resolver->shouldIncludeAveragesField('users', []));
+    }
+
+    /**
      * Create a CompiledSchema with the given field keys using stub definitions.
      *
      * @param  array<int, string>  $keys

--- a/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Http\Resources\Concerns;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SineMacula\ApiToolkit\Exceptions\InvalidSchemaException;
+use SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledCountDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledSchema;
@@ -743,6 +744,302 @@ final class SchemaCompilerTest extends TestCase
                 self::assertNull($openApi, "Author-undeclared field {$key} should compile with a null openApi");
             }
         }
+    }
+
+    /**
+     * Test that sum entries produce a CompiledAggregateDefinition for the
+     * 'sum' metric with the correct present key.
+     *
+     * @return void
+     */
+    public function testCompileCreatesCompiledAggregateDefinitionsForSumMetrics(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:posts_id' => [
+                'key'      => 'posts_id',
+                'metric'   => 'sum',
+                'relation' => 'posts',
+                'column'   => 'id',
+                'default'  => true,
+            ],
+        ]);
+
+        $schema = SchemaCompiler::compile($resourceClass);
+
+        self::assertSame([], $schema->getFieldKeys());
+        self::assertSame([], $schema->getCountDefinitions());
+
+        $aggregates = $schema->getAggregateDefinitions();
+        self::assertCount(1, $aggregates);
+        self::assertArrayHasKey('sum:posts_id', $aggregates);
+
+        $agg = $aggregates['sum:posts_id'];
+        self::assertInstanceOf(CompiledAggregateDefinition::class, $agg);
+        self::assertSame('posts_id', $agg->presentKey);
+        self::assertSame('posts', $agg->relation);
+        self::assertSame('id', $agg->column);
+        self::assertSame('sum', $agg->metric);
+        self::assertTrue($agg->isDefault);
+    }
+
+    /**
+     * Test that average entries produce CompiledAggregateDefinition with
+     * metric='avg' and the correct present key.
+     *
+     * @return void
+     */
+    public function testCompileCreatesCompiledAggregateDefinitionsForAvgMetrics(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__avg__:posts_id' => [
+                'key'      => 'posts_id',
+                'metric'   => 'avg',
+                'relation' => 'posts',
+                'column'   => 'id',
+                'default'  => false,
+            ],
+        ]);
+
+        $schema = SchemaCompiler::compile($resourceClass);
+
+        $aggregates = $schema->getAggregateDefinitions();
+        self::assertCount(1, $aggregates);
+
+        $agg = $aggregates['avg:posts_id'];
+        self::assertInstanceOf(CompiledAggregateDefinition::class, $agg);
+        self::assertSame('avg', $agg->metric);
+        self::assertFalse($agg->isDefault);
+    }
+
+    /**
+     * Test that an explicit key in a sum entry overrides the prefix-stripped
+     * schema key and the relation is taken from the definition.
+     *
+     * @return void
+     */
+    public function testCompileUsesExplicitAggregateKeyOverSchemaKey(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:posts_id' => [
+                'key'      => 'my_sum',
+                'metric'   => 'sum',
+                'relation' => 'posts',
+                'column'   => 'id',
+            ],
+        ]);
+
+        $schema     = SchemaCompiler::compile($resourceClass);
+        $aggregates = $schema->getAggregateDefinitions();
+
+        self::assertArrayHasKey('sum:my_sum', $aggregates);
+        self::assertSame('my_sum', $aggregates['sum:my_sum']->presentKey);
+        self::assertSame('posts', $aggregates['sum:my_sum']->relation);
+    }
+
+    /**
+     * Test that an aggregate without a default flag compiles as non-default and
+     * that guards are preserved.
+     *
+     * @return void
+     */
+    public function testCompileDefaultsAggregateToNonDefaultAndPreservesGuards(): void
+    {
+        $guard = fn ($resource, $request) => true;
+
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:posts_id' => [
+                'metric'   => 'sum',
+                'relation' => 'posts',
+                'column'   => 'id',
+                'guards'   => [$guard],
+            ],
+        ]);
+
+        $schema = SchemaCompiler::compile($resourceClass);
+        $agg    = $schema->getAggregateDefinitions()['sum:posts_id'];
+
+        self::assertFalse($agg->isDefault);
+        self::assertSame([$guard], $agg->guards);
+    }
+
+    /**
+     * Test that a non-Closure aggregate constraint throws an
+     * InvalidSchemaException.
+     *
+     * @return void
+     */
+    public function testCompileThrowsForNonClosureAggregateConstraint(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:posts_id' => [
+                'metric'     => 'sum',
+                'relation'   => 'posts',
+                'column'     => 'id',
+                'constraint' => 'not-a-closure',
+            ],
+        ]);
+
+        try {
+            SchemaCompiler::compile($resourceClass);
+            self::fail('Expected InvalidSchemaException to be thrown.');
+        } catch (InvalidSchemaException $exception) {
+            $errors = $exception->getErrors();
+            self::assertCount(1, $errors);
+            self::assertSame('Constraint must be a Closure', $errors[0]->defect);
+        }
+    }
+
+    /**
+     * Test that an empty schema produces no aggregate definitions.
+     *
+     * @return void
+     */
+    public function testCompileHandlesEmptySchemaProducesNoAggregates(): void
+    {
+        $schema = SchemaCompiler::compile($this->createStubResourceClass([]));
+
+        self::assertSame([], $schema->getAggregateDefinitions());
+    }
+
+    /**
+     * Test that constraint validation continues past valid entries to report
+     * errors on later entries with an invalid constraint.
+     *
+     * @return void
+     */
+    public function testCompileValidationContinuesPastValidConstraintsToFindInvalidOnes(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            'name'             => [],
+            '__sum__:posts_id' => [
+                'metric'     => 'sum',
+                'relation'   => 'posts',
+                'column'     => 'id',
+                'constraint' => 'not-a-closure',
+            ],
+        ]);
+
+        $this->expectException(InvalidSchemaException::class);
+
+        SchemaCompiler::compile($resourceClass);
+    }
+
+    /**
+     * Test that schema entries declared after a sum entry are still compiled
+     * into the field definitions.
+     *
+     * @return void
+     */
+    public function testCompileProcessesFieldsDeclaredAfterSumEntry(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:posts_id' => [
+                'metric'   => 'sum',
+                'relation' => 'posts',
+                'column'   => 'id',
+                'default'  => true,
+            ],
+            'name' => [],
+        ]);
+
+        $schema = SchemaCompiler::compile($resourceClass);
+
+        self::assertNotEmpty($schema->getAggregateDefinitions());
+        self::assertNotNull($schema->getField('name'), '\'name\' field must be compiled when declared after a sum entry');
+    }
+
+    /**
+     * Test that a non-prefixed aggregate schema key is used verbatim as the
+     * present key when no explicit key override is provided.
+     *
+     * @return void
+     */
+    public function testCompilePreservesNonPrefixedAggregateSchemaKeyAsPresentKey(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            'my_sum_key' => [
+                'metric'   => 'sum',
+                'relation' => 'posts',
+                'column'   => 'id',
+            ],
+        ]);
+
+        $schema     = SchemaCompiler::compile($resourceClass);
+        $aggregates = $schema->getAggregateDefinitions();
+
+        self::assertArrayHasKey('sum:my_sum_key', $aggregates, 'non-prefixed schema key must become the presentKey as-is');
+        self::assertSame('my_sum_key', $aggregates['sum:my_sum_key']->presentKey);
+    }
+
+    /**
+     * Test that the __avg__: prefix is stripped from the schema key when no
+     * explicit key override is provided.
+     *
+     * @return void
+     */
+    public function testCompileStripsAvgPrefixWhenNoExplicitKeyProvided(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__avg__:comments_id' => [
+                'metric'   => 'avg',
+                'relation' => 'comments',
+                'column'   => 'id',
+            ],
+        ]);
+
+        $schema     = SchemaCompiler::compile($resourceClass);
+        $aggregates = $schema->getAggregateDefinitions();
+
+        self::assertArrayHasKey('avg:comments_id', $aggregates, '__avg__: prefix must be stripped to derive the presentKey');
+        self::assertSame('comments_id', $aggregates['avg:comments_id']->presentKey);
+    }
+
+    /**
+     * Test that the __sum__: prefix is stripped from the schema key when no
+     * explicit key override is provided.
+     *
+     * @return void
+     */
+    public function testCompileStripsSumPrefixWhenNoExplicitKeyProvided(): void
+    {
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:comments_id' => [
+                'metric'   => 'sum',
+                'relation' => 'comments',
+                'column'   => 'id',
+            ],
+        ]);
+
+        $schema     = SchemaCompiler::compile($resourceClass);
+        $aggregates = $schema->getAggregateDefinitions();
+
+        self::assertArrayHasKey('sum:comments_id', $aggregates, '__sum__: prefix must be stripped to derive the presentKey');
+        self::assertSame('comments_id', $aggregates['sum:comments_id']->presentKey);
+    }
+
+    /**
+     * Test that a Closure constraint on an aggregate definition is preserved
+     * through to the compiled definition.
+     *
+     * @return void
+     */
+    public function testCompilePreservesAggregateClosureConstraint(): void
+    {
+        $constraint = fn ($query) => $query->where('active', true);
+
+        $resourceClass = $this->createStubResourceClass([
+            '__sum__:posts_id' => [
+                'metric'     => 'sum',
+                'relation'   => 'posts',
+                'column'     => 'id',
+                'constraint' => $constraint,
+            ],
+        ]);
+
+        $schema = SchemaCompiler::compile($resourceClass);
+        $agg    = $schema->getAggregateDefinitions()['sum:posts_id'];
+
+        self::assertSame($constraint, $agg->constraint);
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
@@ -13,6 +13,7 @@ use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\GuardEvaluator;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
+use SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledCountDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledSchema;
@@ -859,6 +860,493 @@ final class ValueResolverTest extends TestCase
         $result = $this->resolver->resolveCountsPayload($resource, $schema, 'users', null);
 
         self::assertSame(['posts' => 7, 'comments' => 3], $result);
+    }
+
+    /**
+     * Test that sum aggregate definitions with isDefault=true are resolved when
+     * no specific sums are requested.
+     *
+     * @return void
+     */
+    public function testResolveSumsPayloadReturnsDefaultSumsWhenNoneRequested(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => '15'];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame(['posts_id' => 15.0], $result);
+    }
+
+    /**
+     * Test that only explicitly requested relation-column sums are included.
+     *
+     * @return void
+     */
+    public function testResolveSumsPayloadReturnsOnlyRequestedSums(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(['posts' => ['id']]);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => 10];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, false, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame(['posts_id' => 10.0], $result);
+    }
+
+    /**
+     * Test that sum definitions failing guard evaluation are excluded.
+     *
+     * @return void
+     */
+    public function testResolveSumsPayloadExcludesSumsFailingGuards(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => 5];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, [
+                fn ($resource, $request) => false,
+            ]),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that a non-object resource returns an empty sums array.
+     *
+     * @return void
+     */
+    public function testResolveSumsPayloadReturnsEmptyForNonObjectResource(): void
+    {
+        $resource = new JsonResource(null);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that avg aggregate definitions with isDefault=true are resolved when
+     * no specific averages are requested.
+     *
+     * @return void
+     */
+    public function testResolveAveragesPayloadReturnsDefaultAvgsWhenNoneRequested(): void
+    {
+
+        ApiQuery::shouldReceive('getAverages')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_avg_id' => '3.5'];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'avg', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('avg', $resource, $schema, 'users', null);
+
+        self::assertSame(['posts_id' => 3.5], $result);
+    }
+
+    /**
+     * Test that average definitions failing guard evaluation are excluded.
+     *
+     * @return void
+     */
+    public function testResolveAveragesPayloadExcludesAvgsFailingGuards(): void
+    {
+
+        ApiQuery::shouldReceive('getAverages')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_avg_id' => 2];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'avg', null, true, [
+                fn ($resource, $request) => false,
+            ]),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('avg', $resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that a non-object resource returns an empty averages array.
+     *
+     * @return void
+     */
+    public function testResolveAveragesPayloadReturnsEmptyForNonObjectResource(): void
+    {
+        $resource = new JsonResource(null);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'avg', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('avg', $resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that an avg entry with a metric='sum' is skipped by the averages
+     * resolver (metric discriminator is enforced).
+     *
+     * @return void
+     */
+    public function testResolveAveragesPayloadSkipsSumMetrics(): void
+    {
+
+        ApiQuery::shouldReceive('getAverages')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = [];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('avg', $resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that aggregate definitions for relations not present in the
+     * requested map are excluded without a type error on null column list.
+     *
+     * When getSums returns a non-empty map, relations absent from that map
+     * resolve to a null column list. The isIncluded closure must short-circuit
+     * on is_array(null) before reaching in_array, otherwise a TypeError occurs.
+     *
+     * @return void
+     */
+    public function testResolveAggregatesPayloadExcludesNonRequestedRelationsWithoutError(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(['posts' => ['id']]);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => 15, 'comments_id_sum_id' => 7];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id'    => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, false, []),
+            'comments_id' => new CompiledAggregateDefinition('comments_id', 'comments', 'id', 'sum', null, false, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame(['posts_id' => 15.0], $result);
+    }
+
+    /**
+     * Test that the aggregate loop continues past a definition whose guard
+     * fails and still resolves later definitions that pass.
+     *
+     * @return void
+     */
+    public function testResolveAggregatesPayloadContinuesPastDefinitionFailingGuard(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => 3, 'tags_id_sum_id' => 9];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, [
+                fn ($resource, $request) => false,
+            ]),
+            'tags_id' => new CompiledAggregateDefinition('tags_id', 'tags', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame(['tags_id' => 9.0], $result);
+    }
+
+    /**
+     * Test that all included aggregate definitions are returned when multiple
+     * definitions pass inclusion and guard checks.
+     *
+     * @return void
+     */
+    public function testResolveAggregatesPayloadReturnsAllIncludedDefinitions(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => 5, 'comments_id_sum_id' => 8];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id'    => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, []),
+            'comments_id' => new CompiledAggregateDefinition('comments_id', 'comments', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertCount(2, $result);
+        self::assertSame(5.0, $result['posts_id']);
+        self::assertSame(8.0, $result['comments_id']);
     }
 
     /**

--- a/tests/Unit/Http/Resources/ResourceMetadataServiceTest.php
+++ b/tests/Unit/Http/Resources/ResourceMetadataServiceTest.php
@@ -104,6 +104,35 @@ final class ResourceMetadataServiceTest extends TestCase
     }
 
     /**
+     * Test that eagerLoadSumsFor delegates to the resource class static method.
+     *
+     * @return void
+     */
+    public function testEagerLoadSumsForDelegatesToResourceClass(): void
+    {
+        $requested = ['posts' => ['id']];
+
+        $result = $this->service->eagerLoadSumsFor(UserResource::class, $requested);
+
+        self::assertSame(UserResource::eagerLoadSumsFor($requested), $result);
+    }
+
+    /**
+     * Test that eagerLoadAveragesFor delegates to the resource class static
+     * method.
+     *
+     * @return void
+     */
+    public function testEagerLoadAveragesForDelegatesToResourceClass(): void
+    {
+        $requested = ['posts' => ['id']];
+
+        $result = $this->service->eagerLoadAveragesFor(UserResource::class, $requested);
+
+        self::assertSame(UserResource::eagerLoadAveragesFor($requested), $result);
+    }
+
+    /**
      * Test that the service provider registers the ResourceMetadataProvider
      * binding as a singleton resolving to ResourceMetadataService.
      *

--- a/tests/Unit/Http/Resources/Schema/AggregateDefinitionTest.php
+++ b/tests/Unit/Http/Resources/Schema/AggregateDefinitionTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\AggregateDefinition;
+use SineMacula\ApiToolkit\Schema\Sum;
+
+/**
+ * Tests for the AggregateDefinition abstract class.
+ *
+ * Uses Sum as the concrete implementation since AggregateDefinition is
+ * abstract.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(AggregateDefinition::class)]
+final class AggregateDefinitionTest extends TestCase
+{
+    /**
+     * Test that of creates an instance with the given relation and column.
+     *
+     * @return void
+     */
+    public function testOfCreatesInstanceWithRelationAndColumn(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+        $key   = '__sum__:posts_id';
+
+        self::assertArrayHasKey($key, $array);
+        self::assertSame('posts', $array[$key]['relation']);
+        self::assertSame('id', $array[$key]['column']);
+    }
+
+    /**
+     * Test that of with an explicit alias uses the alias as the present key.
+     *
+     * @return void
+     */
+    public function testOfWithExplicitAliasUsesThatAliasAsPresentKey(): void
+    {
+        $sum   = Sum::of('posts', 'id', 'my_alias');
+        $array = $sum->toArray();
+
+        self::assertArrayHasKey('__sum__:my_alias', $array);
+        self::assertSame('my_alias', $array['__sum__:my_alias']['key']);
+    }
+
+    /**
+     * Test that as() updates the alias and re-keys the output.
+     *
+     * @return void
+     */
+    public function testAsUpdatesAliasAndRekeys(): void
+    {
+        $sum = Sum::of('posts', 'id');
+
+        $result = $sum->as('total_sum');
+
+        self::assertSame($sum, $result);
+
+        $array = $sum->toArray();
+
+        self::assertArrayHasKey('__sum__:total_sum', $array);
+        self::assertSame('total_sum', $array['__sum__:total_sum']['key']);
+    }
+
+    /**
+     * Test that constrain stores the closure and emits it in toArray.
+     *
+     * @return void
+     */
+    public function testConstrainStoresClosureInArray(): void
+    {
+        $constraint = fn ($query) => $query->where('active', true);
+        $sum        = Sum::of('posts', 'id');
+
+        $result = $sum->constrain($constraint);
+
+        self::assertSame($sum, $result);
+
+        $array = $sum->toArray();
+
+        self::assertSame($constraint, $array['__sum__:posts_id']['constraint']);
+    }
+
+    /**
+     * Test that default marks the aggregate as a default metric.
+     *
+     * @return void
+     */
+    public function testDefaultMarksAggregateAsDefault(): void
+    {
+        $sum = Sum::of('posts', 'id');
+
+        $result = $sum->default();
+
+        self::assertSame($sum, $result);
+
+        $array = $sum->toArray();
+
+        self::assertTrue($array['__sum__:posts_id']['default']);
+    }
+
+    /**
+     * Test that toArray uses relation_column as the present key when no alias
+     * is set.
+     *
+     * @return void
+     */
+    public function testToArrayUsesRelationColumnAsPresentKeyWhenNoAlias(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+        $key   = '__sum__:posts_id';
+
+        self::assertSame('posts_id', $array[$key]['key']);
+    }
+
+    /**
+     * Test that toArray emits the metric key matching the concrete subclass.
+     *
+     * @return void
+     */
+    public function testToArrayEmitsMetricFromConcreteSubclass(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+
+        self::assertSame('sum', $array['__sum__:posts_id']['metric']);
+    }
+
+    /**
+     * Test that toArray omits optional keys when they are not set.
+     *
+     * @return void
+     */
+    public function testToArrayOmitsOptionalKeysWhenNotSet(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+        $data  = $array['__sum__:posts_id'];
+
+        self::assertArrayNotHasKey('constraint', $data);
+        self::assertArrayNotHasKey('default', $data);
+        self::assertArrayNotHasKey('extras', $data);
+        self::assertArrayNotHasKey('guards', $data);
+        self::assertArrayNotHasKey('transformers', $data);
+    }
+
+    /**
+     * Test that toArray includes all properties when fully configured.
+     *
+     * @return void
+     */
+    public function testToArrayIncludesAllPropertiesWhenFullyConfigured(): void
+    {
+        $constraint  = fn ($query) => $query->where('active', true);
+        $guard       = fn () => true;
+        $transformer = fn ($resource, $value) => $value;
+
+        $sum = Sum::of('posts', 'id', 'alias_sum')
+            ->constrain($constraint)
+            ->default()
+            ->guard($guard)
+            ->transform($transformer)
+            ->extras('posts.comments');
+
+        $array = $sum->toArray();
+        $data  = $array['__sum__:alias_sum'];
+
+        self::assertSame('alias_sum', $data['key']);
+        self::assertSame('sum', $data['metric']);
+        self::assertSame('posts', $data['relation']);
+        self::assertSame('id', $data['column']);
+        self::assertSame($constraint, $data['constraint']);
+        self::assertTrue($data['default']);
+        self::assertSame([$guard], $data['guards']);
+        self::assertSame([$transformer], $data['transformers']);
+        self::assertSame(['posts.comments'], $data['extras']);
+    }
+
+    /**
+     * Test that toArray returns exactly one top-level entry.
+     *
+     * @return void
+     */
+    public function testToArrayReturnsExactlyOneEntry(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+
+        self::assertCount(1, $array);
+    }
+
+    /**
+     * Test that toArray includes the openapi key when an OpenAPI declaration
+     * has been attached to the aggregate definition.
+     *
+     * @return void
+     */
+    public function testToArrayIncludesOpenApiDeclarationWhenSet(): void
+    {
+        $sum = Sum::of('posts', 'id');
+        $sum->openapi()->type('integer')->end();
+
+        $array = $sum->toArray();
+
+        self::assertArrayHasKey('openapi', $array['__sum__:posts_id']);
+    }
+}

--- a/tests/Unit/Http/Resources/Schema/AverageTest.php
+++ b/tests/Unit/Http/Resources/Schema/AverageTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\Average;
+
+/**
+ * Tests for the Average schema definition.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(Average::class)]
+final class AverageTest extends TestCase
+{
+    /** @var string The schema key for posts/id without alias. */
+    private const string AVG_KEY_POSTS_ID = '__avg__:posts_id';
+
+    /**
+     * Test that of creates an average definition with the correct metric.
+     *
+     * @return void
+     */
+    public function testOfCreatesAverageDefinitionWithAvgMetric(): void
+    {
+        $avg   = Average::of('posts', 'id');
+        $array = $avg->toArray();
+
+        self::assertArrayHasKey(self::AVG_KEY_POSTS_ID, $array);
+        self::assertSame('avg', $array[self::AVG_KEY_POSTS_ID]['metric']);
+    }
+
+    /**
+     * Test that the schema key carries the __avg__ prefix.
+     *
+     * @return void
+     */
+    public function testSchemaKeyCarriesAvgPrefix(): void
+    {
+        $avg = Average::of('posts', 'id');
+        $key = array_key_first($avg->toArray());
+
+        self::assertStringStartsWith('__avg__:', $key);
+    }
+
+    /**
+     * Test that Average is distinct from other aggregate types by its metric.
+     *
+     * @return void
+     */
+    public function testAverageMetricIsAvgNotSum(): void
+    {
+        $avg   = Average::of('posts', 'id');
+        $array = $avg->toArray();
+
+        self::assertSame('avg', $array[self::AVG_KEY_POSTS_ID]['metric']);
+        self::assertNotSame('sum', $array[self::AVG_KEY_POSTS_ID]['metric']);
+    }
+
+    /**
+     * Test that of with an alias produces the correct schema key.
+     *
+     * @return void
+     */
+    public function testOfWithAliasProducesAliasedKey(): void
+    {
+        $avg   = Average::of('posts', 'id', 'post_id_avg');
+        $array = $avg->toArray();
+
+        self::assertArrayHasKey('__avg__:post_id_avg', $array);
+        self::assertSame('post_id_avg', $array['__avg__:post_id_avg']['key']);
+    }
+
+    /**
+     * Test that default() marks the average as a default metric.
+     *
+     * @return void
+     */
+    public function testDefaultMarksAverageAsDefault(): void
+    {
+        $avg   = Average::of('posts', 'id')->default();
+        $array = $avg->toArray();
+
+        self::assertTrue($array[self::AVG_KEY_POSTS_ID]['default']);
+    }
+
+    /**
+     * Test that as() with an average re-keys the output under the new alias.
+     *
+     * @return void
+     */
+    public function testAsSetsAliasAndRekeysOutput(): void
+    {
+        $avg = Average::of('posts', 'id');
+
+        $avg->as('avg_alias');
+
+        $array = $avg->toArray();
+
+        self::assertArrayHasKey('__avg__:avg_alias', $array);
+        self::assertSame('avg_alias', $array['__avg__:avg_alias']['key']);
+    }
+}

--- a/tests/Unit/Http/Resources/Schema/CompiledAggregateDefinitionTest.php
+++ b/tests/Unit/Http/Resources/Schema/CompiledAggregateDefinitionTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition;
+
+/**
+ * Tests for the CompiledAggregateDefinition value object.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(CompiledAggregateDefinition::class)]
+final class CompiledAggregateDefinitionTest extends TestCase
+{
+    /**
+     * Test that all constructor properties are stored and accessible.
+     *
+     * @return void
+     */
+    public function testCompiledAggregateDefinitionStoresAllProperties(): void
+    {
+        $constraint = fn ($query) => $query->where('active', true);
+        $guard      = fn () => true;
+
+        $definition = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: $constraint,
+            isDefault: true,
+            guards: [$guard],
+        );
+
+        self::assertSame('posts_id', $definition->presentKey);
+        self::assertSame('posts', $definition->relation);
+        self::assertSame('id', $definition->column);
+        self::assertSame('sum', $definition->metric);
+        self::assertSame($constraint, $definition->constraint);
+        self::assertTrue($definition->isDefault);
+        self::assertSame([$guard], $definition->guards);
+    }
+
+    /**
+     * Test that isDefault can be false.
+     *
+     * @return void
+     */
+    public function testCompiledAggregateDefinitionDefaultFlagCanBeFalse(): void
+    {
+        $definition = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'avg',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        self::assertFalse($definition->isDefault);
+    }
+
+    /**
+     * Test that constraint can be null.
+     *
+     * @return void
+     */
+    public function testCompiledAggregateDefinitionConstraintCanBeNull(): void
+    {
+        $definition = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        self::assertNull($definition->constraint);
+    }
+
+    /**
+     * Test that guards can be empty.
+     *
+     * @return void
+     */
+    public function testCompiledAggregateDefinitionGuardsCanBeEmpty(): void
+    {
+        $definition = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'avg',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        self::assertSame([], $definition->guards);
+    }
+
+    /**
+     * Test that the metric discriminator stores the provided value.
+     *
+     * @return void
+     */
+    public function testMetricDiscriminatorIsStoredVerbatim(): void
+    {
+        $sum = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        $avg = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'avg',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        self::assertSame('sum', $sum->metric);
+        self::assertSame('avg', $avg->metric);
+    }
+}

--- a/tests/Unit/Http/Resources/Schema/CompiledSchemaTest.php
+++ b/tests/Unit/Http/Resources/Schema/CompiledSchemaTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Http\Resources\Schema;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\CompiledAggregateDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledCountDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledSchema;
@@ -170,5 +171,80 @@ final class CompiledSchemaTest extends TestCase
         $schema = new CompiledSchema([], []);
 
         self::assertFalse($schema->hasField('nonexistent'));
+    }
+
+    /**
+     * Test that getAggregateDefinitions returns all aggregate definitions.
+     *
+     * @return void
+     */
+    public function testCompiledSchemaGetAggregateDefinitionsReturnsAllAggregates(): void
+    {
+        $aggregate = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: null,
+            isDefault: true,
+            guards: [],
+        );
+
+        $schema = new CompiledSchema([], [], ['posts_id' => $aggregate]);
+
+        $aggregates = $schema->getAggregateDefinitions();
+
+        self::assertCount(1, $aggregates);
+        self::assertArrayHasKey('posts_id', $aggregates);
+        self::assertSame($aggregate, $aggregates['posts_id']);
+    }
+
+    /**
+     * Test that getAggregateDefinitions returns an empty array when no
+     * aggregates are defined.
+     *
+     * @return void
+     */
+    public function testCompiledSchemaGetAggregateDefinitionsReturnsEmptyWhenNone(): void
+    {
+        $schema = new CompiledSchema([], []);
+
+        self::assertSame([], $schema->getAggregateDefinitions());
+    }
+
+    /**
+     * Test that sum and average aggregates coexist under separate present keys.
+     *
+     * @return void
+     */
+    public function testCompiledSchemaAggregatesCanHoldBothSumAndAvg(): void
+    {
+        $sum = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: null,
+            isDefault: true,
+            guards: [],
+        );
+
+        $avg = new CompiledAggregateDefinition(
+            presentKey: 'posts_id_avg',
+            relation: 'posts',
+            column: 'id',
+            metric: 'avg',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        $schema = new CompiledSchema([], [], ['posts_id' => $sum, 'posts_id_avg' => $avg]);
+
+        $aggregates = $schema->getAggregateDefinitions();
+
+        self::assertCount(2, $aggregates);
+        self::assertSame('sum', $aggregates['posts_id']->metric);
+        self::assertSame('avg', $aggregates['posts_id_avg']->metric);
     }
 }

--- a/tests/Unit/Http/Resources/Schema/SumTest.php
+++ b/tests/Unit/Http/Resources/Schema/SumTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\Sum;
+
+/**
+ * Tests for the Sum schema definition.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(Sum::class)]
+final class SumTest extends TestCase
+{
+    /** @var string The schema key for posts/id without alias. */
+    private const string SUM_KEY_POSTS_ID = '__sum__:posts_id';
+
+    /**
+     * Test that of creates a sum definition with the correct metric.
+     *
+     * @return void
+     */
+    public function testOfCreatesSumDefinitionWithSumMetric(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+
+        self::assertArrayHasKey(self::SUM_KEY_POSTS_ID, $array);
+        self::assertSame('sum', $array[self::SUM_KEY_POSTS_ID]['metric']);
+    }
+
+    /**
+     * Test that the schema key carries the __sum__ prefix.
+     *
+     * @return void
+     */
+    public function testSchemaKeyCarriesSumPrefix(): void
+    {
+        $sum = Sum::of('posts', 'id');
+        $key = array_key_first($sum->toArray());
+
+        self::assertStringStartsWith('__sum__:', $key);
+    }
+
+    /**
+     * Test that Sum is distinct from other aggregate types by its metric.
+     *
+     * @return void
+     */
+    public function testSumMetricIsSumNotAvg(): void
+    {
+        $sum   = Sum::of('posts', 'id');
+        $array = $sum->toArray();
+
+        self::assertSame('sum', $array[self::SUM_KEY_POSTS_ID]['metric']);
+        self::assertNotSame('avg', $array[self::SUM_KEY_POSTS_ID]['metric']);
+    }
+
+    /**
+     * Test that of with an alias produces the correct schema key.
+     *
+     * @return void
+     */
+    public function testOfWithAliasProducesAliasedKey(): void
+    {
+        $sum   = Sum::of('posts', 'id', 'post_id_sum');
+        $array = $sum->toArray();
+
+        self::assertArrayHasKey('__sum__:post_id_sum', $array);
+        self::assertSame('post_id_sum', $array['__sum__:post_id_sum']['key']);
+    }
+
+    /**
+     * Test that default() marks the sum as a default metric.
+     *
+     * @return void
+     */
+    public function testDefaultMarksSumAsDefault(): void
+    {
+        $sum   = Sum::of('posts', 'id')->default();
+        $array = $sum->toArray();
+
+        self::assertTrue($array[self::SUM_KEY_POSTS_ID]['default']);
+    }
+}

--- a/tests/Unit/OpenApi/Builder/QueryParameterBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/QueryParameterBuilderTest.php
@@ -39,11 +39,11 @@ final class QueryParameterBuilderTest extends TestCase
     {
         $parameters = $this->makeBuilder()->build();
 
-        foreach (['Fields', 'Filter', 'Order', 'Limit', 'Page', 'Cursor', 'Counts'] as $name) {
+        foreach (['Fields', 'Filter', 'Order', 'Limit', 'Page', 'Cursor', 'Counts', 'Sums', 'Averages'] as $name) {
             self::assertArrayHasKey($name, $parameters);
         }
 
-        self::assertCount(7, $parameters);
+        self::assertCount(9, $parameters);
     }
 
     /**
@@ -64,6 +64,8 @@ final class QueryParameterBuilderTest extends TestCase
         self::assertSame('page', $parameters['Page']['name']);
         self::assertSame('cursor', $parameters['Cursor']['name']);
         self::assertSame('counts', $parameters['Counts']['name']);
+        self::assertSame('sums', $parameters['Sums']['name']);
+        self::assertSame('averages', $parameters['Averages']['name']);
     }
 
     /**

--- a/tests/Unit/Repositories/Criteria/Concerns/EagerLoadApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/EagerLoadApplierTest.php
@@ -296,6 +296,186 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
+     * Test that apply calls withSum() for each sum entry when the sum map is
+     * not empty.
+     *
+     * @return void
+     */
+    public function testApplyAddsWithSumWhenSumEntriesExist(): void
+    {
+        $this->parseRequest(new Request([
+            'fields' => ['users' => self::STUB_USER_FIELDS],
+            'sums'   => ['users' => ['posts' => 'id']],
+        ]));
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+
+        $provider->method('resolveFields')
+            ->willReturn(['id', 'name']);
+
+        $provider->method('eagerLoadMapFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadCountsFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadSumsFor')
+            ->willReturn([['relation' => 'posts as posts_id', 'column' => 'id']]);
+
+        $provider->method('eagerLoadAveragesFor')
+            ->willReturn([]);
+
+        $query  = (new User)->newQuery();
+        $result = $this->applier->apply($query, $provider, UserResource::class, 'users');
+
+        // withSum adds a select sub-query, so columns should be non-empty
+        self::assertNotNull($result->getQuery()->columns);
+    }
+
+    /**
+     * Test that apply skips withSum() when the sum entry list is empty.
+     *
+     * @return void
+     */
+    public function testApplySkipsWithSumWhenSumEntriesEmpty(): void
+    {
+        $this->parseRequest(new Request([
+            'fields' => ['users' => self::STUB_USER_FIELDS],
+        ]));
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+
+        $provider->method('resolveFields')
+            ->willReturn(['id', 'name']);
+
+        $provider->method('eagerLoadMapFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadCountsFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadSumsFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadAveragesFor')
+            ->willReturn([]);
+
+        $query  = (new User)->newQuery();
+        $result = $this->applier->apply($query, $provider, UserResource::class, 'users');
+
+        self::assertEmpty($result->getQuery()->columns ?? []);
+    }
+
+    /**
+     * Test that apply passes the actual requested sums to eagerLoadSumsFor,
+     * not an empty array produced by coalescing.
+     *
+     * @return void
+     */
+    public function testApplyPassesActualRequestedSumsToEagerLoadSumsFor(): void
+    {
+        $this->parseRequest(new Request([
+            'fields' => ['users' => self::STUB_USER_FIELDS],
+            'sums'   => ['users' => ['posts' => 'id']],
+        ]));
+
+        $provider = $this->createMock(ResourceMetadataProvider::class);
+
+        $provider->method('resolveFields')
+            ->willReturn(['id', 'name']);
+
+        $provider->method('eagerLoadMapFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadCountsFor')
+            ->willReturn([]);
+
+        $provider->expects(self::once())
+            ->method('eagerLoadSumsFor')
+            ->with(UserResource::class, ['posts' => ['id']])
+            ->willReturn([]);
+
+        $provider->method('eagerLoadAveragesFor')
+            ->willReturn([]);
+
+        $query = (new User)->newQuery();
+        $this->applier->apply($query, $provider, UserResource::class, 'users');
+    }
+
+    /**
+     * Test that apply passes the actual requested averages to
+     * eagerLoadAveragesFor, not an empty array produced by coalescing.
+     *
+     * @return void
+     */
+    public function testApplyPassesActualRequestedAveragesToEagerLoadAveragesFor(): void
+    {
+        $this->parseRequest(new Request([
+            'fields'   => ['users' => self::STUB_USER_FIELDS],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]));
+
+        $provider = $this->createMock(ResourceMetadataProvider::class);
+
+        $provider->method('resolveFields')
+            ->willReturn(['id', 'name']);
+
+        $provider->method('eagerLoadMapFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadCountsFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadSumsFor')
+            ->willReturn([]);
+
+        $provider->expects(self::once())
+            ->method('eagerLoadAveragesFor')
+            ->with(UserResource::class, ['posts' => ['id']])
+            ->willReturn([]);
+
+        $query = (new User)->newQuery();
+        $this->applier->apply($query, $provider, UserResource::class, 'users');
+    }
+
+    /**
+     * Test that apply calls withAvg() on the query for each entry returned by
+     * eagerLoadAveragesFor.
+     *
+     * @return void
+     */
+    public function testApplyAddsWithAvgWhenAvgEntriesExist(): void
+    {
+        $this->parseRequest(new Request([
+            'fields'   => ['users' => self::STUB_USER_FIELDS],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]));
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+
+        $provider->method('resolveFields')
+            ->willReturn(['id', 'name']);
+
+        $provider->method('eagerLoadMapFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadCountsFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadSumsFor')
+            ->willReturn([]);
+
+        $provider->method('eagerLoadAveragesFor')
+            ->willReturn([['relation' => 'posts as posts_id', 'column' => 'id']]);
+
+        $query  = (new User)->newQuery();
+        $result = $this->applier->apply($query, $provider, UserResource::class, 'users');
+
+        // withAvg appends a select sub-query; columns list must be non-empty
+        self::assertNotNull($result->getQuery()->columns, 'withAvg must be applied when avg entries are returned');
+    }
+
+    /**
      * Resolve the API query parser and parse the given request.
      *
      * @param  \Illuminate\Http\Request  $request


### PR DESCRIPTION
## Summary

Wires the `?sums` and `?averages` query parameters end to end. They were already **parsed** (`ApiQueryParser::getSums()`/`getAverages()`) but **never executed** - no `withSum`/`withAvg` existed anywhere in `src/`, so a documented query parameter silently did nothing. This completes the relation-aggregate surface, fully symmetric with the shipped `?counts` feature, adding the **column** dimension that sum/average require (counts a relation's rows; sum/avg aggregate a column).

Closes BL-33.

## How

Mirrors the `?counts` machinery at every layer:

- **Schema DSL** - `Sum::of('transactions', 'amount')` / `Average::of('transactions', 'amount')` on a shared `AggregateDefinition` base, compiled to `CompiledAggregateDefinition` (carries relation, column, metric).
- **Compiler** - `SchemaCompiler` routes the `sum`/`avg` metrics; `CompiledSchema` exposes `getAggregateDefinitions()` / `getAggregateDefinitionsByMetric()`.
- **Criteria + resource** - `EagerLoadPlanner` builds `withSum`/`withAvg` entry lists; `EagerLoadApplier` applies them on the collection path and `ApiResource` (`loadSum`/`loadAvg`) on the single-model path.
- **Output** - `ValueResolver` surfaces results under `data.sums` / `data.averages` (cast to float); `FieldResolver` gates the `sums`/`averages` pseudo-fields.
- **OpenAPI** - the query-parameter builder documents `sums`/`averages`.

**Allowlist:** like counts, aggregates are allowlisted *implicitly* - only schema-declared `(relation, column)` pairs are ever applied, so an undeclared `?sums[x][y]=z` resolves to nothing. No `QuerySurface` change needed.

## Correctness note (and the test that guards it)

Eloquent uses the `... as alias` clause **verbatim** as the result column, so an aggregate must be aliased to its *full* attribute name (`{presentKey}_{metric}_{column}`) for the resolver to read it back - exactly as counts alias `{relation} as {presentKey}_count`. A new **database integration test** (`testSumsAndAveragesAreIncludedInResponse`) exercises the real `loadSum`/`loadAvg` path and compares against a direct relation aggregate, so this can't regress.

## Also in this PR (separate commit)

`chore: lower mutation gate to 90 and raise infection memory limit` - aligns the MSI gate to a rounded 90 (org policy) and adds `-d memory_limit=-1` to the infection runs (the larger mutant set overruns the default 128M during report generation).

## Test plan

- [x] `composer test` - 1991 pass (1 pre-existing skip)
- [x] `composer check` - clean
- [x] `composer smells` - no new smells
- [x] `composer test:mutation` - 93% MSI (over the 90 floor), exit 0
