### PR TITLE
feat: enforce declared filterable set on nested relation columns [BL-32]

### DIFF
--- a/src/Repositories/Criteria/ApiCriteria.php
+++ b/src/Repositories/Criteria/ApiCriteria.php
@@ -204,8 +204,9 @@ final class ApiCriteria implements CriteriaInterface
             ? SchemaCompiler::compile($resource)
             : null;
 
-        $posture = Config::get('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_ALLOWLIST);
-        $reject  = Config::get('api-toolkit.repositories.reject_undeclared', true);
+        $posture     = Config::get('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_ALLOWLIST);
+        $reject      = Config::get('api-toolkit.repositories.reject_undeclared', true);
+        $resourceMap = Config::get('api-toolkit.resources.resource_map', []);
 
         return new QuerySurface(
             $schema?->getFilterableColumns()    ?? [],
@@ -215,6 +216,7 @@ final class ApiCriteria implements CriteriaInterface
             (bool) $reject,
             $this->schemaIntrospector,
             $model,
+            is_array($resourceMap) ? $resourceMap : [],
         );
     }
 }

--- a/src/Repositories/Criteria/QuerySurface.php
+++ b/src/Repositories/Criteria/QuerySurface.php
@@ -6,7 +6,9 @@ namespace SineMacula\ApiToolkit\Repositories\Criteria;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
+use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 
 /**
  * Per-query enforcement policy for a resource's declared query surface.
@@ -21,10 +23,11 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
  * allowlist posture rejects every root key - secure by default.
  *
  * Keys that target a nested/related model (within a declared-traversable
- * relation) fall back to the legacy searchable predicate on that related model:
- * the top-level relation allowlist is the P0 worker, and per-related-resource
- * nested-column granularity is deferred (BL-20 P2). The relation gate still
- * governs which relations may be traversed at all.
+ * relation) are gated against that related model's resource schema under the
+ * allowlist posture. When no mapped resource exists for a related model the
+ * gate fails closed (rejects), matching the root secure-by-default behaviour.
+ * Under the blocklist posture the legacy searchable predicate still applies for
+ * related models. The relation-traversal gate (permitsRelation) is unchanged.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -47,6 +50,7 @@ final readonly class QuerySurface
      * @param  bool  $rejectUndeclared
      * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider  $introspector
      * @param  \Illuminate\Database\Eloquent\Model  $rootModel
+     * @param  array<string, string>  $resourceMap
      */
     public function __construct(
 
@@ -70,12 +74,15 @@ final readonly class QuerySurface
 
         /** The root query's Eloquent model instance. */
         private Model $rootModel,
+
+        /** Resource map used to resolve related model resource classes. */
+        private array $resourceMap = [],
     ) {}
 
     /**
      * Guard a filter column on the given model, returning whether it may be
-     * applied and throwing on an undeclared root key under the fail-closed
-     * allowlist posture.
+     * applied and throwing on an undeclared key under the fail-closed allowlist
+     * posture.
      *
      * @param  string  $column
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -85,7 +92,13 @@ final readonly class QuerySurface
      */
     public function guardFilter(string $column, Model $model): bool
     {
-        return $this->guard($this->permitsFilter($column, $model), 'filters', $column, $model);
+        return $this->guard(
+            $this->permitsFilter($column, $model),
+            'filters',
+            $column,
+            $model,
+            $this->posture === self::POSTURE_ALLOWLIST,
+        );
     }
 
     /**
@@ -99,7 +112,13 @@ final readonly class QuerySurface
      */
     public function guardSort(string $column, Model $model): bool
     {
-        return $this->guard($this->permitsSort($column, $model), 'order', $column, $model);
+        return $this->guard(
+            $this->permitsSort($column, $model),
+            'order',
+            $column,
+            $model,
+            $this->posture === self::POSTURE_ALLOWLIST,
+        );
     }
 
     /**
@@ -125,9 +144,15 @@ final readonly class QuerySurface
      */
     private function permitsFilter(string $column, Model $model): bool
     {
-        return $this->governsRoot($model)
-            ? in_array($column, $this->filterableColumns, true)
-            : $this->introspector->isSearchable($model, $column);
+        if ($this->governsRoot($model)) {
+            return in_array($column, $this->filterableColumns, true);
+        }
+
+        if ($this->posture === self::POSTURE_ALLOWLIST) {
+            return $this->permitsRelatedColumn($column, $model, true);
+        }
+
+        return $this->introspector->isSearchable($model, $column);
     }
 
     /**
@@ -139,9 +164,15 @@ final readonly class QuerySurface
      */
     private function permitsSort(string $column, Model $model): bool
     {
-        return $this->governsRoot($model)
-            ? in_array($column, $this->sortableColumns, true)
-            : $this->introspector->isSearchable($model, $column);
+        if ($this->governsRoot($model)) {
+            return in_array($column, $this->sortableColumns, true);
+        }
+
+        if ($this->posture === self::POSTURE_ALLOWLIST) {
+            return $this->permitsRelatedColumn($column, $model, false);
+        }
+
+        return $this->introspector->isSearchable($model, $column);
     }
 
     /**
@@ -159,6 +190,33 @@ final readonly class QuerySurface
     }
 
     /**
+     * Determine whether the column is permitted on a related (non-root) model
+     * under the allowlist posture by checking the related resource's declared
+     * filterable or sortable set.
+     *
+     * When no resource is mapped for the related model the gate fails closed,
+     * matching the root secure-by-default behaviour.
+     *
+     * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  bool  $filterable
+     * @return bool
+     */
+    private function permitsRelatedColumn(string $column, Model $model, bool $filterable): bool
+    {
+        $resourceClass = $this->resourceMap[$model::class] ?? null;
+
+        if ($resourceClass === null || !is_subclass_of($resourceClass, ApiResourceInterface::class)) {
+            return false;
+        }
+
+        $schema  = SchemaCompiler::compile($resourceClass);
+        $columns = $filterable ? $schema->getFilterableColumns() : $schema->getSortableColumns();
+
+        return in_array($column, $columns, true);
+    }
+
+    /**
      * Determine whether the declared allowlist governs the given model - i.e.
      * the allowlist posture is in force and the model is the root model.
      *
@@ -171,24 +229,28 @@ final readonly class QuerySurface
     }
 
     /**
-     * Resolve a permission result into an apply/skip decision, rejecting an
-     * undeclared root key when fail-closed under the allowlist posture.
+     * Resolve a permission result into an apply/skip decision.
+     *
+     * Rejects with a named ValidationException when fail-closed and the active
+     * posture covers the given model: root keys under allowlist, or any key
+     * under allowlist when rejectForAllowlist is true.
      *
      * @param  bool  $permitted
      * @param  string  $parameter
      * @param  string  $key
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  bool  $rejectForAllowlist
      * @return bool
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    private function guard(bool $permitted, string $parameter, string $key, Model $model): bool
+    private function guard(bool $permitted, string $parameter, string $key, Model $model, bool $rejectForAllowlist = false): bool
     {
         if ($permitted) {
             return true;
         }
 
-        if ($this->rejectUndeclared && $this->governsRoot($model)) {
+        if ($this->rejectUndeclared && ($this->governsRoot($model) || $rejectForAllowlist)) {
             throw ValidationException::withMessages([$parameter . '.' . $key => sprintf('The "%s" key is not a permitted query parameter for this resource.', $key)]);
         }
 

--- a/tests/Fixtures/Resources/PostResource.php
+++ b/tests/Fixtures/Resources/PostResource.php
@@ -33,7 +33,7 @@ final class PostResource extends ApiResource
     {
         return Field::set(
             Field::scalar('id'),
-            Field::scalar('title'),
+            Field::scalar('title')->filterable(),
             Field::scalar('body'),
             Field::scalar('published'),
             Field::timestamp('created_at'),

--- a/tests/Integration/QuerySurfaceIntegrationTest.php
+++ b/tests/Integration/QuerySurfaceIntegrationTest.php
@@ -17,6 +17,7 @@ use SineMacula\Http\Enums\HttpMethod;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\Fixtures\Resources\PostResource;
 use Tests\TestCase;
 
 /**
@@ -25,8 +26,11 @@ use Tests\TestCase;
  * Exercises the secure-by-default posture against a real database: declared
  * filterable/sortable columns and traversable relations are applied, while
  * undeclared keys on the root resource are rejected (fail-closed) or dropped
- * (fail-quiet). Nested columns on a traversed relation fall back to the legacy
- * searchable predicate, and a model with no mapped resource rejects every key.
+ * (fail-quiet). Under the allowlist posture, nested columns on a traversed
+ * relation are gated against the related resource's declared filterable set -
+ * not against the legacy isSearchable predicate. When no mapped resource exists
+ * for a related model the gate fails closed. A model with no mapped resource
+ * rejects every key.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -40,7 +44,8 @@ use Tests\TestCase;
 final class QuerySurfaceIntegrationTest extends TestCase
 {
     /**
-     * Seed users and posts for integration tests.
+     * Seed users and posts for integration tests, and configure the resource
+     * map so related-model column gating can resolve Post to PostResource.
      *
      * @return void
      */
@@ -48,6 +53,10 @@ final class QuerySurfaceIntegrationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        Config::set('api-toolkit.resources.resource_map', [
+            Post::class => PostResource::class,
+        ]);
 
         $this->seedData();
     }
@@ -169,13 +178,15 @@ final class QuerySurfaceIntegrationTest extends TestCase
     }
 
     /**
-     * A column on a declared-traversable relation falls back to the legacy
-     * searchable predicate on the related model, so nested filters still work
-     * without a per-relation column declaration.
+     * Under the allowlist posture a column declared filterable in the related
+     * resource's schema is permitted and the SQL constraint is applied.
+     *
+     * PostResource declares 'title' as filterable; filtering posts.title must
+     * return only the user whose post title matches.
      *
      * @return void
      */
-    public function testNestedRelationColumnFallsBackToLegacySearchable(): void
+    public function testDeclaredNestedRelationColumnIsPermittedUnderAllowlist(): void
     {
         $this->parseQuery(['filters' => json_encode([
             'posts' => [
@@ -191,6 +202,31 @@ final class QuerySurfaceIntegrationTest extends TestCase
         $first = $results->first();
 
         self::assertSame('Alice', $first->name);
+    }
+
+    /**
+     * Under the allowlist posture a column that is NOT declared filterable in
+     * the related resource's schema is rejected with a ValidationException.
+     *
+     * PostResource does not declare 'body' as filterable, so filtering on
+     * posts.body must throw.
+     *
+     * @return void
+     */
+    public function testUndeclaredNestedRelationColumnIsRejectedUnderAllowlist(): void
+    {
+        $this->parseQuery(['filters' => json_encode([
+            'posts' => [
+                'body' => 'Content',
+            ],
+        ])]);
+
+        try {
+            $this->declaredCriteria()->apply(new User);
+            self::fail('Expected a ValidationException for undeclared nested column "body".');
+        } catch (ValidationException $e) {
+            self::assertArrayHasKey('filters.body', $e->errors());
+        }
     }
 
     /**
@@ -224,7 +260,7 @@ final class QuerySurfaceIntegrationTest extends TestCase
 
         $this->expectException(ValidationException::class);
 
-        // No usingResource() and no resource_map entry: the surface is empty.
+        // No usingResource() and no resource_map entry for User: surface empty.
         $this->makeCriteria()->apply(new User);
     }
 

--- a/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
+++ b/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
@@ -10,6 +10,7 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\PostResource;
 use Tests\TestCase;
 
 /**
@@ -87,42 +88,129 @@ final class QuerySurfaceTest extends TestCase
     }
 
     /**
-     * Test that a key targeting a nested/related model falls back to the legacy
-     * searchable predicate rather than the root allowlist, and is never
-     * rejected (nested-column granularity is deferred to P2).
+     * Test that under the allowlist posture, a column declared filterable in
+     * the related model's mapped resource is permitted.
+     *
+     * PostResource declares 'title' as filterable, so it must pass.
      *
      * @return void
      */
-    public function testNestedRelatedModelFallsBackToLegacySearchable(): void
+    public function testAllowlistPermitsDeclaredFilterableColumnOnRelatedModel(): void
     {
-        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
-        $introspector->shouldReceive('isSearchable')->with(\Mockery::type(Post::class), 'title')->andReturnTrue();
-        $introspector->shouldReceive('isSearchable')->with(\Mockery::type(Post::class), 'secret')->andReturnFalse();
-
-        $surface = $this->make(filterable: ['email'], introspector: $introspector);
+        $surface = $this->make(
+            filterable: ['email'],
+            resourceMap: [Post::class => PostResource::class],
+        );
 
         self::assertTrue($surface->guardFilter('title', new Post));
+    }
+
+    /**
+     * Test that under the allowlist posture, a column NOT declared in the
+     * related model's resource filterable set is rejected with a
+     * ValidationException.
+     *
+     * @return void
+     */
+    public function testAllowlistRejectsUndeclaredFilterableColumnOnRelatedModel(): void
+    {
+        $surface = $this->make(
+            filterable: ['email'],
+            resourceMap: [Post::class => PostResource::class],
+        );
+
+        $this->assertRejects(fn () => $surface->guardFilter('secret', new Post), 'filters.secret');
+    }
+
+    /**
+     * Test that under the allowlist posture, a column that is filterable but
+     * not sortable in the related resource is rejected for ordering, confirming
+     * the two sets are enforced independently.
+     *
+     * @return void
+     */
+    public function testAllowlistRejectsUnsortableColumnOnRelatedModel(): void
+    {
+        $surface = $this->make(
+            resourceMap: [Post::class => PostResource::class],
+        );
+
+        // PostResource declares 'title' filterable but NOT sortable.
+        $this->assertRejects(fn () => $surface->guardSort('title', new Post), 'order.title');
+    }
+
+    /**
+     * Test that under the allowlist posture a related model with no entry in
+     * the resource map fails closed: every column is rejected.
+     *
+     * @return void
+     */
+    public function testAllowlistFailsClosedWhenRelatedModelHasNoMappedResource(): void
+    {
+        // Empty resource map - Post is not mapped.
+        $surface = $this->make(filterable: ['email']);
+
+        $this->assertRejects(fn () => $surface->guardFilter('title', new Post), 'filters.title');
+    }
+
+    /**
+     * Test that fail-quiet silently drops an undeclared related-model column
+     * without throwing, even under the allowlist posture.
+     *
+     * @return void
+     */
+    public function testFailQuietDropsUndeclaredRelatedColumnWithoutThrowing(): void
+    {
+        $surface = $this->make(
+            filterable: ['email'],
+            reject: false,
+            resourceMap: [Post::class => PostResource::class],
+        );
+
         self::assertFalse($surface->guardFilter('secret', new Post));
     }
 
     /**
-     * Test that the blocklist posture delegates to the schema introspector and
-     * drops (rather than rejects) an unsearchable key.
+     * Test that the blocklist posture delegates to the schema introspector for
+     * related models and drops (rather than rejects) an unsearchable key.
      *
      * @return void
      */
     public function testBlocklistDelegatesToIntrospectorAndDropsUnsearchable(): void
     {
         $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
-        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'email')->andReturnTrue();
-        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'secret')->andReturnFalse();
-        $introspector->shouldReceive('isRelation')->with('posts', \Mockery::any())->andReturnTrue();
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'email')->andReturnTrue(); // @phpstan-ignore method.notFound
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'secret')->andReturnFalse(); // @phpstan-ignore method.notFound
+        $introspector->shouldReceive('isRelation')->with('posts', \Mockery::any())->andReturnTrue(); // @phpstan-ignore method.notFound
 
         $surface = $this->make(posture: QuerySurface::POSTURE_BLOCKLIST, introspector: $introspector);
 
         self::assertTrue($surface->guardFilter('email', new User));
         self::assertTrue($surface->guardRelation('posts', new User));
         self::assertFalse($surface->guardFilter('secret', new User));
+    }
+
+    /**
+     * Test that the blocklist posture still delegates related-model column
+     * checks to isSearchable, not to the resource schema.
+     *
+     * @return void
+     */
+    public function testBlocklistUsesIsSearchableForRelatedModelColumns(): void
+    {
+        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::type(Post::class), 'title')->andReturnTrue(); // @phpstan-ignore method.notFound
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::type(Post::class), 'secret')->andReturnFalse(); // @phpstan-ignore method.notFound
+
+        // Blocklist posture: must use isSearchable, not the resource schema.
+        $surface = $this->make(
+            posture: QuerySurface::POSTURE_BLOCKLIST,
+            introspector: $introspector,
+            resourceMap: [Post::class => PostResource::class],
+        );
+
+        self::assertTrue($surface->guardFilter('title', new Post));
+        self::assertFalse($surface->guardFilter('secret', new Post));
     }
 
     /**
@@ -134,6 +222,7 @@ final class QuerySurfaceTest extends TestCase
      * @param  string  $posture
      * @param  bool  $reject
      * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider|null  $introspector
+     * @param  array<string, string>  $resourceMap
      * @return \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface
      */
     private function make(
@@ -143,6 +232,7 @@ final class QuerySurfaceTest extends TestCase
         string $posture = QuerySurface::POSTURE_ALLOWLIST,
         bool $reject = true,
         ?SchemaIntrospectionProvider $introspector = null,
+        array $resourceMap = [],
     ): QuerySurface {
         return new QuerySurface(
             $filterable,
@@ -152,6 +242,7 @@ final class QuerySurfaceTest extends TestCase
             $reject,
             $introspector ?? \Mockery::mock(SchemaIntrospectionProvider::class),
             new User,
+            $resourceMap,
         );
     }
 


### PR DESCRIPTION
Closes the BL-20 P2 read-oracle: under the allowlist posture, filter/sort columns on a traversed related model are now gated against that related resource's declared filterable/sortable set (previously a blocklist fallback that allowed a blind boolean read-oracle over undeclared related-model columns). Fails closed when no resource is mapped.

Verified end-to-end (undeclared nested column rejected with ValidationException). Security-reviewed: oracle closed across deep-nesting, polymorphic, self-referential, and case-sensitivity vectors.

Gates: check clean, test green, mutation 93%.

Reviewed: per-item adversarial review (overnight) + /build:review specialist pass (security / architecture / silent-failure) - no blocking findings.