### PR TITLE
refactor: make notification logging optional via class_exists gate [BL-29]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php": "^8.3",
         "illuminate/database": "^12.0",
         "illuminate/http": "^12.0",
-        "illuminate/notifications": "^12.0",
         "illuminate/routing": "^12.0",
         "illuminate/support": "^12.9",
         "illuminate/validation": "^12.0",
@@ -29,6 +28,7 @@
         "sinemacula/laravel-resource-exporter": "^2.0"
     },
     "suggest": {
+        "illuminate/notifications": "Required only for notification-event logging",
         "sinemacula/laravel-log-cloudwatch": "CloudWatch log driver (Monolog), extracted from this package",
         "sinemacula/laravel-log-database": "Database log driver (Monolog), extracted from this package",
         "sinemacula/laravel-sse": "Server-sent event streaming for controllers, extracted from this package"

--- a/src/Providers/Registrars/LoggingRegistrar.php
+++ b/src/Providers/Registrars/LoggingRegistrar.php
@@ -13,7 +13,8 @@ use SineMacula\ApiToolkit\Listeners\NotificationListener;
 /**
  * Registers the toolkit notification logging functionality.
  *
- * Wires the notification logging listeners when enabled.
+ * Wires the notification logging listeners when enabled and when the
+ * illuminate/notifications package is installed.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -33,11 +34,18 @@ final class LoggingRegistrar
     /**
      * Register the notification logging functionality.
      *
+     * Skipped when notification logging is disabled or when
+     * illuminate/notifications is not installed.
+     *
      * @return void
      */
     private function registerNotificationLogging(): void
     {
         if (!Config::get('api-toolkit.notifications.enable_logging', true)) {
+            return;
+        }
+
+        if (!class_exists(NotificationSending::class)) {
             return;
         }
 

--- a/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
@@ -29,7 +29,8 @@ final class LoggingRegistrarTest extends TestCase
 {
     /**
      * Test that the notification logging listeners are registered when the
-     * registrar is invoked with logging enabled.
+     * registrar is invoked with logging enabled and illuminate/notifications
+     * is installed (class_exists guard traversed successfully).
      *
      * @return void
      */
@@ -37,10 +38,14 @@ final class LoggingRegistrarTest extends TestCase
     {
         $app = $this->getApplication();
 
-        /** @var \Illuminate\Contracts\Config\Repository $config */
+        /** @var \Illuminate\Config\Repository $config */
         $config = $app->make('config');
 
         $config->set('api-toolkit.notifications.enable_logging', true);
+
+        // illuminate/notifications is present via testbench, so class_exists
+        // returns true and the listeners must be wired.
+        self::assertTrue(class_exists(NotificationSending::class), 'Prerequisite: illuminate/notifications must be present for this assertion to hold');
 
         (new LoggingRegistrar)->register();
 
@@ -51,6 +56,32 @@ final class LoggingRegistrarTest extends TestCase
 
         self::assertContains([NotificationListener::class, 'sending'], $raw[NotificationSending::class] ?? []);
         self::assertContains([NotificationListener::class, 'sent'], $raw[NotificationSent::class] ?? []);
+    }
+
+    /**
+     * Test that no notification logging listeners are registered when logging
+     * is explicitly disabled in configuration.
+     *
+     * @return void
+     */
+    public function testRegisterSkipsNotificationLoggingListenersWhenDisabled(): void
+    {
+        $app = $this->getApplication();
+
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $app->make('config');
+
+        $config->set('api-toolkit.notifications.enable_logging', false);
+
+        (new LoggingRegistrar)->register();
+
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $app->make('events');
+
+        $raw = $events->getRawListeners();
+
+        self::assertNotContains([NotificationListener::class, 'sending'], $raw[NotificationSending::class] ?? []);
+        self::assertNotContains([NotificationListener::class, 'sent'], $raw[NotificationSent::class] ?? []);
     }
 
     /**


### PR DESCRIPTION
Moves `illuminate/notifications` from require to suggest and soft-gates the notification-logging listeners behind `class_exists`, so the toolkit no longer hard-requires the component for an optional observability feature.

Note: UPGRADE.md migration note to be added at the release cut.

Gates: check clean, test green, mutation 94%.

Reviewed: per-item adversarial review (overnight) + /build:review specialist pass (security / architecture / silent-failure) - no blocking findings.