### PR TITLE
perf: warn about unbounded metadata-memo growth when lifecycle flush is disabled [BL-27]

### DIFF
--- a/src/Providers/Registrars/LifecycleRegistrar.php
+++ b/src/Providers/Registrars/LifecycleRegistrar.php
@@ -95,7 +95,11 @@ final class LifecycleRegistrar
         $runtime = app(RuntimeContext::class);
 
         if ($runtime->isServingUnderOctane() && !(bool) Config::get('api-toolkit.lifecycle.octane')) {
-            Log::info('API Toolkit: serving under Octane but the lifecycle cache flush is disabled (API_TOOLKIT_LIFECYCLE_OCTANE=false); cross-request metadata may go stale.');
+            Log::info(
+                'API Toolkit: serving under Octane but the lifecycle cache flush is disabled'
+                . ' (API_TOOLKIT_LIFECYCLE_OCTANE=false); cross-request metadata may go stale'
+                . ' and field-keyed metadata memos can grow unbounded per worker (memory tradeoff).',
+            );
         }
 
         if (!$runtime->isServingAsQueueWorker() || (bool) Config::get('api-toolkit.lifecycle.queue')) {

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -98,7 +98,9 @@ final class LifecycleRegistrarTest extends TestCase
         $config->set('api-toolkit.lifecycle.octane', false);
 
         Log::shouldReceive('info')->once()->with(\Mockery::on(
-            fn (string $message): bool => str_contains($message, 'Octane') && str_contains($message, 'API_TOOLKIT_LIFECYCLE_OCTANE'),
+            fn (string $message): bool => str_contains($message, 'Octane')
+                && str_contains($message, 'API_TOOLKIT_LIFECYCLE_OCTANE')
+                && str_contains($message, 'unbounded'),
         ));
 
         (new LifecycleRegistrar)->register();


### PR DESCRIPTION
Extends the Octane lifecycle-flush off-state diagnostic to also warn that the field-keyed metadata memos can grow unbounded per worker when the flush is disabled (a memory tradeoff, not only a freshness one).

Gates: check clean, test green, mutation 93%.

Reviewed: per-item adversarial review (overnight) + /build:review specialist pass (security / architecture / silent-failure) - no blocking findings.