### PR TITLE
style: normalize docblock wrapping

### DIFF
--- a/src/ApiQueryParser.php
+++ b/src/ApiQueryParser.php
@@ -12,9 +12,9 @@ use SineMacula\ApiToolkit\Concerns\QueryParameterValidator;
 /**
  * API query parser.
  *
- * Thin orchestrator that validates and extracts API parameters supplied
- * within the query string of a request, delegating to single-responsibility
- * concern classes and exposing typed access to the parsed parameters.
+ * Thin orchestrator that validates and extracts API parameters supplied within
+ * the query string of a request, delegating to single-responsibility concern
+ * classes and exposing typed access to the parsed parameters.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -19,9 +19,9 @@ use SineMacula\ApiToolkit\Services\SchemaValidator;
  * API service provider.
  *
  * Thin coordinator that merges the package configuration, handles publishing
- * and schema validation, and delegates registration of middleware,
- * logging, lifecycle listeners, and container bindings to single-
- * responsibility registrars.
+ * and schema validation, and delegates registration of middleware, logging,
+ * lifecycle listeners, and container bindings to single-responsibility
+ * registrars.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -17,8 +17,8 @@ use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 /**
  * Centralized orchestrator for flushing all toolkit caches.
  *
- * Registered as a singleton in the container. Delegates to all known cache
- * site flush methods and dispatches the CacheFlushed event upon completion.
+ * Registered as a singleton in the container. Delegates to all known cache site
+ * flush methods and dispatches the CacheFlushed event upon completion.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Concerns/Lockable.php
+++ b/src/Concerns/Lockable.php
@@ -13,11 +13,11 @@ use SineMacula\ApiToolkit\Exceptions\LockUnavailableException;
 /**
  * Cache-based atomic locking.
  *
- * Provides lock acquisition and release using Laravel's cache lock
- * system. Classes using this trait should implement the LockKeyProvider
- * contract to supply a lock key. Override the $lockExpiration property
- * to customize the lock duration (default 60 seconds). This trait has
- * no dependency on the Service base class or any other base class.
+ * Provides lock acquisition and release using Laravel's cache lock system.
+ * Classes using this trait should implement the LockKeyProvider contract to
+ * supply a lock key. Override the $lockExpiration property to customize the
+ * lock duration (default 60 seconds). This trait has no dependency on the
+ * Service base class or any other base class.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/LockKeyProvider.php
+++ b/src/Contracts/LockKeyProvider.php
@@ -5,8 +5,7 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Contracts;
 
 /**
- * Contract for classes that provide their own lock key to the Lockable
- * trait.
+ * Contract for classes that provide their own lock key to the Lockable trait.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/ResourceMetadataProvider.php
+++ b/src/Contracts/ResourceMetadataProvider.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Contracts;
 /**
  * Resource metadata provider interface.
  *
- * Decouples the repository criteria layer from resource class statics,
- * allowing metadata to be resolved without direct static calls.
+ * Decouples the repository criteria layer from resource class statics, allowing
+ * metadata to be resolved without direct static calls.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/SchemaIntrospectionProvider.php
+++ b/src/Contracts/SchemaIntrospectionProvider.php
@@ -30,8 +30,8 @@ interface SchemaIntrospectionProvider
     public function getColumns(Model $model): array;
 
     /**
-     * Get the per-column type and nullability definitions for the given
-     * model, keyed by column name.
+     * Get the per-column type and nullability definitions for the given model,
+     * keyed by column name.
      *
      * Results are cached forever per model, mirroring getColumns().
      *

--- a/src/Enums/FlushStrategy.php
+++ b/src/Enums/FlushStrategy.php
@@ -13,29 +13,26 @@ namespace SineMacula\ApiToolkit\Enums;
 enum FlushStrategy: string
 {
     /**
-     * Opt-in best-effort: catch the exception, log at error level,
-     * continue to the next chunk, and clear the entire buffer after
-     * processing. Failed records are dropped, so this strategy is only
-     * appropriate for genuinely disposable writes such as audit,
-     * analytics, or telemetry.
+     * Opt-in best-effort: catch the exception, log at error level, continue to
+     * the next chunk, and clear the entire buffer after processing. Failed
+     * records are dropped, so this strategy is only appropriate for genuinely
+     * disposable writes such as audit, analytics, or telemetry.
      */
     case LOG = 'log';
 
     /**
-     * Safe explicit: on the first chunk failure, throw the exception
-     * carrying the partial result and preserve the failed and
-     * unprocessed records in the buffer. No record is dropped. Intended
-     * for callers that own an explicit flush site and want to be told
-     * loudly when a write fails.
+     * Safe explicit: on the first chunk failure, throw the exception carrying
+     * the partial result and preserve the failed and unprocessed records in the
+     * buffer. No record is dropped. Intended for callers that own an explicit
+     * flush site and want to be told loudly when a write fails.
      */
     case THROW = 'throw';
 
     /**
-     * Safe default: catch all failures, accumulate them in the result,
-     * and retain the failed records in the buffer for the next flush
-     * attempt. No record is dropped and no exception escapes, so a
-     * boundary flush surfaces failures loudly without disrupting the
-     * lifecycle.
+     * Safe default: catch all failures, accumulate them in the result, and
+     * retain the failed records in the buffer for the next flush attempt. No
+     * record is dropped and no exception escapes, so a boundary flush surfaces
+     * failures loudly without disrupting the lifecycle.
      */
     case COLLECT = 'collect';
 }

--- a/src/Events/CacheFlushed.php
+++ b/src/Events/CacheFlushed.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Events;
 /**
  * Dispatched after a centralized toolkit cache flush completes.
  *
- * Consumers can listen for this event to perform post-flush cleanup
- * or re-warming of application-level caches.
+ * Consumers can listen for this event to perform post-flush cleanup or
+ * re-warming of application-level caches.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Events/WritePoolFlushFailed.php
+++ b/src/Events/WritePoolFlushFailed.php
@@ -7,10 +7,9 @@ namespace SineMacula\ApiToolkit\Events;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
 
 /**
- * Dispatched by the WritePoolFlushSubscriber when a flush operation
- * detects failures, enabling consuming applications to implement
- * custom escalation such as alerting, dead-letter queues, or
- * metrics collection.
+ * Dispatched by the WritePoolFlushSubscriber when a flush operation detects
+ * failures, enabling consuming applications to implement custom escalation such
+ * as alerting, dead-letter queues, or metrics collection.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -79,9 +79,9 @@ abstract class ApiException extends \Exception
      * Get the HTTP status code for this exception instance.
      *
      * Defaults to the static resolution (HTTP_STATUS constant or a static
-     * override for non-standard codes). Subclasses carrying a runtime
-     * status (e.g. the generic HttpException) may override this; the
-     * exception handler renders responses from this instance-level code.
+     * override for non-standard codes). Subclasses carrying a runtime status
+     * (e.g. the generic HttpException) may override this; the exception handler
+     * renders responses from this instance-level code.
      *
      * @return int
      */
@@ -93,8 +93,8 @@ abstract class ApiException extends \Exception
     /**
      * Get the HTTP status for this exception instance.
      *
-     * Defaults to the HTTP_STATUS constant. Used to derive the default
-     * title when no translation exists for the error code.
+     * Defaults to the HTTP_STATUS constant. Used to derive the default title
+     * when no translation exists for the error code.
      *
      * @return \SineMacula\Http\Enums\HttpStatus
      */

--- a/src/Exceptions/ApiExceptionHandler.php
+++ b/src/Exceptions/ApiExceptionHandler.php
@@ -122,10 +122,10 @@ final class ApiExceptionHandler
     /**
      * Resolve the API exception class that the given throwable maps to.
      *
-     * The first source-type the throwable is an instance of wins, so the
-     * order of the map is significant: more specific source types must
-     * precede the broader interfaces they extend. Anything unmatched falls
-     * back to the unhandled exception.
+     * The first source-type the throwable is an instance of wins, so the order
+     * of the map is significant: more specific source types must precede the
+     * broader interfaces they extend. Anything unmatched falls back to the
+     * unhandled exception.
      *
      * @param  \Throwable  $exception
      * @return class-string<\SineMacula\ApiToolkit\Exceptions\ApiException>
@@ -145,8 +145,8 @@ final class ApiExceptionHandler
      * The ordered map of source exception types to their API exception class.
      *
      * Ordering is significant: entries are evaluated top-to-bottom and the
-     * first match wins, so more specific types precede the broader
-     * interfaces they implement.
+     * first match wins, so more specific types precede the broader interfaces
+     * they implement.
      *
      * @return array<class-string<\Throwable>, class-string<\SineMacula\ApiToolkit\Exceptions\ApiException>>
      */
@@ -177,8 +177,8 @@ final class ApiExceptionHandler
     }
 
     /**
-     * Map an unrecognised HTTP-layer exception, preserving its status code
-     * and headers. Unknown status codes fall back to an unhandled error.
+     * Map an unrecognised HTTP-layer exception, preserving its status code and
+     * headers. Unknown status codes fall back to an unhandled error.
      *
      * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $exception
      * @param  array<string, mixed>|null  $meta

--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -10,8 +10,8 @@ use SineMacula\Http\Enums\HttpStatus;
 /**
  * Generic HTTP exception.
  *
- * Carries a runtime HTTP status, allowing the exception handler to preserve
- * the status code of any HTTP-layer exception (e.g. abort(409)) that has no
+ * Carries a runtime HTTP status, allowing the exception handler to preserve the
+ * status code of any HTTP-layer exception (e.g. abort(409)) that has no
  * dedicated ApiException subclass. The HTTP_STATUS constant exists only to
  * satisfy the base contract; rendering always uses the runtime status.
  *

--- a/src/Exceptions/TokenMismatchException.php
+++ b/src/Exceptions/TokenMismatchException.php
@@ -20,9 +20,9 @@ final class TokenMismatchException extends ApiException
     /**
      * Get HTTP status code.
      *
-     * Overrides the base method to return the non-standard 419 status
-     * code directly, as this code has no corresponding case in the
-     * shared HttpStatus enum.
+     * Overrides the base method to return the non-standard 419 status code
+     * directly, as this code has no corresponding case in the shared HttpStatus
+     * enum.
      *
      * @return int
      */

--- a/src/Exceptions/WritePoolFlushException.php
+++ b/src/Exceptions/WritePoolFlushException.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Exceptions;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
 
 /**
- * Thrown by the throw flush strategy when a chunk insert fails during
- * a WritePool flush operation.
+ * Thrown by the throw flush strategy when a chunk insert fails during a
+ * WritePool flush operation.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Http/Middleware/Concerns/ThrottleRequestsTrait.php
+++ b/src/Http/Middleware/Concerns/ThrottleRequestsTrait.php
@@ -17,7 +17,8 @@ trait ThrottleRequestsTrait
     /**
      * Resolve request signature.
      *
-     * phpcs:disable Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
+     * phpcs:disable
+     * Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
      *
      * @param  \Illuminate\Http\Request  $request
      * @return string

--- a/src/Http/Middleware/Concerns/ThrottleRequestsTrait.php
+++ b/src/Http/Middleware/Concerns/ThrottleRequestsTrait.php
@@ -17,8 +17,7 @@ trait ThrottleRequestsTrait
     /**
      * Resolve request signature.
      *
-     * phpcs:disable
-     * Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
+     * phpcs:disable Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
      *
      * @param  \Illuminate\Http\Request  $request
      * @return string

--- a/src/Http/Middleware/DetectsCapabilities.php
+++ b/src/Http/Middleware/DetectsCapabilities.php
@@ -11,8 +11,8 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Detects request capabilities middleware.
  *
- * Resolves capability flags from the current request and stores them
- * as a typed request attribute for downstream consumption.
+ * Resolves capability flags from the current request and stores them as a typed
+ * request attribute for downstream consumption.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -37,8 +37,7 @@ final class PreventRequestsDuringMaintenance extends Middleware
     /**
      * Handle an incoming request.
      *
-     * phpcs:disable
-     * Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
+     * phpcs:disable Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): mixed  $next

--- a/src/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -37,7 +37,8 @@ final class PreventRequestsDuringMaintenance extends Middleware
     /**
      * Handle an incoming request.
      *
-     * phpcs:disable Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
+     * phpcs:disable
+     * Squiz.Commenting.FunctionComment.ScalarTypeHintMissing,Squiz.Commenting.FunctionComment.TypeHintMissing
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): mixed  $next

--- a/src/Http/RequestCapabilities.php
+++ b/src/Http/RequestCapabilities.php
@@ -11,8 +11,8 @@ use SineMacula\Http\Enums\MediaType;
 /**
  * Request capabilities value object.
  *
- * Encapsulates the 4 boolean capability checks resolved from the
- * current request. Immutable once created.
+ * Encapsulates the 4 boolean capability checks resolved from the current
+ * request. Immutable once created.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -48,9 +48,9 @@ final class RequestCapabilities
     /**
      * Retrieve the capabilities instance from the request.
      *
-     * Returns the instance stored by the DetectsCapabilities middleware
-     * when available, otherwise resolves the capabilities on demand and
-     * caches them on the request.
+     * Returns the instance stored by the DetectsCapabilities middleware when
+     * available, otherwise resolves the capabilities on demand and caches them
+     * on the request.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return self

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -163,8 +163,8 @@ final class EagerLoadPlanner
     }
 
     /**
-     * Build a withSum/withAvg-ready entry list for the given resource class
-     * and metric ('sum' or 'avg').
+     * Build a withSum/withAvg-ready entry list for the given resource class and
+     * metric ('sum' or 'avg').
      *
      * Results are memoised in $aggregateCache, keyed by metric:class|requested
      * signature, so both metrics share one cache cleared by clearCache().
@@ -297,8 +297,8 @@ final class EagerLoadPlanner
     }
 
     /**
-     * Wrap a constraint closure to safely handle MorphTo, EloquentRelation,
-     * and Builder instances.
+     * Wrap a constraint closure to safely handle MorphTo, EloquentRelation, and
+     * Builder instances.
      *
      * @param  \Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void  $constraint
      * @return \Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void

--- a/src/Http/Resources/Concerns/FieldResolver.php
+++ b/src/Http/Resources/Concerns/FieldResolver.php
@@ -93,8 +93,8 @@ final class FieldResolver
     /**
      * Determine whether all fields should be included.
      *
-     * Returns true when the all-fields flag has been set explicitly or the
-     * API query contains the `:all` token for the given resource type.
+     * Returns true when the all-fields flag has been set explicitly or the API
+     * query contains the `:all` token for the given resource type.
      *
      * @param  string  $resourceType
      * @return bool

--- a/src/Http/Resources/Concerns/GuardEvaluator.php
+++ b/src/Http/Resources/Concerns/GuardEvaluator.php
@@ -21,8 +21,8 @@ final class GuardEvaluator
      * Evaluate whether all guards pass.
      *
      * Each guard is a callable that receives the resource instance and the
-     * current request. If any guard returns exactly `false`, the definition
-     * is suppressed.
+     * current request. If any guard returns exactly `false`, the definition is
+     * suppressed.
      *
      * @param  array<int, mixed>  $guards
      * @param  mixed  $resource

--- a/src/Http/Resources/ResourceMetadataService.php
+++ b/src/Http/Resources/ResourceMetadataService.php
@@ -9,9 +9,9 @@ use SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider;
 /**
  * Default resource metadata provider.
  *
- * Delegates each metadata query to the corresponding static method on the
- * given resource class, maintaining behavioural equivalence with direct static
- * calls while enabling substitution via the container.
+ * Delegates each metadata query to the corresponding static method on the given
+ * resource class, maintaining behavioural equivalence with direct static calls
+ * while enabling substitution via the container.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Listeners/OctaneFlushListener.php
+++ b/src/Listeners/OctaneFlushListener.php
@@ -39,8 +39,8 @@ final class OctaneFlushListener
     /**
      * Handle the event.
      *
-     * The event parameter is unused but required by Laravel's event
-     * listener signature.
+     * The event parameter is unused but required by Laravel's event listener
+     * signature.
      *
      * @SuppressWarnings("php:S1172")
      *

--- a/src/Listeners/QueueFlushSubscriber.php
+++ b/src/Listeners/QueueFlushSubscriber.php
@@ -14,10 +14,10 @@ use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 /**
  * Flushes all toolkit caches after each queue job completes or fails.
  *
- * Prevents stale metadata from persisting across jobs in long-running
- * worker processes by delegating to the centralized CacheManager. When the
- * job was dispatched via the sync driver (i.e. within an HTTP request), the
- * flush is skipped entirely.
+ * Prevents stale metadata from persisting across jobs in long-running worker
+ * processes by delegating to the centralized CacheManager. When the job was
+ * dispatched via the sync driver (i.e. within an HTTP request), the flush is
+ * skipped entirely.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Listeners/WritePoolFlushSubscriber.php
+++ b/src/Listeners/WritePoolFlushSubscriber.php
@@ -21,9 +21,8 @@ use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
 /**
  * Flushes the deferred write pool at lifecycle boundaries.
  *
- * This subscriber listens to HTTP request, CLI command, and queue
- * job lifecycle events to ensure all buffered inserts are persisted
- * before the process ends.
+ * This subscriber listens to HTTP request, CLI command, and queue job lifecycle
+ * events to ensure all buffered inserts are persisted before the process ends.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -59,19 +58,18 @@ final class WritePoolFlushSubscriber
     /**
      * Flush the write pool and handle any failures.
      *
-     * The pool is resolved from the container at event time to ensure
-     * the correct scoped instance is used in Octane environments. When
-     * the flush returns a result with failures, or raises a
-     * WritePoolFlushException under the throw strategy, the failure is
-     * escalated loudly: a warning is logged and a WritePoolFlushFailed
-     * event is dispatched. The exception is only re-thrown when the
-     * rethrow_at_boundary config flag is enabled, so the lifecycle
-     * boundary is never hard-crashed by default. Any other throwable is
-     * unexpected and logged at error level.
+     * The pool is resolved from the container at event time to ensure the
+     * correct scoped instance is used in Octane environments. When the flush
+     * returns a result with failures, or raises a WritePoolFlushException under
+     * the throw strategy, the failure is escalated loudly: a warning is logged
+     * and a WritePoolFlushFailed event is dispatched. The exception is only
+     * re-thrown when the rethrow_at_boundary config flag is enabled, so the
+     * lifecycle boundary is never hard-crashed by default. Any other throwable
+     * is unexpected and logged at error level.
      *
      * Regardless of outcome, the per-query cache for every table the flush
-     * attempted is invalidated so a deferred insert never leaves a stale
-     * cached collection behind.
+     * attempted is invalidated so a deferred insert never leaves a stale cached
+     * collection behind.
      *
      * @return void
      *
@@ -109,9 +107,9 @@ final class WritePoolFlushSubscriber
      * persist.
      *
      * Best-effort and gated by the invalidate_query_cache config flag: it
-     * covers default-config Cacheable repositories, mirroring what an
-     * immediate write does. A repository on a custom cache store or key prefix
-     * is not covered and must invalidate manually.
+     * covers default-config Cacheable repositories, mirroring what an immediate
+     * write does. A repository on a custom cache store or key prefix is not
+     * covered and must invalidate manually.
      *
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult  $flushResult
      * @return void

--- a/src/OpenApi/Contracts/MetadataCatalogue.php
+++ b/src/OpenApi/Contracts/MetadataCatalogue.php
@@ -9,9 +9,9 @@ namespace SineMacula\ApiToolkit\OpenApi\Contracts;
  * emission context.
  *
  * Provides the registered resource map, the full filter operator vocabulary
- * (registered tokens plus structural operators), and the error catalogue
- * (one descriptor per defined error code with its HTTP status and
- * title/detail strings).
+ * (registered tokens plus structural operators), and the error catalogue (one
+ * descriptor per defined error code with its HTTP status and title/detail
+ * strings).
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -32,8 +32,8 @@ interface MetadataCatalogue
     /**
      * Return the registered filter operator tokens.
      *
-     * Reads the bound OperatorRegistry so any application-registered
-     * additions or overrides are reflected.
+     * Reads the bound OperatorRegistry so any application-registered additions
+     * or overrides are reflected.
      *
      * @return array<int, string>
      */

--- a/src/OpenApi/Metadata/ErrorCatalogueReader.php
+++ b/src/OpenApi/Metadata/ErrorCatalogueReader.php
@@ -147,9 +147,9 @@ final class ErrorCatalogueReader
     /**
      * Resolve the title string for the given integer error code.
      *
-     * Returns null when no title is defined in the language file (e.g. for
-     * the generic HTTP_ERROR code, where the title is derived at runtime
-     * from the HTTP status phrase).
+     * Returns null when no title is defined in the language file (e.g. for the
+     * generic HTTP_ERROR code, where the title is derived at runtime from the
+     * HTTP status phrase).
      *
      * @param  int  $code
      * @return string|null

--- a/src/OpenApi/Metadata/ErrorDescriptor.php
+++ b/src/OpenApi/Metadata/ErrorDescriptor.php
@@ -7,10 +7,10 @@ namespace SineMacula\ApiToolkit\OpenApi\Metadata;
 /**
  * Immutable descriptor for a single error code's OpenAPI contract.
  *
- * Carries the integer error code, its resolved HTTP status, and the
- * canonical title and detail strings sourced from the package language
- * file. Consumed by the error-response builder to assemble the
- * components.responses section of the emitted document.
+ * Carries the integer error code, its resolved HTTP status, and the canonical
+ * title and detail strings sourced from the package language file. Consumed by
+ * the error-response builder to assemble the components.responses section of
+ * the emitted document.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/OpenApi/Output/FilesystemDocumentWriter.php
+++ b/src/OpenApi/Output/FilesystemDocumentWriter.php
@@ -11,10 +11,10 @@ use SineMacula\ApiToolkit\OpenApi\Exceptions\DocumentWriteException;
 /**
  * Filesystem adapter for the DocumentWriter output port.
  *
- * Writes the serialized OpenAPI document to disk, creating the target
- * directory tree when it does not yet exist. This is the only write of the
- * entire exporter feature; failures surface as a DocumentWriteException so the
- * command can report them rather than silently emitting nothing.
+ * Writes the serialized OpenAPI document to disk, creating the target directory
+ * tree when it does not yet exist. This is the only write of the entire
+ * exporter feature; failures surface as a DocumentWriteException so the command
+ * can report them rather than silently emitting nothing.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/OpenApi/Resolution/ColumnTypeMapper.php
+++ b/src/OpenApi/Resolution/ColumnTypeMapper.php
@@ -87,8 +87,8 @@ final class ColumnTypeMapper
     }
 
     /**
-     * Resolve a schema shape from a driver-normalised column type name, or
-     * null when the type is unknown.
+     * Resolve a schema shape from a driver-normalised column type name, or null
+     * when the type is unknown.
      *
      * @param  string  $typeName
      * @return array{type: string, format?: string}|null

--- a/src/Providers/Registrars/LifecycleRegistrar.php
+++ b/src/Providers/Registrars/LifecycleRegistrar.php
@@ -49,8 +49,7 @@ final class LifecycleRegistrar
     }
 
     /**
-     * Register the Octane flush listener if configured and Octane is
-     * installed.
+     * Register the Octane flush listener if configured and Octane is installed.
      *
      * @return void
      */

--- a/src/Providers/Registrars/MiddlewareRegistrar.php
+++ b/src/Providers/Registrars/MiddlewareRegistrar.php
@@ -67,8 +67,8 @@ final class MiddlewareRegistrar
      *
      * When enabled, the toolkit's PreventRequestsDuringMaintenance middleware
      * is prepended to the global middleware stack. Since it extends Laravel's
-     * built-in middleware, it takes precedence without requiring removal of
-     * the original.
+     * built-in middleware, it takes precedence without requiring removal of the
+     * original.
      *
      * @param  \Illuminate\Foundation\Http\Kernel  $kernel
      * @return void
@@ -114,8 +114,8 @@ final class MiddlewareRegistrar
      * Register the throttle middleware alias.
      *
      * When a custom class is provided via config, that class is used.
-     * Otherwise, the toolkit auto-detects between standard and Redis
-     * variants based on the configured cache driver.
+     * Otherwise, the toolkit auto-detects between standard and Redis variants
+     * based on the configured cache driver.
      *
      * @param  \Illuminate\Routing\Router  $router
      * @return void

--- a/src/Repositories/ApiRepository.php
+++ b/src/Repositories/ApiRepository.php
@@ -111,10 +111,10 @@ abstract class ApiRepository extends Repository
     /**
      * Persist the given attributes to the model.
      *
-     * This method handles both create and update operations
-     * transparently. Attributes are cast-resolved, BelongsTo and
-     * MorphTo relations are associated, and BelongsToMany and
-     * MorphToMany relations are synced after the model is saved.
+     * This method handles both create and update operations transparently.
+     * Attributes are cast-resolved, BelongsTo and MorphTo relations are
+     * associated, and BelongsToMany and MorphToMany relations are synced after
+     * the model is saved.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array<string, mixed>|\Illuminate\Support\Collection<string, mixed>  $attributes

--- a/src/Repositories/Concerns/AttributeSetter.php
+++ b/src/Repositories/Concerns/AttributeSetter.php
@@ -18,8 +18,7 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Enums\CacheKeys;
 
 /**
- * Encapsulates cast resolution and attribute setting for repository
- * models.
+ * Encapsulates cast resolution and attribute setting for repository models.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -30,8 +29,8 @@ final class AttributeSetter
     private array $casts = [];
 
     /**
-     * Create an attribute setter with the given schema introspector
-     * for resolving model relation types.
+     * Create an attribute setter with the given schema introspector for
+     * resolving model relation types.
      *
      * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider  $schemaIntrospector
      * @param  \SineMacula\ApiToolkit\Cache\MetadataCacheWriter  $metadataCacheWriter
@@ -47,8 +46,8 @@ final class AttributeSetter
     ) {}
 
     /**
-     * Persist the given attributes to the model, deferring sync
-     * relations until after the model is saved.
+     * Persist the given attributes to the model, deferring sync relations until
+     * after the model is saved.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array<string, mixed>  $attributes
@@ -88,8 +87,8 @@ final class AttributeSetter
     }
 
     /**
-     * Flush the instance-level cast cache, forcing re-resolution on
-     * the next access.
+     * Flush the instance-level cast cache, forcing re-resolution on the next
+     * access.
      *
      * @return void
      */
@@ -119,9 +118,9 @@ final class AttributeSetter
     }
 
     /**
-     * Resolve the native cast key for the given attribute by
-     * checking the configured cast map, then falling back to
-     * relation introspection or enum detection.
+     * Resolve the native cast key for the given attribute by checking the
+     * configured cast map, then falling back to relation introspection or enum
+     * detection.
      *
      * @param  string  $attribute
      * @param  string|null  $cast
@@ -153,8 +152,8 @@ final class AttributeSetter
     }
 
     /**
-     * Map a relation type to its sync/associate cast, or null when
-     * the attribute does not correspond to a recognized relation.
+     * Map a relation type to its sync/associate cast, or null when the
+     * attribute does not correspond to a recognized relation.
      *
      * @param  string  $attribute
      * @param  \Illuminate\Database\Eloquent\Model|null  $model
@@ -182,9 +181,8 @@ final class AttributeSetter
     }
 
     /**
-     * Check whether a model cast matches a configured Laravel cast
-     * entry, supporting exact match, class-based match, and
-     * wildcard patterns.
+     * Check whether a model cast matches a configured Laravel cast entry,
+     * supporting exact match, class-based match, and wildcard patterns.
      *
      * @param  string  $cast
      * @param  string  $laravelCast
@@ -209,8 +207,7 @@ final class AttributeSetter
     }
 
     /**
-     * Dispatch to the appropriate setter based on the resolved
-     * cast type.
+     * Dispatch to the appropriate setter based on the resolved cast type.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $attribute
@@ -229,8 +226,7 @@ final class AttributeSetter
     }
 
     /**
-     * Associate a BelongsTo or MorphTo relation by its foreign
-     * key value.
+     * Associate a BelongsTo or MorphTo relation by its foreign key value.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $attribute
@@ -251,8 +247,8 @@ final class AttributeSetter
     }
 
     /**
-     * Sync a many-to-many relation, accepting an array of IDs, a
-     * Collection of models, or a single Model instance.
+     * Sync a many-to-many relation, accepting an array of IDs, a Collection of
+     * models, or a single Model instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $attribute
@@ -286,8 +282,8 @@ final class AttributeSetter
     }
 
     /**
-     * Resolve the relation instance for the given attribute by
-     * invoking its camel-cased relation method on the model.
+     * Resolve the relation instance for the given attribute by invoking its
+     * camel-cased relation method on the model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $attribute
@@ -299,8 +295,8 @@ final class AttributeSetter
     }
 
     /**
-     * Persist the resolved casts to the memo cache so subsequent
-     * requests skip re-resolution.
+     * Persist the resolved casts to the memo cache so subsequent requests skip
+     * re-resolution.
      *
      * @param  string  $modelClass
      * @return void
@@ -321,8 +317,8 @@ final class AttributeSetter
     }
 
     /**
-     * Load previously resolved casts from the memo cache, returning
-     * an empty array on cache miss.
+     * Load previously resolved casts from the memo cache, returning an empty
+     * array on cache miss.
      *
      * @param  string  $modelClass
      * @return array<string, string|null>

--- a/src/Repositories/Concerns/CacheSizeGuard.php
+++ b/src/Repositories/Concerns/CacheSizeGuard.php
@@ -5,12 +5,12 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Repositories\Concerns;
 
 /**
- * Decides whether a query result is small enough to be stored in the
- * repository cache.
+ * Decides whether a query result is small enough to be stored in the repository
+ * cache.
  *
- * The guard bounds both the row count and the serialized byte size of a
- * result. A result that exceeds either bound is still fetched and returned to
- * the caller, but is never written to the cache, preventing unbounded growth.
+ * The guard bounds both the row count and the serialized byte size of a result.
+ * A result that exceeds either bound is still fetched and returned to the
+ * caller, but is never written to the cache, preventing unbounded growth.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Repositories/Concerns/CacheStatus.php
+++ b/src/Repositories/Concerns/CacheStatus.php
@@ -8,8 +8,8 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 
 /**
- * Immutable value object representing the current state of a
- * repository cache entry.
+ * Immutable value object representing the current state of a repository cache
+ * entry.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Repositories/Concerns/CacheStore.php
+++ b/src/Repositories/Concerns/CacheStore.php
@@ -16,12 +16,12 @@ use SineMacula\ApiToolkit\Enums\CacheKeys;
  *
  * Each executed query is stored under a key derived from its fingerprint, so a
  * filtered or by-id read never returns the full-table collection. Invalidation
- * is performed per table - via cache tags when the store supports them, or
- * via a generational table version otherwise: every per-query key embeds the
+ * is performed per table - via cache tags when the store supports them, or via
+ * a generational table version otherwise: every per-query key embeds the
  * current table version, and a write bumps the version with a single atomic
- * increment.
- * Invalidation is therefore O(1) and free of the read-modify-write races a
- * tracked key set suffers; orphaned old-version entries simply expire by TTL.
+ * increment. Invalidation is therefore O(1) and free of the read-modify-write
+ * races a tracked key set suffers; orphaned old-version entries simply expire
+ * by TTL.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -260,10 +260,10 @@ final class CacheStore implements CacheInvalidator
      * The trade-off is eventual consistency across processes. If a different
      * request (or queue worker) bumps the version via a write while this
      * instance is alive, the bump is invisible here until this instance is
-     * destroyed (typically at end-of-request). During that window this
-     * instance may serve cache entries that have been logically invalidated
-     * by the other process. Because the orphaned entries expire naturally by
-     * their TTL, the inconsistency is bounded and self-healing.
+     * destroyed (typically at end-of-request). During that window this instance
+     * may serve cache entries that have been logically invalidated by the other
+     * process. Because the orphaned entries expire naturally by their TTL, the
+     * inconsistency is bounded and self-healing.
      *
      * Taggable stores (e.g. Redis with tags enabled) are not affected by this
      * contract - they skip the generational-version path entirely and rely on

--- a/src/Repositories/Concerns/Cacheable.php
+++ b/src/Repositories/Concerns/Cacheable.php
@@ -13,11 +13,11 @@ use SineMacula\ApiToolkit\Contracts\CacheInvalidator;
 /**
  * Provides opt-in transparent caching for API repositories.
  *
- * When used by an ApiRepository subclass, this trait intercepts read
- * operations before execution and serves matching results from a per-query
- * cache, guaranteeing zero database queries on a cache hit. Each executed
- * query is keyed by its fingerprint, so a filtered or by-id read never returns
- * the full-table collection. Write operations invalidate the whole table.
+ * When used by an ApiRepository subclass, this trait intercepts read operations
+ * before execution and serves matching results from a per-query cache,
+ * guaranteeing zero database queries on a cache hit. Each executed query is
+ * keyed by its fingerprint, so a filtered or by-id read never returns the
+ * full-table collection. Write operations invalidate the whole table.
  *
  * Overridable configuration properties (declare in the consuming class to
  * change defaults):

--- a/src/Repositories/Concerns/Deferrable.php
+++ b/src/Repositories/Concerns/Deferrable.php
@@ -7,19 +7,18 @@ namespace SineMacula\ApiToolkit\Repositories\Concerns;
 /**
  * Provides opt-in deferred write capability for API repositories.
  *
- * When used by an ApiRepository subclass, this trait allows insert
- * operations to be collected in memory and flushed as bulk INSERT
- * statements at the end of the request lifecycle.
+ * When used by an ApiRepository subclass, this trait allows insert operations
+ * to be collected in memory and flushed as bulk INSERT statements at the end of
+ * the request lifecycle.
  *
- * Durability window: deferred writes live only in PHP memory until the
- * boundary flush performed by the WritePoolFlushSubscriber on
- * RequestHandled, CommandFinished, JobProcessed, or JobFailed. A crash,
- * out-of-memory condition, or SIGKILL in that window loses any unflushed
- * records. This is inherent to in-memory deferral; for true durability
- * use a real queue, which is out of scope for this trait. Under the
- * default collect strategy a failed flush retains the records in the
- * pool for the next boundary; use the log strategy for fire-and-forget
- * writes that may be dropped.
+ * Durability window: deferred writes live only in PHP memory until the boundary
+ * flush performed by the WritePoolFlushSubscriber on RequestHandled,
+ * CommandFinished, JobProcessed, or JobFailed. A crash, out-of-memory
+ * condition, or SIGKILL in that window loses any unflushed records. This is
+ * inherent to in-memory deferral; for true durability use a real queue, which
+ * is out of scope for this trait. Under the default collect strategy a failed
+ * flush retains the records in the pool for the next boundary; use the log
+ * strategy for fire-and-forget writes that may be dropped.
  *
  * Cache interaction: this concern coexists with Cacheable on the same
  * repository (each boots via its own boot{Concern} hook). Deferred writes are
@@ -43,11 +42,11 @@ trait Deferrable
     /**
      * Defer an insert operation to the write pool.
      *
-     * The attributes are buffered in memory and flushed as a bulk
-     * INSERT at the end of the request lifecycle. Timestamps are
-     * captured at the time of deferral, not at flush time. When the pool
-     * reaches its limit an automatic flush is triggered, which under the
-     * throw strategy may raise a WritePoolFlushException from this call.
+     * The attributes are buffered in memory and flushed as a bulk INSERT at the
+     * end of the request lifecycle. Timestamps are captured at the time of
+     * deferral, not at flush time. When the pool reaches its limit an automatic
+     * flush is triggered, which under the throw strategy may raise a
+     * WritePoolFlushException from this call.
      *
      * @param  array<string, mixed>  $attributes
      * @return void

--- a/src/Repositories/Concerns/ReferenceCache.php
+++ b/src/Repositories/Concerns/ReferenceCache.php
@@ -18,10 +18,10 @@ use SineMacula\ApiToolkit\Enums\CacheKeys;
  * In reference mode the table is loaded once and served from memory: full
  * collection reads and single-record lookups by primary key resolve without
  * touching the database. The deserialized snapshot is memoised on the instance
- * and indexed by key, so repeated reads within a request neither re-hydrate
- * the cached payload nor scan it linearly. This preserves the toolkit's
- * historical whole-table caching semantics, including cross-request
- * persistence, as an explicit opt-in.
+ * and indexed by key, so repeated reads within a request neither re-hydrate the
+ * cached payload nor scan it linearly. This preserves the toolkit's historical
+ * whole-table caching semantics, including cross-request persistence, as an
+ * explicit opt-in.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -152,8 +152,8 @@ final class ReferenceCache implements CacheInvalidator
     }
 
     /**
-     * Load the whole-table snapshot from the database, caching and memoising
-     * it unless it exceeds the size guard.
+     * Load the whole-table snapshot from the database, caching and memoising it
+     * unless it exceeds the size guard.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>

--- a/src/Repositories/Concerns/WritePool.php
+++ b/src/Repositories/Concerns/WritePool.php
@@ -10,8 +10,8 @@ use SineMacula\ApiToolkit\Enums\FlushStrategy;
 use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
 
 /**
- * Buffers insert attribute arrays in memory grouped by table
- * and flushes them as chunked bulk INSERT statements.
+ * Buffers insert attribute arrays in memory grouped by table and flushes them
+ * as chunked bulk INSERT statements.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -51,10 +51,9 @@ final class WritePool
     /**
      * Add an attribute array to the buffer for the given table.
      *
-     * When the total buffered record count reaches or exceeds the
-     * configured pool limit, an automatic flush is triggered using the
-     * instance strategy. Under the throw strategy this auto-flush may
-     * raise out of add().
+     * When the total buffered record count reaches or exceeds the configured
+     * pool limit, an automatic flush is triggered using the instance strategy.
+     * Under the throw strategy this auto-flush may raise out of add().
      *
      * @param  string  $table
      * @param  array<string, mixed>  $attributes
@@ -76,9 +75,9 @@ final class WritePool
     /**
      * Flush all buffered records as chunked bulk INSERT statements.
      *
-     * Records are grouped by table and split into chunks of at most
-     * the configured chunk size. The active strategy determines how
-     * chunk failures are handled and whether the buffer is retained.
+     * Records are grouped by table and split into chunks of at most the
+     * configured chunk size. The active strategy determines how chunk failures
+     * are handled and whether the buffer is retained.
      *
      * @param  \SineMacula\ApiToolkit\Enums\FlushStrategy|null  $strategy
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult
@@ -95,8 +94,8 @@ final class WritePool
     }
 
     /**
-     * Return the result from the most recent auto-flush triggered
-     * by add(), or null if no auto-flush has occurred.
+     * Return the result from the most recent auto-flush triggered by add(), or
+     * null if no auto-flush has occurred.
      *
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult|null
      */
@@ -181,8 +180,8 @@ final class WritePool
     }
 
     /**
-     * Flush a table's chunks inside a database transaction so the
-     * table's inserts are applied all-or-nothing.
+     * Flush a table's chunks inside a database transaction so the table's
+     * inserts are applied all-or-nothing.
      *
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushContext  $context
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushAccumulator  $accumulator
@@ -207,8 +206,8 @@ final class WritePool
     }
 
     /**
-     * Account for a table whose transaction committed, counting every
-     * chunk and record as flushed.
+     * Account for a table whose transaction committed, counting every chunk and
+     * record as flushed.
      *
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushContext  $context
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushAccumulator  $accumulator
@@ -222,8 +221,8 @@ final class WritePool
     }
 
     /**
-     * Account for a table whose transaction rolled back, treating the
-     * whole table's records as a single failure for the strategy.
+     * Account for a table whose transaction rolled back, treating the whole
+     * table's records as a single failure for the strategy.
      *
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushContext  $context
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushAccumulator  $accumulator
@@ -338,8 +337,8 @@ final class WritePool
     /**
      * Retain the failed chunk and all unprocessed records in the buffer.
      *
-     * The context must carry the chunk index (set via withChunkIndex) so
-     * that the remaining chunks for this table can be computed correctly.
+     * The context must carry the chunk index (set via withChunkIndex) so that
+     * the remaining chunks for this table can be computed correctly.
      *
      * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushContext  $context
      * @param  list<array<string, mixed>>  $chunk

--- a/src/Repositories/Concerns/WritePoolFlushAccumulator.php
+++ b/src/Repositories/Concerns/WritePoolFlushAccumulator.php
@@ -9,8 +9,8 @@ use SineMacula\ApiToolkit\Enums\FlushStrategy;
 /**
  * Mutable accumulator that tallies the outcome of a WritePool flush.
  *
- * Tracks chunk-level counts, record-level counts, failure details, and
- * the records retained for retry, then materialises an immutable
+ * Tracks chunk-level counts, record-level counts, failure details, and the
+ * records retained for retry, then materialises an immutable
  * WritePoolFlushResult once the flush completes.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
@@ -93,8 +93,8 @@ final class WritePoolFlushAccumulator
     /**
      * Materialise an immutable flush result for the given strategy.
      *
-     * For COLLECT the retained count equals the failed record count;
-     * for LOG every failed record is dropped instead of retained.
+     * For COLLECT the retained count equals the failed record count; for LOG
+     * every failed record is dropped instead of retained.
      *
      * @param  \SineMacula\ApiToolkit\Enums\FlushStrategy  $strategy
      * @param  array<int, string>  $flushedTables
@@ -109,8 +109,8 @@ final class WritePoolFlushAccumulator
     }
 
     /**
-     * Materialise an immutable flush result for the throw strategy,
-     * where retained records include both failed and unprocessed rows.
+     * Materialise an immutable flush result for the throw strategy, where
+     * retained records include both failed and unprocessed rows.
      *
      * @param  int  $retainedRecordCount
      * @param  array<int, string>  $flushedTables
@@ -122,8 +122,8 @@ final class WritePoolFlushAccumulator
     }
 
     /**
-     * Build the immutable flush result with explicit retain and drop
-     * record counts.
+     * Build the immutable flush result with explicit retain and drop record
+     * counts.
      *
      * @param  int  $retainedRecordCount
      * @param  int  $droppedRecordCount

--- a/src/Repositories/Concerns/WritePoolFlushContext.php
+++ b/src/Repositories/Concerns/WritePoolFlushContext.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Repositories\Concerns;
 use SineMacula\ApiToolkit\Enums\FlushStrategy;
 
 /**
- * Immutable carrier for the parameters required to flush a single
- * table's chunk set within a WritePool flush operation.
+ * Immutable carrier for the parameters required to flush a single table's chunk
+ * set within a WritePool flush operation.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Repositories/Concerns/WritePoolFlushResult.php
+++ b/src/Repositories/Concerns/WritePoolFlushResult.php
@@ -5,8 +5,8 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Repositories\Concerns;
 
 /**
- * Immutable value object encapsulating the outcome of a WritePool
- * flush operation.
+ * Immutable value object encapsulating the outcome of a WritePool flush
+ * operation.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Repositories/Criteria/OperatorRegistry.php
+++ b/src/Repositories/Criteria/OperatorRegistry.php
@@ -25,8 +25,8 @@ final class OperatorRegistry
     /**
      * Register a handler for the given operator token.
      *
-     * Throws if the token is already registered. Use override() to replace
-     * an existing handler.
+     * Throws if the token is already registered. Use override() to replace an
+     * existing handler.
      *
      * @param  string  $token
      * @param  \Closure|\SineMacula\ApiToolkit\Contracts\FilterOperator  $operator
@@ -48,8 +48,8 @@ final class OperatorRegistry
     /**
      * Replace the handler for the given operator token unconditionally.
      *
-     * If the token is not currently registered, this behaves identically
-     * to register().
+     * If the token is not currently registered, this behaves identically to
+     * register().
      *
      * @param  string  $token
      * @param  \Closure|\SineMacula\ApiToolkit\Contracts\FilterOperator  $operator

--- a/src/Repositories/Criteria/Operators/ContainsOperator.php
+++ b/src/Repositories/Criteria/Operators/ContainsOperator.php
@@ -45,8 +45,8 @@ final class ContainsOperator implements FilterOperator
     }
 
     /**
-     * Determine whether the value can be passed directly to a JSON
-     * containment constraint.
+     * Determine whether the value can be passed directly to a JSON containment
+     * constraint.
      *
      * @param  mixed  $value
      * @return bool
@@ -61,8 +61,8 @@ final class ContainsOperator implements FilterOperator
     }
 
     /**
-     * Split a comma-separated string into trimmed, non-empty items and
-     * apply them as a grouped JSON containment constraint.
+     * Split a comma-separated string into trimmed, non-empty items and apply
+     * them as a grouped JSON containment constraint.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
      * @param  string  $column
@@ -83,8 +83,8 @@ final class ContainsOperator implements FilterOperator
     }
 
     /**
-     * Apply each item as an OR-combined JSON containment constraint within
-     * the given query group.
+     * Apply each item as an OR-combined JSON containment constraint within the
+     * given query group.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
      * @param  string  $column

--- a/src/Repositories/Criteria/Operators/NullityOperator.php
+++ b/src/Repositories/Criteria/Operators/NullityOperator.php
@@ -12,8 +12,8 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
  * Base handler for nullity filter operators.
  *
  * Applies a null or not-null constraint to the query builder depending on the
- * negation declared by the concrete subclass, honouring the logical operator
- * of the current filter context.
+ * negation declared by the concrete subclass, honouring the logical operator of
+ * the current filter context.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Runtime/RuntimeContext.php
+++ b/src/Runtime/RuntimeContext.php
@@ -33,8 +33,8 @@ final class RuntimeContext
     /**
      * Determine whether the current process is serving as a real queue worker.
      *
-     * When `$connection` is null, the default queue connection is resolved
-     * from config. Returns true only when the resolved driver is a non-`sync`
+     * When `$connection` is null, the default queue connection is resolved from
+     * config. Returns true only when the resolved driver is a non-`sync`
      * string. The `sync` driver runs jobs inside the dispatching HTTP request
      * and is therefore not a real worker boundary.
      *

--- a/src/Schema/AggregateDefinition.php
+++ b/src/Schema/AggregateDefinition.php
@@ -10,8 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
  * Abstract base for relation aggregate (sum / average) schema definitions.
  *
  * Holds the common fluent API for building aggregate DSL entries and
- * serialising them to the raw schema array consumed by SchemaCompiler.
- * Concrete
+ * serialising them to the raw schema array consumed by SchemaCompiler. Concrete
  * subclasses declare their metric identifier via {@see metric()}.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/src/Schema/BaseDefinition.php
+++ b/src/Schema/BaseDefinition.php
@@ -93,9 +93,9 @@ abstract class BaseDefinition implements Arrayable
     /**
      * Begin (or continue) declaring this field's OpenAPI contract.
      *
-     * Returns the carrier for chaining; call end() to return to the
-     * definition. The carrier is created lazily on first use, so a definition
-     * that never calls openapi() carries no declaration and is unaffected.
+     * Returns the carrier for chaining; call end() to return to the definition.
+     * The carrier is created lazily on first use, so a definition that never
+     * calls openapi() carries no declaration and is unaffected.
      *
      * @return \SineMacula\ApiToolkit\Schema\OpenApiFieldDeclaration
      */
@@ -115,8 +115,8 @@ abstract class BaseDefinition implements Arrayable
     }
 
     /**
-     * Declare the base-table columns this field reads so a narrowed SELECT
-     * can include them.
+     * Declare the base-table columns this field reads so a narrowed SELECT can
+     * include them.
      *
      * @param  string  ...$columns
      * @return static

--- a/src/Schema/OpenApiFieldDeclaration.php
+++ b/src/Schema/OpenApiFieldDeclaration.php
@@ -7,12 +7,12 @@ namespace SineMacula\ApiToolkit\Schema;
 /**
  * Fluent carrier for an author-declared OpenAPI field contract.
  *
- * Returned by BaseDefinition::openapi(), it collects the declared type,
- * format, nullability, enumerated values, example, and description through
- * chainable setters, then freezes into an immutable OpenApiFieldSchema. The
- * carrier is additive: it exists only when openapi() is called and is omitted
- * from the definition's toArray() output otherwise, preserving byte-for-byte
- * backward compatibility.
+ * Returned by BaseDefinition::openapi(), it collects the declared type, format,
+ * nullability, enumerated values, example, and description through chainable
+ * setters, then freezes into an immutable OpenApiFieldSchema. The carrier is
+ * additive: it exists only when openapi() is called and is omitted from the
+ * definition's toArray() output otherwise, preserving byte-for-byte backward
+ * compatibility.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/SchemaCompiler.php
+++ b/src/Schema/SchemaCompiler.php
@@ -186,9 +186,8 @@ final class SchemaCompiler
      *
      * Returns the bare present key used both as the `presentKey` property on
      * the compiled definition and as the suffix for the Eloquent attribute
-     * name.
-     * Both the `__sum__:` and `__avg__:` prefixes are 8 characters long, so a
-     * single substr offset strips either.
+     * name. Both the `__sum__:` and `__avg__:` prefixes are 8 characters long,
+     * so a single substr offset strips either.
      *
      * The dict key stored in `$aggregates` is `{metric}:{presentKey}`; this
      * method returns only the bare present-key portion.

--- a/src/Services/Actors/AnonymousActor.php
+++ b/src/Services/Actors/AnonymousActor.php
@@ -9,9 +9,9 @@ use SineMacula\ApiToolkit\Services\Contracts\Actor;
 /**
  * Unauthenticated-caller actor.
  *
- * Represents a public API caller with no authenticated identity.
- * Distinct from SystemActor: anonymous callers originate from
- * outside the system, whereas system actors are internal processes.
+ * Represents a public API caller with no authenticated identity. Distinct from
+ * SystemActor: anonymous callers originate from outside the system, whereas
+ * system actors are internal processes.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Actors/EloquentActor.php
+++ b/src/Services/Actors/EloquentActor.php
@@ -12,12 +12,12 @@ use SineMacula\ApiToolkit\Services\Contracts\Actor;
 /**
  * Queue-serialisable actor adapting an Eloquent user/model.
  *
- * Wraps any Eloquent model that also implements Authenticatable (the
- * standard Laravel user) and exposes the Actor contract. Serialises as
- * a morph-type + identifier pair plus a snapshot of the label taken at
- * construction time. On a queue worker the model is re-resolved from
- * the morph map via a fresh DB query; the label and identifier scalars
- * survive even when the underlying record is later changed or deleted.
+ * Wraps any Eloquent model that also implements Authenticatable (the standard
+ * Laravel user) and exposes the Actor contract. Serialises as a morph-type +
+ * identifier pair plus a snapshot of the label taken at construction time. On a
+ * queue worker the model is re-resolved from the morph map via a fresh DB
+ * query; the label and identifier scalars survive even when the underlying
+ * record is later changed or deleted.
  *
  * Label resolution order (first non-empty string wins):
  *   1. The `name` attribute on the model.
@@ -41,18 +41,17 @@ final class EloquentActor implements Actor
     /**
      * The live model instance.
      *
-     * Null after unserialisation until the first call to
-     * toAuthenticatable(). Also null when the underlying record has
-     * been deleted and re-resolution returned nothing.
+     * Null after unserialisation until the first call to toAuthenticatable().
+     * Also null when the underlying record has been deleted and re-resolution
+     * returned nothing.
      *
      * @var (\Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Database\Eloquent\Model)|null
      */
     private (Authenticatable&Model)|null $model = null;
 
     /**
-     * Whether the model has been resolved (or attempted) after
-     * unserialisation. False only between __unserialize and the first
-     * toAuthenticatable() call.
+     * Whether the model has been resolved (or attempted) after unserialisation.
+     * False only between __unserialize and the first toAuthenticatable() call.
      *
      * @var bool
      */
@@ -81,8 +80,8 @@ final class EloquentActor implements Actor
     /**
      * Serialise as morph type + identifier + label snapshot only.
      *
-     * The live model is intentionally excluded so the serialised
-     * payload contains only re-resolvable scalars.
+     * The live model is intentionally excluded so the serialised payload
+     * contains only re-resolvable scalars.
      *
      * @return array<string, int|string>
      */
@@ -98,8 +97,8 @@ final class EloquentActor implements Actor
     /**
      * Restore scalar state from the serialised payload.
      *
-     * The model is left null and will be re-resolved from the morph
-     * map on the first toAuthenticatable() call.
+     * The model is left null and will be re-resolved from the morph map on the
+     * first toAuthenticatable() call.
      *
      * @param  array<string, int|string>  $data
      * @return void
@@ -153,8 +152,8 @@ final class EloquentActor implements Actor
     /**
      * Return the label snapshotted at construction time.
      *
-     * The snapshot is retained verbatim so attribution survives
-     * subsequent changes to or deletion of the underlying record.
+     * The snapshot is retained verbatim so attribution survives subsequent
+     * changes to or deletion of the underlying record.
      *
      * @return string
      */
@@ -167,9 +166,9 @@ final class EloquentActor implements Actor
     /**
      * Return the live Authenticatable model.
      *
-     * After unserialisation the model is re-resolved lazily from the
-     * morph map on the first call. Returns null when the record cannot
-     * be found (e.g. after deletion).
+     * After unserialisation the model is re-resolved lazily from the morph map
+     * on the first call. Returns null when the record cannot be found (e.g.
+     * after deletion).
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */

--- a/src/Services/Actors/SystemActor.php
+++ b/src/Services/Actors/SystemActor.php
@@ -9,9 +9,9 @@ use SineMacula\ApiToolkit\Services\Contracts\Actor;
 /**
  * Null-object actor for system and scheduled contexts.
  *
- * Represents a system process or background job with no authenticated
- * identity. Returns null from toAuthenticatable(), which allows the
- * service runner to short-circuit authorisation.
+ * Represents a system process or background job with no authenticated identity.
+ * Returns null from toAuthenticatable(), which allows the service runner to
+ * short-circuit authorisation.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Concerns/LockConcern.php
+++ b/src/Services/Concerns/LockConcern.php
@@ -9,9 +9,9 @@ use SineMacula\ApiToolkit\Services\Service;
 /**
  * Cache-based atomic locking stage.
  *
- * Acquires a cache lock before executing the pipeline and releases it in
- * a finally block, ensuring the lock is always released even on exception.
- * The runner only invokes this stage for lockable services.
+ * Acquires a cache lock before executing the pipeline and releases it in a
+ * finally block, ensuring the lock is always released even on exception. The
+ * runner only invokes this stage for lockable services.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Concerns/TransactionConcern.php
+++ b/src/Services/Concerns/TransactionConcern.php
@@ -9,9 +9,8 @@ use Illuminate\Support\Facades\DB;
 /**
  * Database transaction stage.
  *
- * Wraps the service pipeline in a database transaction with configurable
- * retry attempts. The transaction commits on success and rolls back on
- * exception.
+ * Wraps the service pipeline in a database transaction with configurable retry
+ * attempts. The transaction commits on success and rolls back on exception.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Contracts/Actor.php
+++ b/src/Services/Contracts/Actor.php
@@ -9,8 +9,8 @@ use Illuminate\Contracts\Auth\Authenticatable;
 /**
  * Explicit-causer contract.
  *
- * Represents the identity that initiated a service action. Implementers
- * may be authenticated users, system processes, or anonymous callers.
+ * Represents the identity that initiated a service action. Implementers may be
+ * authenticated users, system processes, or anonymous callers.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -20,8 +20,8 @@ interface Actor
     /**
      * Return the unique identifier for this actor.
      *
-     * Returns null for system or anonymous actors that have no
-     * persistent identity.
+     * Returns null for system or anonymous actors that have no persistent
+     * identity.
      *
      * @return int|string|null
      */
@@ -39,8 +39,8 @@ interface Actor
     /**
      * Return the human-readable label for this actor.
      *
-     * The label is snapshotted at capture time and must not change
-     * after the actor is constructed.
+     * The label is snapshotted at capture time and must not change after the
+     * actor is constructed.
      *
      * @return string
      */
@@ -49,8 +49,8 @@ interface Actor
     /**
      * Return the Authenticatable instance for this actor.
      *
-     * Used by Gate::forUser() to perform authorisation checks on behalf
-     * of the actor. Returns null for system or anonymous actors.
+     * Used by Gate::forUser() to perform authorisation checks on behalf of the
+     * actor. Returns null for system or anonymous actors.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */

--- a/src/Services/Contracts/ServiceConcern.php
+++ b/src/Services/Contracts/ServiceConcern.php
@@ -9,9 +9,9 @@ use SineMacula\ApiToolkit\Services\ServiceContext;
 /**
  * Contract for composable service concerns.
  *
- * Defines the middleware-style contract for cross-cutting concerns that
- * wrap the service lifecycle. Each concern receives the immutable context
- * and a closure representing the next step in the pipeline.
+ * Defines the middleware-style contract for cross-cutting concerns that wrap
+ * the service lifecycle. Each concern receives the immutable context and a
+ * closure representing the next step in the pipeline.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -21,8 +21,8 @@ interface ServiceConcern
     /**
      * Handle the concern around the service lifecycle.
      *
-     * The concern wraps the remaining pipeline by calling $next() to
-     * continue execution, and may transform or short-circuit the result.
+     * The concern wraps the remaining pipeline by calling $next() to continue
+     * execution, and may transform or short-circuit the result.
      *
      * @param  \SineMacula\ApiToolkit\Services\ServiceContext  $context
      * @param  \Closure(): mixed  $next

--- a/src/Services/Contracts/ServiceInput.php
+++ b/src/Services/Contracts/ServiceInput.php
@@ -8,9 +8,9 @@ namespace SineMacula\ApiToolkit\Services\Contracts;
  * Minimal typed-input contract.
  *
  * Defines the smallest interface a service input must satisfy. Keeping the
- * contract to a single method allows spatie/laravel-data Data objects
- * (which already expose toArray()) to satisfy it without introducing a
- * hard dependency on that package.
+ * contract to a single method allows spatie/laravel-data Data objects (which
+ * already expose toArray()) to satisfy it without introducing a hard dependency
+ * on that package.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Enums/ServiceSource.php
+++ b/src/Services/Enums/ServiceSource.php
@@ -7,9 +7,8 @@ namespace SineMacula\ApiToolkit\Services\Enums;
 /**
  * Service execution-source enumeration.
  *
- * Identifies the execution context from which a service was invoked,
- * enabling context-aware behaviour such as logging, throttling, and
- * actor resolution.
+ * Identifies the execution context from which a service was invoked, enabling
+ * context-aware behaviour such as logging, throttling, and actor resolution.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Enums/ServiceStatus.php
+++ b/src/Services/Enums/ServiceStatus.php
@@ -7,11 +7,10 @@ namespace SineMacula\ApiToolkit\Services\Enums;
 /**
  * Service execution status enumeration.
  *
- * Every service execution produces a total result - exactly one of
- * these cases is assigned. There is no pending or indeterminate case
- * because the result only exists once execution has completed. Use
- * exhaustive match expressions to handle both cases without a default
- * arm.
+ * Every service execution produces a total result - exactly one of these cases
+ * is assigned. There is no pending or indeterminate case because the result
+ * only exists once execution has completed. Use exhaustive match expressions to
+ * handle both cases without a default arm.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Input/ArrayInput.php
+++ b/src/Services/Input/ArrayInput.php
@@ -63,8 +63,8 @@ final class ArrayInput implements ServiceInput
     /**
      * Return the value for the given key coerced to an integer.
      *
-     * Returns zero when the key is absent. Non-scalar, non-null values
-     * (arrays, objects) coerce to zero.
+     * Returns zero when the key is absent. Non-scalar, non-null values (arrays,
+     * objects) coerce to zero.
      *
      * @param  string  $key
      * @return int

--- a/src/Services/Input/InputData.php
+++ b/src/Services/Input/InputData.php
@@ -12,8 +12,8 @@ use SineMacula\ApiToolkit\Services\Contracts\ServiceInput;
  * Self-validating input base for typed service inputs.
  *
  * Concrete subclasses declare constructor-promoted readonly properties and
- * override rules() to supply standard Laravel validation rules. Call from()
- * to validate a request or raw array and produce a typed, immutable instance.
+ * override rules() to supply standard Laravel validation rules. Call from() to
+ * validate a request or raw array and produce a typed, immutable instance.
  * Direct named-argument construction is also supported for tests and queue
  * deserialisers that already hold validated data.
  *
@@ -68,8 +68,8 @@ abstract class InputData implements ServiceInput
     /**
      * Return the input as an associative array.
      *
-     * Reflects over the instance's public promoted properties and returns
-     * a name-to-value map. Concrete subclasses need not implement toArray()
+     * Reflects over the instance's public promoted properties and returns a
+     * name-to-value map. Concrete subclasses need not implement toArray()
      * unless they require custom serialisation.
      *
      * @return array<string, mixed>
@@ -101,9 +101,9 @@ abstract class InputData implements ServiceInput
     /**
      * Return the Laravel validation rules for this input.
      *
-     * Concrete subclasses override this method to declare per-field rules
-     * using standard Laravel rule syntax. Cross-field constraints such as
-     * confirmed or after:other_field are also expressed here.
+     * Concrete subclasses override this method to declare per-field rules using
+     * standard Laravel rule syntax. Cross-field constraints such as confirmed
+     * or after:other_field are also expressed here.
      *
      * @return array<string, mixed>
      */
@@ -115,9 +115,9 @@ abstract class InputData implements ServiceInput
     /**
      * Cast a validated value to the parameter's declared PHP type.
      *
-     * Only backed enum parameters require casting from string; all other
-     * types are returned as-is because Laravel's validator already yields
-     * the correct scalar representation.
+     * Only backed enum parameters require casting from string; all other types
+     * are returned as-is because Laravel's validator already yields the correct
+     * scalar representation.
      *
      * @param  \ReflectionParameter  $parameter
      * @param  mixed  $value

--- a/src/Services/Introspection/ColumnDefinition.php
+++ b/src/Services/Introspection/ColumnDefinition.php
@@ -7,10 +7,10 @@ namespace SineMacula\ApiToolkit\Services\Introspection;
 /**
  * Immutable description of a single database column's type and nullability.
  *
- * Returned by the schema introspection port to supply the inference tier of
- * the OpenAPI exporter with a column's driver-normalised base type and whether
- * it admits null. Read only by the emission path; never consulted during
- * runtime serialization.
+ * Returned by the schema introspection port to supply the inference tier of the
+ * OpenAPI exporter with a column's driver-normalised base type and whether it
+ * admits null. Read only by the emission path; never consulted during runtime
+ * serialization.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Jobs/ServiceJob.php
+++ b/src/Services/Jobs/ServiceJob.php
@@ -22,9 +22,9 @@ use SineMacula\ApiToolkit\Services\ServiceRunner;
  * re-hydrates and runs the service identically via ServiceRunner with the
  * source forced to QUEUE - no Auth or Request is consulted (NFR-07).
  *
- * Naming deviation: jobs are normally named with a leading verb; this
- * generic bridge runs an arbitrary service so the Job suffix is used
- * instead (#php-nam-063).
+ * Naming deviation: jobs are normally named with a leading verb; this generic
+ * bridge runs an arbitrary service so the Job suffix is used instead
+ * (#php-nam-063).
  *
  * Limitation: subject-bearing services that require a Model constructor
  * argument beyond the input are out of scope for this bridge; the subject

--- a/src/Services/SchemaIntrospector.php
+++ b/src/Services/SchemaIntrospector.php
@@ -89,8 +89,8 @@ final class SchemaIntrospector implements SchemaIntrospectionProvider
     }
 
     /**
-     * Get the per-column type and nullability definitions for the given
-     * model, keyed by column name.
+     * Get the per-column type and nullability definitions for the given model,
+     * keyed by column name.
      *
      * Results are cached forever per model, mirroring getColumns().
      *

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -16,12 +16,14 @@ use SineMacula\ApiToolkit\Services\Jobs\ServiceJob;
 /**
  * Abstract action skeleton.
  *
- * Holds a typed input and an explicit actor. Subclasses implement
- * the six lifecycle hooks; the runner sequences them in a fixed,
- * transaction-aware order and returns a total ServiceResult.
+ * Holds a typed input and an explicit actor. Subclasses implement the six
+ * lifecycle hooks; the runner sequences them in a fixed, transaction-aware
+ * order and returns a total ServiceResult.
  *
  * @template TInput of \SineMacula\ApiToolkit\Services\Contracts\ServiceInput
  * @template TOutput
+ *
+ * @phpstan-import-type ServiceHooks from \SineMacula\ApiToolkit\Services\ServiceRunner
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -102,8 +104,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Return the actor for this invocation.
      *
-     * Defaults to an AnonymousActor when no actor has been supplied.
-     * Never reads Auth or any ambient state.
+     * Defaults to an AnonymousActor when no actor has been supplied. Never
+     * reads Auth or any ambient state.
      *
      * @return \SineMacula\ApiToolkit\Services\Contracts\Actor
      */
@@ -115,8 +117,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Execute the service synchronously and return a total result.
      *
-     * Builds or reuses a ServiceContext, then delegates lifecycle
-     * sequencing to ServiceRunner. Never throws for business failures.
+     * Builds or reuses a ServiceContext, then delegates lifecycle sequencing to
+     * ServiceRunner. Never throws for business failures.
      *
      * @return \SineMacula\ApiToolkit\Services\ServiceResult<TOutput>
      */
@@ -161,21 +163,7 @@ abstract class Service implements LockKeyProvider
      *
      * @internal
      *
-     * @return array{
-     *     authorize: \Closure(): void,
-     *     validate: \Closure(): void,
-     *     prepare: \Closure(): void,
-     *     handle: \Closure(): mixed,
-     *     afterCommit: \Closure(mixed): void,
-     *     onFailure: \Closure(\Throwable): void,
-     *     concerns: array<int,
-     * class-string<\SineMacula\ApiToolkit\Services\Contracts\ServiceConcern>>,
-     *     lockId: string,
-     *     transactional: bool,
-     *     transactionAttempts: int,
-     *     lockable: bool,
-     *     inputSummary: array<string, mixed>,
-     * }
+     * @return ServiceHooks
      */
     final public function serviceHooks(): array
     {
@@ -208,8 +196,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Authorize the current actor to perform this action.
      *
-     * Runs before the lock and transaction. Throw AuthorizationException
-     * to deny access. Default: allow.
+     * Runs before the lock and transaction. Throw AuthorizationException to
+     * deny access. Default: allow.
      *
      * @return void
      */
@@ -218,8 +206,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Validate the input data for this action.
      *
-     * Runs before the lock and transaction. Throw ValidationException
-     * to signal invalid input. Default: pass.
+     * Runs before the lock and transaction. Throw ValidationException to signal
+     * invalid input. Default: pass.
      *
      * @return void
      */
@@ -228,8 +216,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Perform pre-handle setup inside the transaction.
      *
-     * Load or lock rows, pre-compute values, or perform any setup that
-     * must happen within the transaction but before handle(). Default: no-op.
+     * Load or lock rows, pre-compute values, or perform any setup that must
+     * happen within the transaction but before handle(). Default: no-op.
      *
      * @return void
      */
@@ -238,8 +226,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Execute the core domain action.
      *
-     * Runs inside the transaction. Signal failure only by throwing; the
-     * return value is the typed output threaded through ServiceResult.
+     * Runs inside the transaction. Signal failure only by throwing; the return
+     * value is the typed output threaded through ServiceResult.
      *
      * @return TOutput
      */
@@ -249,8 +237,8 @@ abstract class Service implements LockKeyProvider
      * React to a successful outcome after the transaction has committed.
      *
      * Runs outside the lock and transaction. Exceptions thrown here are
-     * captured as side-effect errors on the result and logged, leaving
-     * the committed outcome intact. Default: no-op.
+     * captured as side-effect errors on the result and logged, leaving the
+     * committed outcome intact. Default: no-op.
      *
      * @param  TOutput  $output
      * @return void
@@ -260,8 +248,8 @@ abstract class Service implements LockKeyProvider
     /**
      * React to a failed outcome after the transaction has rolled back.
      *
-     * Runs after rollback and lock release. Exceptions thrown here are
-     * caught and logged. Default: no-op.
+     * Runs after rollback and lock release. Exceptions thrown here are caught
+     * and logged. Default: no-op.
      *
      * @param  \Throwable  $exception
      * @return void
@@ -271,8 +259,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Return the ordered list of custom concern classes.
      *
-     * Concerns run inside the transaction, in declaration order, wrapping
-     * the core (prepare + handle). Default: none.
+     * Concerns run inside the transaction, in declaration order, wrapping the
+     * core (prepare + handle). Default: none.
      *
      * @return array<int, class-string<\SineMacula\ApiToolkit\Services\Contracts\ServiceConcern>>
      */
@@ -284,8 +272,8 @@ abstract class Service implements LockKeyProvider
     /**
      * Return the unique lock identity for this invocation.
      *
-     * Required when $lockable is true; must be non-empty. The final lock
-     * key is sha1(class | lockId()). Default: empty string (disabled).
+     * Required when $lockable is true; must be non-empty. The final lock key is
+     * sha1(class | lockId()). Default: empty string (disabled).
      *
      * @return string
      */

--- a/src/Services/ServiceContext.php
+++ b/src/Services/ServiceContext.php
@@ -12,9 +12,9 @@ use SineMacula\ApiToolkit\Services\Enums\ServiceSource;
  * Immutable, queue-serialisable execution-context envelope.
  *
  * Carries the actor that initiated the service, a correlation id (generated
- * when absent), the execution source, and captured ambient metadata such as
- * IP address, user-agent, or request id. Metadata is supplied explicitly at
- * the capture site and never read ambiently inside services (NFR-07).
+ * when absent), the execution source, and captured ambient metadata such as IP
+ * address, user-agent, or request id. Metadata is supplied explicitly at the
+ * capture site and never read ambiently inside services (NFR-07).
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -47,8 +47,8 @@ final readonly class ServiceContext
     /**
      * Create a ServiceContext for the given actor.
      *
-     * When no correlation id is supplied, a UUID is generated. When no
-     * source is supplied, it defaults to INTERNAL.
+     * When no correlation id is supplied, a UUID is generated. When no source
+     * is supplied, it defaults to INTERNAL.
      *
      * @param  \SineMacula\ApiToolkit\Services\Contracts\Actor  $actor
      * @param  \SineMacula\ApiToolkit\Services\Enums\ServiceSource|null  $source

--- a/src/Services/ServiceResult.php
+++ b/src/Services/ServiceResult.php
@@ -7,15 +7,13 @@ namespace SineMacula\ApiToolkit\Services;
 use SineMacula\ApiToolkit\Services\Enums\ServiceStatus;
 
 /**
- * Immutable value object representing the total outcome of a service
- * execution.
+ * Immutable value object representing the total outcome of a service execution.
  *
- * Every execution produces exactly one result - either SUCCEEDED or
- * FAILED. A successful result carries the typed output and any
- * side-effect errors collected during afterCommit processing. A failed
- * result carries the exception that caused the failure, or null when
- * failure was signalled without throwing. Failed results never carry
- * side-effect errors.
+ * Every execution produces exactly one result - either SUCCEEDED or FAILED. A
+ * successful result carries the typed output and any side-effect errors
+ * collected during afterCommit processing. A failed result carries the
+ * exception that caused the failure, or null when failure was signalled without
+ * throwing. Failed results never carry side-effect errors.
  *
  * @template TOutput
  *
@@ -104,9 +102,9 @@ final readonly class ServiceResult
     /**
      * Return the output when succeeded, or the given default otherwise.
      *
-     * A failed result always returns the default, even when a non-null
-     * output was captured alongside the failure. This lets the caller
-     * distinguish "no output" from "failed" without checking the status.
+     * A failed result always returns the default, even when a non-null output
+     * was captured alongside the failure. This lets the caller distinguish "no
+     * output" from "failed" without checking the status.
      *
      * @param  mixed  $default
      * @return mixed
@@ -117,11 +115,11 @@ final readonly class ServiceResult
     }
 
     /**
-     * Rethrow the captured exception when failed; otherwise return $this
-     * to allow fluent chaining.
+     * Rethrow the captured exception when failed; otherwise return $this to
+     * allow fluent chaining.
      *
-     * When the result failed but no exception was captured, this method
-     * returns $this without throwing.
+     * When the result failed but no exception was captured, this method returns
+     * $this without throwing.
      *
      * @return $this
      *

--- a/src/Services/ServiceRunner.php
+++ b/src/Services/ServiceRunner.php
@@ -16,8 +16,8 @@ use SineMacula\ApiToolkit\Services\Events\ServiceFailed;
 /**
  * Fixed lifecycle orchestrator for service actions.
  *
- * Sequences the lifecycle in a fixed, transaction-aware order:
- * authorize -> validate -> [lock] -> [tx] -> concerns -> prepare -> handle
+ * Sequences the lifecycle in a fixed, transaction-aware order: authorize ->
+ * validate -> [lock] -> [tx] -> concerns -> prepare -> handle
  * -> commit -> release -> afterCommit; onFailure after rollback + release;
  * finally emits ServiceCompleted or ServiceFailed.
  *
@@ -95,8 +95,8 @@ final class ServiceRunner
     }
 
     /**
-     * Build the execution pipeline in fixed composition order:
-     * lock (outermost) -> transaction -> concerns -> core.
+     * Build the execution pipeline in fixed composition order: lock (outermost)
+     * -> transaction -> concerns -> core.
      *
      * @param  \SineMacula\ApiToolkit\Services\Service  $service
      * @param  ServiceHooks  $hooks

--- a/src/Services/Validation/Rules/ValidateComputedFields.php
+++ b/src/Services/Validation/Rules/ValidateComputedFields.php
@@ -9,8 +9,8 @@ use SineMacula\ApiToolkit\Schema\CompiledSchema;
 use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
 
 /**
- * Validate that computed field values are callable or reference valid
- * methods on the resource class.
+ * Validate that computed field values are callable or reference valid methods
+ * on the resource class.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Validation/Rules/ValidateRelationMethods.php
+++ b/src/Services/Validation/Rules/ValidateRelationMethods.php
@@ -66,8 +66,8 @@ final class ValidateRelationMethods implements SchemaValidationRule
     }
 
     /**
-     * Validate that a relation method exists and has a return type hinting
-     * to a Relation subclass.
+     * Validate that a relation method exists and has a return type hinting to a
+     * Relation subclass.
      *
      * @param  string  $resourceClass
      * @param  string  $fieldKey

--- a/src/Services/Validation/Rules/ValidatesCallableLists.php
+++ b/src/Services/Validation/Rules/ValidatesCallableLists.php
@@ -13,8 +13,8 @@ use SineMacula\ApiToolkit\Services\Validation\SchemaValidationError;
  * Base rule for validating callable lists on compiled field definitions.
  *
  * Iterates the compiled fields and reports a validation error for every list
- * entry that is not callable, using the callable list and label declared by
- * the concrete subclass.
+ * entry that is not callable, using the callable list and label declared by the
+ * concrete subclass.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Listeners/ChildExclusiveLockListenerFixture.php
+++ b/tests/Fixtures/Listeners/ChildExclusiveLockListenerFixture.php
@@ -7,8 +7,8 @@ namespace Tests\Fixtures\Listeners;
 /**
  * Fixture child listener invoking the inherited exclusive lock helper.
  *
- * Used to assert that handleWithLock remains accessible from subclasses of
- * a listener that uses the ProvidesExclusiveLock trait.
+ * Used to assert that handleWithLock remains accessible from subclasses of a
+ * listener that uses the ProvidesExclusiveLock trait.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Models/AggregateCapturingModel.php
+++ b/tests/Fixtures/Models/AggregateCapturingModel.php
@@ -117,8 +117,8 @@ final class AggregateCapturingModel
     /**
      * Derive the present-key alias from the relation argument.
      *
-     * The 'relation as alias' string form yields the alias segment after
-     * ' as '. An array uses the key in the same format.
+     * The 'relation as alias' string form yields the alias segment after ' as
+     * '. An array uses the key in the same format.
      *
      * @param  mixed  $relations
      * @return string

--- a/tests/Fixtures/Services/Jobs/ContextCapturingConcern.php
+++ b/tests/Fixtures/Services/Jobs/ContextCapturingConcern.php
@@ -10,8 +10,8 @@ use SineMacula\ApiToolkit\Services\ServiceContext;
 /**
  * Concern fixture that captures the execution context for assertion.
  *
- * Stores the most recently received context in a static property so that
- * tests can assert which context was used to invoke the service pipeline.
+ * Stores the most recently received context in a static property so that tests
+ * can assert which context was used to invoke the service pipeline.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Services/OutputService.php
+++ b/tests/Fixtures/Services/OutputService.php
@@ -9,8 +9,8 @@ use SineMacula\ApiToolkit\Services\Service;
 /**
  * Fixture service that returns typed output.
  *
- * Demonstrates that handle() returns a non-boolean output value and that
- * the service reads a typed property from $this->input (AC-11). Used by
+ * Demonstrates that handle() returns a non-boolean output value and that the
+ * service reads a typed property from $this->input (AC-11). Used by
  * ServiceRunnerTest and ServiceTest to verify the output threads through
  * ServiceResult::output().
  *

--- a/tests/Fixtures/Support/FunctionOverrides.php
+++ b/tests/Fixtures/Support/FunctionOverrides.php
@@ -8,8 +8,8 @@ namespace Tests\Fixtures\Support;
  * Static registry for namespace-scoped PHP function overrides.
  *
  * Test code sets callbacks here; namespace-level function stubs in
- * Overrides/functions.php delegate to these callbacks, falling back to the
- * real built-in when no override is active.
+ * Overrides/functions.php delegate to these callbacks, falling back to the real
+ * built-in when no override is active.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/ApiServiceProviderTest.php
+++ b/tests/Integration/ApiServiceProviderTest.php
@@ -136,8 +136,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the toolkit's PreventRequestsDuringMaintenance middleware
-     * is prepended to the global stack when enabled (default).
+     * Test that the toolkit's PreventRequestsDuringMaintenance middleware is
+     * prepended to the global stack when enabled (default).
      *
      * @return void
      */
@@ -185,8 +185,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test backward compatibility: default config produces the same behavior
-     * as the previous version.
+     * Test backward compatibility: default config produces the same behavior as
+     * the previous version.
      *
      * @return void
      */
@@ -227,8 +227,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that DetectsCapabilities middleware is appended to the api
-     * group when scoped.
+     * Test that DetectsCapabilities middleware is appended to the api group
+     * when scoped.
      *
      * @return void
      */
@@ -249,8 +249,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that DetectsCapabilities middleware is not registered when
-     * config is disabled.
+     * Test that DetectsCapabilities middleware is not registered when config is
+     * disabled.
      *
      * @return void
      */
@@ -328,8 +328,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that registerMorphMap builds the map when dynamic mapping is
-     * enabled and a valid resource map is configured.
+     * Test that registerMorphMap builds the map when dynamic mapping is enabled
+     * and a valid resource map is configured.
      *
      * @return void
      */
@@ -378,8 +378,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the OperatorRegistry is registered as a singleton with
-     * built-in operators.
+     * Test that the OperatorRegistry is registered as a singleton with built-in
+     * operators.
      *
      * @return void
      */
@@ -530,8 +530,7 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the Octane flush listener is registered when config is
-     * enabled.
+     * Test that the Octane flush listener is registered when config is enabled.
      *
      * @return void
      */
@@ -622,8 +621,7 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the on_failure config key is available with the default
-     * value.
+     * Test that the on_failure config key is available with the default value.
      *
      * @return void
      */
@@ -666,8 +664,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the WritePool receives the configured strategy when
-     * on_failure is set to a non-default value.
+     * Test that the WritePool receives the configured strategy when on_failure
+     * is set to a non-default value.
      *
      * @return void
      */
@@ -689,8 +687,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that an invalid on_failure config value throws a ValueError
-     * when resolving the WritePool.
+     * Test that an invalid on_failure config value throws a ValueError when
+     * resolving the WritePool.
      *
      * @return void
      */
@@ -709,8 +707,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the ParseApiQuery middleware is pushed to the global stack
-     * when parser middleware registration is enabled.
+     * Test that the ParseApiQuery middleware is pushed to the global stack when
+     * parser middleware registration is enabled.
      *
      * @return void
      */
@@ -724,8 +722,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that all middleware registrations fall back to enabled defaults
-     * when the relevant config keys are missing entirely.
+     * Test that all middleware registrations fall back to enabled defaults when
+     * the relevant config keys are missing entirely.
      *
      * A fresh kernel and router are resolved so the assertions observe only
      * what this boot registers.
@@ -765,8 +763,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the DetectsCapabilities middleware is not registered on a
-     * fresh kernel when disabled via config.
+     * Test that the DetectsCapabilities middleware is not registered on a fresh
+     * kernel when disabled via config.
      *
      * @return void
      */
@@ -790,8 +788,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the DetectsCapabilities middleware scoped to the api group
-     * is not also pushed to the global stack.
+     * Test that the DetectsCapabilities middleware scoped to the api group is
+     * not also pushed to the global stack.
      *
      * @return void
      */
@@ -815,8 +813,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the package config file is publishable under the config
-     * group with the expected source and destination paths.
+     * Test that the package config file is publishable under the config group
+     * with the expected source and destination paths.
      *
      * @return void
      */
@@ -831,8 +829,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the package translations are publishable under the
-     * translations group with the expected source and destination paths.
+     * Test that the package translations are publishable under the translations
+     * group with the expected source and destination paths.
      *
      * @return void
      */
@@ -871,8 +869,8 @@ final class ApiServiceProviderTest extends TestCase
      * Test that schema validation defaults to disabled when the
      * validate_schemas config key is missing entirely.
      *
-     * Boot must complete without throwing even though the resource map
-     * contains an invalid schema, proving the default gate is off.
+     * Boot must complete without throwing even though the resource map contains
+     * an invalid schema, proving the default gate is off.
      *
      * @return void
      */
@@ -894,8 +892,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that schema validation is skipped when the resource map is not
-     * an array, completing boot without error.
+     * Test that schema validation is skipped when the resource map is not an
+     * array, completing boot without error.
      *
      * @return void
      */
@@ -933,8 +931,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that no notification listeners are added when notification
-     * logging is disabled.
+     * Test that no notification listeners are added when notification logging
+     * is disabled.
      *
      * @return void
      */
@@ -999,8 +997,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the write pool flush subscriber is subscribed to the HTTP
-     * and console lifecycle events.
+     * Test that the write pool flush subscriber is subscribed to the HTTP and
+     * console lifecycle events.
      *
      * @return void
      */
@@ -1053,8 +1051,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the WritePool falls back to the default sizes when the
-     * config keys are missing entirely.
+     * Test that the WritePool falls back to the default sizes when the config
+     * keys are missing entirely.
      *
      * @return void
      */
@@ -1175,8 +1173,8 @@ final class ApiServiceProviderTest extends TestCase
     /**
      * Resolve a path relative to the service provider source directory.
      *
-     * Mirrors the __DIR__-relative paths used by the provider when
-     * registering publishable assets.
+     * Mirrors the __DIR__-relative paths used by the provider when registering
+     * publishable assets.
      *
      * @param  string  $path
      * @return string
@@ -1204,8 +1202,8 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Determine whether the given event has a listener belonging to the
-     * given subscriber class.
+     * Determine whether the given event has a listener belonging to the given
+     * subscriber class.
      *
      * @param  class-string  $event
      * @param  class-string  $subscriber

--- a/tests/Integration/ColumnNarrowingIntegrationTest.php
+++ b/tests/Integration/ColumnNarrowingIntegrationTest.php
@@ -28,8 +28,8 @@ use Tests\TestCase;
  * End-to-end integration tests for repository-driven column narrowing.
  *
  * Drives the full ApiCriteria applier chain against a real SQLite database,
- * capturing the emitted base-table SQL via the query log to prove the
- * narrowing decision, the safety set, and byte-identical default-off behaviour.
+ * capturing the emitted base-table SQL via the query log to prove the narrowing
+ * decision, the safety set, and byte-identical default-off behaviour.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/DeferrableIntegrationTest.php
+++ b/tests/Integration/DeferrableIntegrationTest.php
@@ -295,8 +295,8 @@ final class DeferrableIntegrationTest extends TestCase
     }
 
     /**
-     * Test that RequestHandled event dispatches WritePoolFlushFailed
-     * event on flush failure.
+     * Test that RequestHandled event dispatches WritePoolFlushFailed event on
+     * flush failure.
      *
      * @return void
      */
@@ -318,8 +318,8 @@ final class DeferrableIntegrationTest extends TestCase
     }
 
     /**
-     * Test that the default collect strategy retains failed records in
-     * the pool when a boundary flush fails, without dropping them.
+     * Test that the default collect strategy retains failed records in the pool
+     * when a boundary flush fails, without dropping them.
      *
      * @return void
      */
@@ -342,8 +342,8 @@ final class DeferrableIntegrationTest extends TestCase
     }
 
     /**
-     * Test that a transactional boundary flush rolls back a table whose
-     * chunk set contains a failure and dispatches the failure event.
+     * Test that a transactional boundary flush rolls back a table whose chunk
+     * set contains a failure and dispatches the failure event.
      *
      * @return void
      */

--- a/tests/Integration/DeferredWriteRequestBoundaryTest.php
+++ b/tests/Integration/DeferredWriteRequestBoundaryTest.php
@@ -17,14 +17,13 @@ use Tests\Fixtures\Repositories\DeferrableUserRepository;
 use Tests\TestCase;
 
 /**
- * Integration tests for the deferred-write flush across a simulated
- * request boundary.
+ * Integration tests for the deferred-write flush across a simulated request
+ * boundary.
  *
- * Exercises the WritePool and WritePoolFlushSubscriber lifecycle the
- * way a consuming application does: records are buffered through a
- * Deferrable repository inside a route handler, the kernel completes
- * the request, and the subscriber flushes the pool when the
- * RequestHandled lifecycle event fires.
+ * Exercises the WritePool and WritePoolFlushSubscriber lifecycle the way a
+ * consuming application does: records are buffered through a Deferrable
+ * repository inside a route handler, the kernel completes the request, and the
+ * subscriber flushes the pool when the RequestHandled lifecycle event fires.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -68,8 +67,8 @@ final class DeferredWriteRequestBoundaryTest extends TestCase
     }
 
     /**
-     * Test that records deferred during a request are flushed to the
-     * database when the request lifecycle completes.
+     * Test that records deferred during a request are flushed to the database
+     * when the request lifecycle completes.
      *
      * @return void
      */
@@ -89,8 +88,8 @@ final class DeferredWriteRequestBoundaryTest extends TestCase
     }
 
     /**
-     * Test that the request boundary flush leaves the scoped write
-     * pool empty for subsequent work.
+     * Test that the request boundary flush leaves the scoped write pool empty
+     * for subsequent work.
      *
      * @return void
      */
@@ -106,8 +105,8 @@ final class DeferredWriteRequestBoundaryTest extends TestCase
     }
 
     /**
-     * Test that sequential requests each flush their own deferred
-     * records at their own request boundary.
+     * Test that sequential requests each flush their own deferred records at
+     * their own request boundary.
      *
      * @return void
      */

--- a/tests/Integration/ExceptionRenderingTest.php
+++ b/tests/Integration/ExceptionRenderingTest.php
@@ -20,9 +20,9 @@ use Tests\TestCase;
  * End-to-end integration tests for exception rendering.
  *
  * Registers the toolkit exception handler against the application's real
- * exception handler (mirroring the bootstrap/app.php withExceptions()
- * wiring) and asserts the toolkit JSON error format through real HTTP
- * routes dispatched via the HTTP kernel.
+ * exception handler (mirroring the bootstrap/app.php withExceptions() wiring)
+ * and asserts the toolkit JSON error format through real HTTP routes dispatched
+ * via the HTTP kernel.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -85,8 +85,8 @@ final class ExceptionRenderingTest extends TestCase
     }
 
     /**
-     * Test that abort() inside a route is rendered in the toolkit JSON
-     * error format with the original status code preserved.
+     * Test that abort() inside a route is rendered in the toolkit JSON error
+     * format with the original status code preserved.
      *
      * @return void
      */
@@ -106,8 +106,8 @@ final class ExceptionRenderingTest extends TestCase
     }
 
     /**
-     * Test that a toolkit ApiException thrown inside a route is rendered
-     * with its own status, code, and custom meta.
+     * Test that a toolkit ApiException thrown inside a route is rendered with
+     * its own status, code, and custom meta.
      *
      * @return void
      */
@@ -127,8 +127,8 @@ final class ExceptionRenderingTest extends TestCase
     }
 
     /**
-     * Test that a ValidationException raised by request validation is
-     * rendered as a 422 with the validation errors as meta.
+     * Test that a ValidationException raised by request validation is rendered
+     * as a 422 with the validation errors as meta.
      *
      * @return void
      */

--- a/tests/Integration/LifecycleDefaultEngagementTest.php
+++ b/tests/Integration/LifecycleDefaultEngagementTest.php
@@ -21,10 +21,10 @@ use Tests\TestCase;
  * Proves that the SHIPPED DEFAULT config engages the lifecycle flush.
  *
  * No lifecycle config keys are set in this file - the tests read the merged
- * package default directly to pin that the shipped default is true and that
- * the flush engages under a detected serving runtime. This kills the
- * default-value mutation (a mutant flipping the default back to false must
- * fail these assertions).
+ * package default directly to pin that the shipped default is true and that the
+ * flush engages under a detected serving runtime. This kills the default-value
+ * mutation (a mutant flipping the default back to false must fail these
+ * assertions).
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -70,8 +70,8 @@ final class LifecycleDefaultEngagementTest extends TestCase
     }
 
     /**
-     * Test that the shipped default for lifecycle.octane and lifecycle.queue
-     * is true and that the Octane flush engages on a detected serving runtime.
+     * Test that the shipped default for lifecycle.octane and lifecycle.queue is
+     * true and that the Octane flush engages on a detected serving runtime.
      *
      * Validates TAC-09-01 and TAC-09-02: with no config override the merged
      * default is true, and invoking the Octane boundary on a serving runtime

--- a/tests/Integration/LifecycleFlushDefaultsTest.php
+++ b/tests/Integration/LifecycleFlushDefaultsTest.php
@@ -22,9 +22,9 @@ use Tests\TestCase;
 /**
  * Integration harness: cross-request metadata staleness under Octane and queue.
  *
- * Proves that stale metadata is cleared at the correct lifecycle boundary,
- * that php-fpm does not engage, that opt-out is honoured, and that non-toolkit
- * keys on the shared store survive the scoped flush.
+ * Proves that stale metadata is cleared at the correct lifecycle boundary, that
+ * php-fpm does not engage, that opt-out is honoured, and that non-toolkit keys
+ * on the shared store survive the scoped flush.
  *
  * Every test sets the relevant config and $_SERVER state EXPLICITLY so the
  * mechanism is validated before the shipped default is flipped in Tier 4.

--- a/tests/Integration/MiddlewareConfigApiScopeTest.php
+++ b/tests/Integration/MiddlewareConfigApiScopeTest.php
@@ -17,8 +17,8 @@ use Tests\TestCase;
  * Integration tests for JsonPrettyPrint middleware with api scope.
  *
  * This test class configures the JsonPrettyPrint scope to 'api' before the
- * service provider boots, verifying it is appended to the api middleware
- * group instead of the global stack.
+ * service provider boots, verifying it is appended to the api middleware group
+ * instead of the global stack.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/MiddlewareConfigCustomThrottleTest.php
+++ b/tests/Integration/MiddlewareConfigCustomThrottleTest.php
@@ -15,8 +15,8 @@ use Tests\TestCase;
  * Integration tests for the throttle middleware with a custom class override.
  *
  * This test class configures a custom throttle middleware class before the
- * service provider boots, verifying the custom class is used for the
- * throttle alias.
+ * service provider boots, verifying the custom class is used for the throttle
+ * alias.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/MiddlewareConfigDisabledTest.php
+++ b/tests/Integration/MiddlewareConfigDisabledTest.php
@@ -20,8 +20,8 @@ use Tests\TestCase;
  * Integration tests for the ApiServiceProvider with all middleware disabled.
  *
  * This test class configures the environment to disable all three middleware
- * registrations before the service provider boots, ensuring the disabled
- * code paths are exercised.
+ * registrations before the service provider boots, ensuring the disabled code
+ * paths are exercised.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/Providers/Registrars/ContainerBindingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/ContainerBindingRegistrarTest.php
@@ -19,9 +19,8 @@ use Tests\TestCase;
 /**
  * Integration tests for the ContainerBindingRegistrar.
  *
- * The binding behaviour is pinned by the ApiServiceProvider integration
- * suite; this test proves the registrar binds its surface when invoked
- * directly.
+ * The binding behaviour is pinned by the ApiServiceProvider integration suite;
+ * this test proves the registrar binds its surface when invoked directly.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -32,8 +31,8 @@ use Tests\TestCase;
 final class ContainerBindingRegistrarTest extends TestCase
 {
     /**
-     * Test that all toolkit container bindings resolve after the registrar
-     * is invoked.
+     * Test that all toolkit container bindings resolve after the registrar is
+     * invoked.
      *
      * @return void
      */

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -17,9 +17,9 @@ use Tests\TestCase;
 /**
  * Integration tests for the LifecycleRegistrar.
  *
- * The lifecycle configuration permutations are pinned by the
- * ApiServiceProvider integration suite; this test proves the registrar
- * registers its surface when invoked directly.
+ * The lifecycle configuration permutations are pinned by the ApiServiceProvider
+ * integration suite; this test proves the registrar registers its surface when
+ * invoked directly.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -63,8 +63,8 @@ final class LifecycleRegistrarTest extends TestCase
     }
 
     /**
-     * Test that the lifecycle subscribers are registered when the registrar
-     * is invoked with the queue lifecycle enabled.
+     * Test that the lifecycle subscribers are registered when the registrar is
+     * invoked with the queue lifecycle enabled.
      *
      * @return void
      */
@@ -163,8 +163,8 @@ final class LifecycleRegistrarTest extends TestCase
     }
 
     /**
-     * Determine whether the given event has a listener belonging to the
-     * given subscriber class.
+     * Determine whether the given event has a listener belonging to the given
+     * subscriber class.
      *
      * @param  class-string  $event
      * @param  class-string  $subscriber

--- a/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
@@ -15,9 +15,9 @@ use Tests\TestCase;
 /**
  * Integration tests for the LoggingRegistrar.
  *
- * The logging configuration permutations are pinned by the
- * ApiServiceProvider integration suite; this test proves the registrar
- * registers its surface when invoked directly.
+ * The logging configuration permutations are pinned by the ApiServiceProvider
+ * integration suite; this test proves the registrar registers its surface when
+ * invoked directly.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -29,8 +29,8 @@ final class LoggingRegistrarTest extends TestCase
 {
     /**
      * Test that the notification logging listeners are registered when the
-     * registrar is invoked with logging enabled and illuminate/notifications
-     * is installed (class_exists guard traversed successfully).
+     * registrar is invoked with logging enabled and illuminate/notifications is
+     * installed (class_exists guard traversed successfully).
      *
      * @return void
      */

--- a/tests/Integration/QuerySurfaceIntegrationTest.php
+++ b/tests/Integration/QuerySurfaceIntegrationTest.php
@@ -27,10 +27,10 @@ use Tests\TestCase;
  * filterable/sortable columns and traversable relations are applied, while
  * undeclared keys on the root resource are rejected (fail-closed) or dropped
  * (fail-quiet). Under the allowlist posture, nested columns on a traversed
- * relation are gated against the related resource's declared filterable set -
- * not against the legacy isSearchable predicate. When no mapped resource exists
- * for a related model the gate fails closed. A model with no mapped resource
- * rejects every key.
+ * relation are gated against the related resource's declared filterable set
+ * -not against the legacy isSearchable predicate. When no mapped resource
+ * exists for a related model the gate fails closed. A model with no mapped
+ * resource rejects every key.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/Repositories/DeferredWriteCacheInvalidationTest.php
+++ b/tests/Integration/Repositories/DeferredWriteCacheInvalidationTest.php
@@ -15,13 +15,13 @@ use Tests\Fixtures\Repositories\CacheableTagRepository;
 use Tests\TestCase;
 
 /**
- * Integration tests for per-query cache invalidation triggered by a
- * deferred write-pool flush at the lifecycle boundary.
+ * Integration tests for per-query cache invalidation triggered by a deferred
+ * write-pool flush at the lifecycle boundary.
  *
- * Warms a Cacheable repository's per-query cache, defers a write to the
- * same table, completes the boundary flush through the subscriber, then
- * asserts the next read observes the freshly persisted row rather than a
- * stale cached collection.
+ * Warms a Cacheable repository's per-query cache, defers a write to the same
+ * table, completes the boundary flush through the subscriber, then asserts the
+ * next read observes the freshly persisted row rather than a stale cached
+ * collection.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -85,9 +85,9 @@ final class DeferredWriteCacheInvalidationTest extends TestCase
     }
 
     /**
-     * Test that, with invalidation disabled, the boundary flush still
-     * persists the deferred row but leaves the stale cached collection in
-     * place until its TTL expires.
+     * Test that, with invalidation disabled, the boundary flush still persists
+     * the deferred row but leaves the stale cached collection in place until
+     * its TTL expires.
      *
      * @return void
      */

--- a/tests/Integration/Repositories/PerQueryCacheTest.php
+++ b/tests/Integration/Repositories/PerQueryCacheTest.php
@@ -171,8 +171,8 @@ final class PerQueryCacheTest extends TestCase
     }
 
     /**
-     * Test that a non-taggable file store invalidates per-query entries via
-     * the registry on a write.
+     * Test that a non-taggable file store invalidates per-query entries via the
+     * registry on a write.
      *
      * @return void
      */

--- a/tests/Integration/RequestLifecycleTest.php
+++ b/tests/Integration/RequestLifecycleTest.php
@@ -18,10 +18,9 @@ use Tests\TestCase;
 /**
  * End-to-end feature tests covering the full request lifecycle.
  *
- * Exercises the package exactly as a consuming application does: a real
- * HTTP request travels through the ParseApiQuery middleware, the
- * repository applies the parsed criteria, and the resource layer
- * serializes the response payload.
+ * Exercises the package exactly as a consuming application does: a real HTTP
+ * request travels through the ParseApiQuery middleware, the repository applies
+ * the parsed criteria, and the resource layer serializes the response payload.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -61,8 +60,7 @@ final class RequestLifecycleTest extends TestCase
     }
 
     /**
-     * Test that an index request returns the default fields for every
-     * record.
+     * Test that an index request returns the default fields for every record.
      *
      * @return void
      */
@@ -79,8 +77,7 @@ final class RequestLifecycleTest extends TestCase
     }
 
     /**
-     * Test that field selection via the query string restricts the
-     * payload.
+     * Test that field selection via the query string restricts the payload.
      *
      * @return void
      */
@@ -99,8 +96,7 @@ final class RequestLifecycleTest extends TestCase
     }
 
     /**
-     * Test that filters from the query string are applied to the result
-     * set.
+     * Test that filters from the query string are applied to the result set.
      *
      * @return void
      */
@@ -115,8 +111,7 @@ final class RequestLifecycleTest extends TestCase
     }
 
     /**
-     * Test that ordering from the query string is applied to the result
-     * set.
+     * Test that ordering from the query string is applied to the result set.
      *
      * @return void
      */
@@ -130,8 +125,7 @@ final class RequestLifecycleTest extends TestCase
     }
 
     /**
-     * Test that pagination limits are applied and meta information is
-     * present.
+     * Test that pagination limits are applied and meta information is present.
      *
      * @return void
      */

--- a/tests/Integration/ServiceIntegrationTest.php
+++ b/tests/Integration/ServiceIntegrationTest.php
@@ -21,8 +21,8 @@ use Tests\TestCase;
  * Integration tests for the real-path service lifecycle with a real database.
  *
  * Proves atomicity (a failed handle() leaves no committed writes), full
- * lifecycle sequencing, transaction skipping, and lock contention captured
- * in the result.
+ * lifecycle sequencing, transaction skipping, and lock contention captured in
+ * the result.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -109,8 +109,8 @@ final class ServiceIntegrationTest extends TestCase
     /**
      * Test that a lockable service acquires and releases the lock.
      *
-     * A contended run is captured as a failure in the result, proving
-     * the runner is total and never rethrows lock contention.
+     * A contended run is captured as a failure in the result, proving the
+     * runner is total and never rethrows lock contention.
      *
      * @return void
      */

--- a/tests/Integration/ServiceQueueIntegrationTest.php
+++ b/tests/Integration/ServiceQueueIntegrationTest.php
@@ -22,8 +22,8 @@ use Tests\TestCase;
  * Queue integration tests for ServiceJob and the actor serialisation path.
  *
  * Proves that a queued run re-hydrates identically, the actor survives
- * serialisation without consulting Auth or Request (NFR-07, AC-36), and
- * the worker run carries source = QUEUE.
+ * serialisation without consulting Auth or Request (NFR-07, AC-36), and the
+ * worker run carries source = QUEUE.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -37,8 +37,8 @@ final class ServiceQueueIntegrationTest extends TestCase
     /**
      * Set up the test environment.
      *
-     * Registers the ActorUser morph alias so EloquentActor can re-resolve
-     * the model after deserialisation, and resets the static concern capture.
+     * Registers the ActorUser morph alias so EloquentActor can re-resolve the
+     * model after deserialisation, and resets the static concern capture.
      *
      * @return void
      */
@@ -55,9 +55,9 @@ final class ServiceQueueIntegrationTest extends TestCase
      * Test that a queued run carries the actor without Auth in scope.
      *
      * No Auth::login() is called anywhere in this test. The actor travels
-     * exclusively via PHP serialisation through the ServiceJob payload.
-     * After the worker executes, the re-hydrated actor retains its
-     * identifier and label snapshot from construction time.
+     * exclusively via PHP serialisation through the ServiceJob payload. After
+     * the worker executes, the re-hydrated actor retains its identifier and
+     * label snapshot from construction time.
      *
      * @return void
      */
@@ -93,8 +93,8 @@ final class ServiceQueueIntegrationTest extends TestCase
      * Test that the worker run reports the QUEUE source.
      *
      * ServiceJob::handle() forces source = QUEUE on the context it hands to
-     * ServiceRunner, so the pipeline and any downstream consumers always
-     * know the invocation came from a queue worker.
+     * ServiceRunner, so the pipeline and any downstream consumers always know
+     * the invocation came from a queue worker.
      *
      * @return void
      */

--- a/tests/Unit/ApiQueryParserTest.php
+++ b/tests/Unit/ApiQueryParserTest.php
@@ -553,8 +553,7 @@ final class ApiQueryParserTest extends TestCase
     }
 
     /**
-     * Test that getFields trims values stored directly in the parameter
-     * state.
+     * Test that getFields trims values stored directly in the parameter state.
      *
      * @return void
      */
@@ -566,8 +565,7 @@ final class ApiQueryParserTest extends TestCase
     }
 
     /**
-     * Test that getCounts trims values stored directly in the parameter
-     * state.
+     * Test that getCounts trims values stored directly in the parameter state.
      *
      * @return void
      */
@@ -592,8 +590,8 @@ final class ApiQueryParserTest extends TestCase
     }
 
     /**
-     * Test that getPage truncates fractional values below one and returns
-     * the first page.
+     * Test that getPage truncates fractional values below one and returns the
+     * first page.
      *
      * @return void
      */

--- a/tests/Unit/Cache/MetadataKeyRegistryTest.php
+++ b/tests/Unit/Cache/MetadataKeyRegistryTest.php
@@ -56,8 +56,8 @@ final class MetadataKeyRegistryTest extends TestCase
     }
 
     /**
-     * Test that keys returns all distinct registered keys as an
-     * integer-indexed list.
+     * Test that keys returns all distinct registered keys as an integer-indexed
+     * list.
      *
      * @return void
      */

--- a/tests/Unit/Concerns/QueryParameterExtractorTest.php
+++ b/tests/Unit/Concerns/QueryParameterExtractorTest.php
@@ -42,8 +42,7 @@ final class QueryParameterExtractorTest extends TestCase
     }
 
     /**
-     * Test that extract returns an empty array when no parameters are
-     * supplied.
+     * Test that extract returns an empty array when no parameters are supplied.
      *
      * @return void
      */
@@ -244,8 +243,8 @@ final class QueryParameterExtractorTest extends TestCase
     }
 
     /**
-     * Test that extract wraps scalar non-string aggregation field values in
-     * an array.
+     * Test that extract wraps scalar non-string aggregation field values in an
+     * array.
      *
      * @return void
      */

--- a/tests/Unit/Contracts/FilterOperatorTest.php
+++ b/tests/Unit/Contracts/FilterOperatorTest.php
@@ -22,8 +22,8 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
 final class FilterOperatorTest extends TestCase
 {
     /**
-     * Test that the FilterOperator interface declares the apply method
-     * with the correct signature.
+     * Test that the FilterOperator interface declares the apply method with the
+     * correct signature.
      *
      * @return void
      */

--- a/tests/Unit/Contracts/SchemaIntrospectionProviderTest.php
+++ b/tests/Unit/Contracts/SchemaIntrospectionProviderTest.php
@@ -92,8 +92,7 @@ final class SchemaIntrospectionProviderTest extends TestCase
     }
 
     /**
-     * Test that getSearchableColumns is declared with the correct
-     * signature.
+     * Test that getSearchableColumns is declared with the correct signature.
      *
      * @return void
      */

--- a/tests/Unit/Enums/FlushStrategyTest.php
+++ b/tests/Unit/Enums/FlushStrategyTest.php
@@ -50,8 +50,7 @@ final class FlushStrategyTest extends TestCase
     }
 
     /**
-     * Test that from() resolves valid string values to the correct
-     * enum cases.
+     * Test that from() resolves valid string values to the correct enum cases.
      *
      * @return void
      */
@@ -63,8 +62,7 @@ final class FlushStrategyTest extends TestCase
     }
 
     /**
-     * Test that from() throws a ValueError for an invalid backing
-     * value.
+     * Test that from() throws a ValueError for an invalid backing value.
      *
      * @return void
      */

--- a/tests/Unit/Events/CacheFlushedTest.php
+++ b/tests/Unit/Events/CacheFlushedTest.php
@@ -32,8 +32,8 @@ final class CacheFlushedTest extends TestCase
     }
 
     /**
-     * Test that the event is a pure marker with no additional public
-     * properties or methods beyond those inherited from object.
+     * Test that the event is a pure marker with no additional public properties
+     * or methods beyond those inherited from object.
      *
      * @return void
      */

--- a/tests/Unit/Events/WritePoolFlushFailedTest.php
+++ b/tests/Unit/Events/WritePoolFlushFailedTest.php
@@ -21,8 +21,8 @@ use Tests\TestCase;
 final class WritePoolFlushFailedTest extends TestCase
 {
     /**
-     * Test that the flushResult property is accessible and returns the
-     * same instance provided to the constructor.
+     * Test that the flushResult property is accessible and returns the same
+     * instance provided to the constructor.
      *
      * @return void
      */

--- a/tests/Unit/Exceptions/ApiExceptionHandlerTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionHandlerTest.php
@@ -249,8 +249,7 @@ final class ApiExceptionHandlerTest extends TestCase
 
     /**
      * Test that the generic catch-all preserves the original status code,
-     * derives the title from the HTTP status, and uses the generic error
-     * code.
+     * derives the title from the HTTP status, and uses the generic error code.
      *
      * @return void
      */
@@ -276,8 +275,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that the generic catch-all preserves headers from the original
-     * HTTP exception.
+     * Test that the generic catch-all preserves headers from the original HTTP
+     * exception.
      *
      * @return void
      */
@@ -298,8 +297,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that application-layer database exceptions are not mapped to
-     * HTTP semantics and remain 500.
+     * Test that application-layer database exceptions are not mapped to HTTP
+     * semantics and remain 500.
      *
      * @return void
      */
@@ -480,8 +479,8 @@ final class ApiExceptionHandlerTest extends TestCase
      * mismatch exception with the non-standard 419 status code.
      *
      * The mapping is asserted directly because rendering the toolkit
-     * TokenMismatchException requires the package translations, which are
-     * not registered in this isolated test application.
+     * TokenMismatchException requires the package translations, which are not
+     * registered in this isolated test application.
      *
      * @return void
      */
@@ -496,8 +495,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that the json_when_expected strategy returns null for requests
-     * that do not expect JSON.
+     * Test that the json_when_expected strategy returns null for requests that
+     * do not expect JSON.
      *
      * @return void
      */
@@ -516,8 +515,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that the json_when_expected strategy renders JSON when the
-     * request expects JSON.
+     * Test that the json_when_expected strategy renders JSON when the request
+     * expects JSON.
      *
      * @return void
      */
@@ -537,8 +536,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that the auto strategy renders JSON for non-JSON requests when
-     * debug mode is disabled.
+     * Test that the auto strategy renders JSON for non-JSON requests when debug
+     * mode is disabled.
      *
      * @return void
      */
@@ -581,8 +580,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that JSON output is compact when the pretty request parameter is
-     * not provided.
+     * Test that JSON output is compact when the pretty request parameter is not
+     * provided.
      *
      * @return void
      */
@@ -628,8 +627,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that the include_debug_info config takes precedence over a
-     * disabled debug mode.
+     * Test that the include_debug_info config takes precedence over a disabled
+     * debug mode.
      *
      * @return void
      */
@@ -655,8 +654,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that the include_debug_info config takes precedence over an
-     * enabled debug mode.
+     * Test that the include_debug_info config takes precedence over an enabled
+     * debug mode.
      *
      * @return void
      */
@@ -680,8 +679,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that custom meta is returned untouched when debug mode is
-     * enabled but the exception has no previous exception.
+     * Test that custom meta is returned untouched when debug mode is enabled
+     * but the exception has no previous exception.
      *
      * @return void
      */
@@ -888,8 +887,8 @@ final class ApiExceptionHandlerTest extends TestCase
     }
 
     /**
-     * Test that getContext includes the authenticated user id and filters
-     * out empty values.
+     * Test that getContext includes the authenticated user id and filters out
+     * empty values.
      *
      * @return void
      */
@@ -1017,8 +1016,8 @@ final class ApiExceptionHandlerTest extends TestCase
      * Define the test environment.
      *
      * Loads the package's exception translations so rendered error responses
-     * include a non-empty detail rather than relying on the (now-fixed)
-     * raw-key fallback.
+     * include a non-empty detail rather than relying on the (now-fixed) raw-key
+     * fallback.
      *
      * @param  mixed  $app
      * @return void

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -299,8 +299,8 @@ final class ApiExceptionTest extends TestCase
 
     /**
      * Test that getCustomDetail returns an empty string when the detail
-     * translation key is missing from every locale, rather than leaking the
-     * raw translation key.
+     * translation key is missing from every locale, rather than leaking the raw
+     * translation key.
      *
      * @return void
      */
@@ -357,8 +357,8 @@ final class ApiExceptionTest extends TestCase
     }
 
     /**
-     * Test that getCustomTitle derives a multi-word title from the HTTP
-     * status enum case name when no translation exists.
+     * Test that getCustomTitle derives a multi-word title from the HTTP status
+     * enum case name when no translation exists.
      *
      * @return void
      */

--- a/tests/Unit/Exceptions/WritePoolFlushExceptionTest.php
+++ b/tests/Unit/Exceptions/WritePoolFlushExceptionTest.php
@@ -21,8 +21,8 @@ use Tests\TestCase;
 final class WritePoolFlushExceptionTest extends TestCase
 {
     /**
-     * Test that the constructor sets a message containing the failure
-     * and total counts from the flush result.
+     * Test that the constructor sets a message containing the failure and total
+     * counts from the flush result.
      *
      * @return void
      */

--- a/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
+++ b/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
@@ -46,8 +46,8 @@ final class DetectsCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that the middleware passes the request to the next handler
-     * and returns the response.
+     * Test that the middleware passes the request to the next handler and
+     * returns the response.
      *
      * @return void
      */
@@ -63,8 +63,8 @@ final class DetectsCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that the stored capabilities reflect the request's query
-     * parameters and headers.
+     * Test that the stored capabilities reflect the request's query parameters
+     * and headers.
      *
      * @return void
      */

--- a/tests/Unit/Http/Middleware/JsonPrettyPrintTest.php
+++ b/tests/Unit/Http/Middleware/JsonPrettyPrintTest.php
@@ -82,8 +82,7 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
-     * Test that non-JSON content passes through unmodified with
-     * pretty=true.
+     * Test that non-JSON content passes through unmodified with pretty=true.
      *
      * @return void
      */
@@ -141,8 +140,7 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
-     * Test that already pretty-printed JsonResponse produces identical
-     * output.
+     * Test that already pretty-printed JsonResponse produces identical output.
      *
      * @return void
      */
@@ -223,8 +221,7 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
-     * Test that plain Response with JSON content-type preserves malformed
-     * JSON.
+     * Test that plain Response with JSON content-type preserves malformed JSON.
      *
      * @return void
      */
@@ -261,8 +258,8 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
-     * Test that plain Response with JSON content-type and literal
-     * JSON null content is preserved.
+     * Test that plain Response with JSON content-type and literal JSON null
+     * content is preserved.
      *
      * @return void
      */
@@ -320,8 +317,7 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
-     * Test that deeply nested JsonResponse data is correctly
-     * pretty-printed.
+     * Test that deeply nested JsonResponse data is correctly pretty-printed.
      *
      * @return void
      */

--- a/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
+++ b/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
@@ -159,9 +159,9 @@ final class ThrottleRequestsTraitTest extends TestCase
     }
 
     /**
-     * Test that resolveRequestSignature is callable from a middleware
-     * subclass, asserting the trait override remains compatible with the
-     * protected hook declared by Laravel's base ThrottleRequests middleware.
+     * Test that resolveRequestSignature is callable from a middleware subclass,
+     * asserting the trait override remains compatible with the protected hook
+     * declared by Laravel's base ThrottleRequests middleware.
      *
      * @return void
      */

--- a/tests/Unit/Http/RequestCapabilitiesTest.php
+++ b/tests/Unit/Http/RequestCapabilitiesTest.php
@@ -60,8 +60,8 @@ final class RequestCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that fromRequest reflects the request state when resolving
-     * lazily, and caches the resolved instance on the request.
+     * Test that fromRequest reflects the request state when resolving lazily,
+     * and caches the resolved instance on the request.
      *
      * @return void
      */
@@ -152,8 +152,7 @@ final class RequestCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that all 4 accessor methods return the correct corresponding
-     * values.
+     * Test that all 4 accessor methods return the correct corresponding values.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/ApiResourceCollectionTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceCollectionTest.php
@@ -166,8 +166,8 @@ final class ApiResourceCollectionTest extends TestCase
     }
 
     /**
-     * Test that paginationInformation for LengthAwarePaginator returns meta
-     * and links.
+     * Test that paginationInformation for LengthAwarePaginator returns meta and
+     * links.
      *
      * @return void
      */
@@ -196,8 +196,8 @@ final class ApiResourceCollectionTest extends TestCase
     }
 
     /**
-     * Test that paginationInformation for CursorPaginator returns cursor
-     * meta and links.
+     * Test that paginationInformation for CursorPaginator returns cursor meta
+     * and links.
      *
      * @return void
      */
@@ -321,8 +321,8 @@ final class ApiResourceCollectionTest extends TestCase
     }
 
     /**
-     * Test that toArray does not eager load missing relations when wrapping
-     * raw model items.
+     * Test that toArray does not eager load missing relations when wrapping raw
+     * model items.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -77,8 +77,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that getResourceType throws LogicException when RESOURCE_TYPE is
-     * not defined.
+     * Test that getResourceType throws LogicException when RESOURCE_TYPE is not
+     * defined.
      *
      * @return void
      */
@@ -1801,8 +1801,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that eagerLoadMapFor skips metric fields in walkRelationsWith
-     * (line 608).
+     * Test that eagerLoadMapFor skips metric fields in walkRelationsWith (line
+     * 608).
      *
      * @return void
      */
@@ -1939,9 +1939,9 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that resolveSimpleProperty reflects on a model method when the
-     * field name matches a method that does NOT return an Attribute, covering
-     * the reflection path (lines 385-386) and the non-Attribute check (388).
+     * Test that resolveSimpleProperty reflects on a model method when the field
+     * name matches a method that does NOT return an Attribute, covering the
+     * reflection path (lines 385-386) and the non-Attribute check (388).
      *
      * @return void
      */
@@ -1993,9 +1993,9 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that the scoped-constraint closure returned by eagerLoadMapFor
-     * is properly invoked for a non-MorphTo builder, covering the
-     * Builder-path inside the wrapper closure (lines 637-640).
+     * Test that the scoped-constraint closure returned by eagerLoadMapFor is
+     * properly invoked for a non-MorphTo builder, covering the Builder-path
+     * inside the wrapper closure (lines 637-640).
      *
      * @return void
      */
@@ -2040,8 +2040,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that resolveSimpleProperty returns the accessor value when the
-     * model method's return type is Attribute (line 389).
+     * Test that resolveSimpleProperty returns the accessor value when the model
+     * method's return type is Attribute (line 389).
      *
      * @return void
      */
@@ -2096,8 +2096,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that getAttributeIfLoaded returns via __isset when the owner has
-     * no getAttributes method (line 555).
+     * Test that getAttributeIfLoaded returns via __isset when the owner has no
+     * getAttributes method (line 555).
      *
      * @return void
      */
@@ -2140,8 +2140,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that the scoped-constraint closure passes the query directly to
-     * the user constraint when the query is a MorphTo instance (lines 633-634).
+     * Test that the scoped-constraint closure passes the query directly to the
+     * user constraint when the query is a MorphTo instance (lines 633-634).
      *
      * @return void
      */
@@ -2185,8 +2185,7 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that getResourceType lowercases a mixed-case RESOURCE_TYPE
-     * constant.
+     * Test that getResourceType lowercases a mixed-case RESOURCE_TYPE constant.
      *
      * @return void
      */
@@ -2212,8 +2211,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that resolve skips fields missing from the schema and still
-     * resolves the remaining fields.
+     * Test that resolve skips fields missing from the schema and still resolves
+     * the remaining fields.
      *
      * @return void
      */
@@ -2304,8 +2303,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that load_missing does not load counts when the counts field is
-     * not requested.
+     * Test that load_missing does not load counts when the counts field is not
+     * requested.
      *
      * @return void
      */
@@ -2417,10 +2416,9 @@ final class ApiResourceTest extends TestCase
      * virtual field is requested and loadMissing loads the aggregate
      * attributes.
      *
-     * Uses AggregateCapturingModel that intercepts loadSum to set the
-     * name that ValueResolver expects, since Eloquent's 'relation as alias'
-     * form produces only the bare alias key rather than the full
-     * presentKey_sum_column key.
+     * Uses AggregateCapturingModel that intercepts loadSum to set the name that
+     * ValueResolver expects, since Eloquent's 'relation as alias' form produces
+     * only the bare alias key rather than the full presentKey_sum_column key.
      *
      * @return void
      */
@@ -2479,10 +2477,9 @@ final class ApiResourceTest extends TestCase
      * Test that averages payload is included when the averages field is
      * requested and loadMissing loads the aggregate attribute.
      *
-     * Uses AggregateCapturingModel that intercepts loadAvg to set the
-     * name that ValueResolver expects, since Eloquent's 'relation as alias'
-     * form produces only the bare alias key rather than the full
-     * presentKey_avg_column key.
+     * Uses AggregateCapturingModel that intercepts loadAvg to set the name that
+     * ValueResolver expects, since Eloquent's 'relation as alias' form produces
+     * only the bare alias key rather than the full presentKey_avg_column key.
      *
      * @return void
      */
@@ -2510,8 +2507,8 @@ final class ApiResourceTest extends TestCase
 
     /**
      * Test that the averages key is absent from the resolved output when the
-     * averages virtual field is not included in the requested fields, even
-     * when getAverages returns a non-null value and an attribute is preloaded.
+     * averages virtual field is not included in the requested fields, even when
+     * getAverages returns a non-null value and an attribute is preloaded.
      *
      * @return void
      */
@@ -2578,10 +2575,9 @@ final class ApiResourceTest extends TestCase
      * Test that loadMissing loads a non-default sum when it is explicitly
      * requested via the sums query parameter.
      *
-     * Uses AggregateCapturingModel that intercepts loadSum to set the
-     * name that ValueResolver expects, since Eloquent's 'relation as alias'
-     * form produces only the bare alias key rather than the full
-     * presentKey_sum_column key.
+     * Uses AggregateCapturingModel that intercepts loadSum to set the name that
+     * ValueResolver expects, since Eloquent's 'relation as alias' form produces
+     * only the bare alias key rather than the full presentKey_sum_column key.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -123,8 +123,8 @@ final class EagerLoadPlannerTest extends TestCase
     /**
      * Test that child resource relations are recursed into and prefixed.
      *
-     * When the API query requests relation fields for the child resource,
-     * the planner recurses into those fields and prefixes the paths.
+     * When the API query requests relation fields for the child resource, the
+     * planner recurses into those fields and prefixes the paths.
      *
      * @return void
      */
@@ -189,9 +189,9 @@ final class EagerLoadPlannerTest extends TestCase
     /**
      * Test that visited resource/path pairs are not traversed again.
      *
-     * When a resource class references the same relation path that has
-     * already been visited, the planner skips it to prevent duplicate
-     * entries and unbounded traversal.
+     * When a resource class references the same relation path that has already
+     * been visited, the planner skips it to prevent duplicate entries and
+     * unbounded traversal.
      *
      * @return void
      */
@@ -364,8 +364,8 @@ final class EagerLoadPlannerTest extends TestCase
     }
 
     /**
-     * Test that the API query fields for a child resource type are used when
-     * no explicit fields are defined on the relation.
+     * Test that the API query fields for a child resource type are used when no
+     * explicit fields are defined on the relation.
      *
      * @return void
      */
@@ -488,8 +488,8 @@ final class EagerLoadPlannerTest extends TestCase
     }
 
     /**
-     * Test that count definitions after an excluded one are still evaluated
-     * and that every matching count is returned.
+     * Test that count definitions after an excluded one are still evaluated and
+     * that every matching count is returned.
      *
      * @return void
      */
@@ -549,8 +549,8 @@ final class EagerLoadPlannerTest extends TestCase
     }
 
     /**
-     * Test that an already-visited path is skipped while later fields are
-     * still traversed.
+     * Test that an already-visited path is skipped while later fields are still
+     * traversed.
      *
      * @return void
      */
@@ -572,8 +572,8 @@ final class EagerLoadPlannerTest extends TestCase
     }
 
     /**
-     * Test that relations pointing at non-ApiResource classes are not
-     * recursed into.
+     * Test that relations pointing at non-ApiResource classes are not recursed
+     * into.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/Concerns/FieldResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/FieldResolverTest.php
@@ -428,8 +428,8 @@ final class FieldResolverTest extends TestCase
     }
 
     /**
-     * Test that shouldIncludeSumsField returns false when requested fields
-     * lack sums and it is not in defaults.
+     * Test that shouldIncludeSumsField returns false when requested fields lack
+     * sums and it is not in defaults.
      *
      * @return void
      */
@@ -444,8 +444,8 @@ final class FieldResolverTest extends TestCase
     }
 
     /**
-     * Test that shouldIncludeAveragesField returns true when averages is in
-     * the API query fields.
+     * Test that shouldIncludeAveragesField returns true when averages is in the
+     * API query fields.
      *
      * @return void
      */
@@ -478,8 +478,8 @@ final class FieldResolverTest extends TestCase
     }
 
     /**
-     * Test that shouldIncludeAveragesField returns true when averages is in
-     * the default fields and not excluded.
+     * Test that shouldIncludeAveragesField returns true when averages is in the
+     * default fields and not excluded.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/SchemaCompilerTest.php
@@ -747,8 +747,8 @@ final class SchemaCompilerTest extends TestCase
     }
 
     /**
-     * Test that sum entries produce a CompiledAggregateDefinition for the
-     * 'sum' metric with the correct present key.
+     * Test that sum entries produce a CompiledAggregateDefinition for the 'sum'
+     * metric with the correct present key.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/PolymorphicResourceTest.php
+++ b/tests/Unit/Http/Resources/PolymorphicResourceTest.php
@@ -213,8 +213,8 @@ final class PolymorphicResourceTest extends TestCase
     }
 
     /**
-     * Test that withAll sets the all flag locally and returns the instance
-     * for fluent chaining.
+     * Test that withAll sets the all flag locally and returns the instance for
+     * fluent chaining.
      *
      * @return void
      */
@@ -228,8 +228,8 @@ final class PolymorphicResourceTest extends TestCase
     }
 
     /**
-     * Test that withFields sets the fields locally and returns the instance
-     * for fluent chaining.
+     * Test that withFields sets the fields locally and returns the instance for
+     * fluent chaining.
      *
      * @return void
      */
@@ -243,8 +243,8 @@ final class PolymorphicResourceTest extends TestCase
     }
 
     /**
-     * Test that withoutFields sets the excluded fields locally and returns
-     * the instance for fluent chaining.
+     * Test that withoutFields sets the excluded fields locally and returns the
+     * instance for fluent chaining.
      *
      * @return void
      */
@@ -258,8 +258,8 @@ final class PolymorphicResourceTest extends TestCase
     }
 
     /**
-     * Test that mapping a resource does not eager load missing relations on
-     * the underlying model.
+     * Test that mapping a resource does not eager load missing relations on the
+     * underlying model.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/Schema/AggregateDefinitionTest.php
+++ b/tests/Unit/Http/Resources/Schema/AggregateDefinitionTest.php
@@ -209,7 +209,7 @@ final class AggregateDefinitionTest extends TestCase
     public function testToArrayIncludesOpenApiDeclarationWhenSet(): void
     {
         $sum = Sum::of('posts', 'id');
-        $sum->openapi()->type('integer')->end();
+        $sum->openapi()->type('integer');
 
         $array = $sum->toArray();
 

--- a/tests/Unit/Http/Resources/Schema/FieldTest.php
+++ b/tests/Unit/Http/Resources/Schema/FieldTest.php
@@ -416,8 +416,8 @@ final class FieldTest extends TestCase
     /**
      * Test that the openapi key is absent when no declaration was made.
      *
-     * This is the byte-for-byte backward-compatibility oracle (AC-11): a
-     * scalar field with no openapi() call must serialize identically.
+     * This is the byte-for-byte backward-compatibility oracle (AC-11): a scalar
+     * field with no openapi() call must serialize identically.
      *
      * @return void
      */

--- a/tests/Unit/Http/Routing/AuthorizedControllerTest.php
+++ b/tests/Unit/Http/Routing/AuthorizedControllerTest.php
@@ -39,8 +39,8 @@ final class AuthorizedControllerTest extends TestCase
     }
 
     /**
-     * Test that getResourceModel throws LogicException when the constant is
-     * not defined.
+     * Test that getResourceModel throws LogicException when the constant is not
+     * defined.
      *
      * @return void
      */

--- a/tests/Unit/Http/Routing/ControllerTest.php
+++ b/tests/Unit/Http/Routing/ControllerTest.php
@@ -162,8 +162,7 @@ final class ControllerTest extends TestCase
 
     /**
      * Test that respondWithData is callable from a subclass, asserting the
-     * protected extension surface remains available to consuming
-     * controllers.
+     * protected extension surface remains available to consuming controllers.
      *
      * @return void
      */
@@ -215,8 +214,8 @@ final class ControllerTest extends TestCase
     /**
      * Create a controller subclass exposing the protected response helpers.
      *
-     * Calling the helpers from a subclass scope asserts they remain part of
-     * the protected extension surface available to consuming controllers.
+     * Calling the helpers from a subclass scope asserts they remain part of the
+     * protected extension surface available to consuming controllers.
      *
      * @return object
      */

--- a/tests/Unit/Listeners/NotificationListenerTest.php
+++ b/tests/Unit/Listeners/NotificationListenerTest.php
@@ -200,8 +200,8 @@ final class NotificationListenerTest extends TestCase
     }
 
     /**
-     * Test that the payload omits the notifiable id when the notifiable is
-     * not an Eloquent model.
+     * Test that the payload omits the notifiable id when the notifiable is not
+     * an Eloquent model.
      *
      * @return void
      */

--- a/tests/Unit/Listeners/QueueFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/QueueFlushSubscriberTest.php
@@ -96,8 +96,8 @@ final class QueueFlushSubscriberTest extends TestCase
      * Test that handleFlush does not flush for a sync connection (in-request
      * job).
      *
-     * Pins AC-06: sync jobs run within the HTTP request and must not trigger
-     * a metadata flush at the job boundary.
+     * Pins AC-06: sync jobs run within the HTTP request and must not trigger a
+     * metadata flush at the job boundary.
      *
      * @return void
      */

--- a/tests/Unit/Listeners/Traits/ProvidesExclusiveLockTest.php
+++ b/tests/Unit/Listeners/Traits/ProvidesExclusiveLockTest.php
@@ -140,8 +140,8 @@ final class ProvidesExclusiveLockTest extends TestCase
     }
 
     /**
-     * Test that handleWithLock remains callable from a subclass of the
-     * listener that uses the trait.
+     * Test that handleWithLock remains callable from a subclass of the listener
+     * that uses the trait.
      *
      * @return void
      */
@@ -183,8 +183,7 @@ final class ProvidesExclusiveLockTest extends TestCase
     }
 
     /**
-     * Test that handleWithLock acquires the lock with a ten second
-     * expiration.
+     * Test that handleWithLock acquires the lock with a ten second expiration.
      *
      * @return void
      */

--- a/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
@@ -41,10 +41,10 @@ final class WritePoolFlushSubscriberTest extends TestCase
     /**
      * Set up the test environment.
      *
-     * The per-query cache invalidation path is covered by its own
-     * dedicated tests below; disable it here so the flush and escalation
-     * assertions observe the subscriber in isolation without the
-     * container being asked for the invalidator.
+     * The per-query cache invalidation path is covered by its own dedicated
+     * tests below; disable it here so the flush and escalation assertions
+     * observe the subscriber in isolation without the container being asked for
+     * the invalidator.
      *
      * @return void
      */
@@ -162,8 +162,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that dispatching JobFailed flushes the pool through the
-     * registered listener.
+     * Test that dispatching JobFailed flushes the pool through the registered
+     * listener.
      *
      * @return void
      */
@@ -177,8 +177,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that handleFlush resolves the WritePool from the container
-     * and calls flush.
+     * Test that handleFlush resolves the WritePool from the container and calls
+     * flush.
      *
      * @return void
      */
@@ -233,8 +233,7 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that handleFlush dispatches WritePoolFlushFailed event on
-     * failure.
+     * Test that handleFlush dispatches WritePoolFlushFailed event on failure.
      *
      * @return void
      */
@@ -333,8 +332,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that an unexpected throwable during pool resolution is
-     * caught and logged at error level without crashing the boundary.
+     * Test that an unexpected throwable during pool resolution is caught and
+     * logged at error level without crashing the boundary.
      *
      * @return void
      */
@@ -359,9 +358,9 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that a WritePoolFlushException raised by the throw strategy
-     * is escalated loudly with a warning and a dispatched event rather
-     * than being swallowed into a generic error log.
+     * Test that a WritePoolFlushException raised by the throw strategy is
+     * escalated loudly with a warning and a dispatched event rather than being
+     * swallowed into a generic error log.
      *
      * @return void
      */
@@ -388,8 +387,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that the subscriber does not re-throw a flush exception when
-     * the rethrow_at_boundary flag is disabled.
+     * Test that the subscriber does not re-throw a flush exception when the
+     * rethrow_at_boundary flag is disabled.
      *
      * @return void
      */
@@ -417,8 +416,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that the subscriber re-throws a flush exception after
-     * escalating it when the rethrow_at_boundary flag is enabled.
+     * Test that the subscriber re-throws a flush exception after escalating it
+     * when the rethrow_at_boundary flag is enabled.
      *
      * @return void
      */
@@ -446,8 +445,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that, when invalidation is enabled, the subscriber invalidates
-     * the per-query cache for every table the flush persisted.
+     * Test that, when invalidation is enabled, the subscriber invalidates the
+     * per-query cache for every table the flush persisted.
      *
      * @return void
      */
@@ -485,8 +484,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that, when invalidation is disabled, the subscriber never
-     * resolves the invalidator from the container.
+     * Test that, when invalidation is disabled, the subscriber never resolves
+     * the invalidator from the container.
      *
      * @return void
      */
@@ -509,8 +508,8 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
-     * Test that a throw-strategy failure still invalidates the per-query
-     * cache for every attempted table before the failure is escalated.
+     * Test that a throw-strategy failure still invalidates the per-query cache
+     * for every attempted table before the failure is escalated.
      *
      * @return void
      */

--- a/tests/Unit/OpenApi/Builder/QueryParameterBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/QueryParameterBuilderTest.php
@@ -171,8 +171,8 @@ final class QueryParameterBuilderTest extends TestCase
     }
 
     /**
-     * Build a QueryParameterBuilder backed by a stub returning the default
-     * 12+4 operator vocabulary.
+     * Build a QueryParameterBuilder backed by a stub returning the default 12+4
+     * operator vocabulary.
      *
      * @return \SineMacula\ApiToolkit\OpenApi\Builder\QueryParameterBuilder
      */

--- a/tests/Unit/OpenApi/Resolution/ColumnTypeMapperTest.php
+++ b/tests/Unit/OpenApi/Resolution/ColumnTypeMapperTest.php
@@ -70,8 +70,8 @@ final class ColumnTypeMapperTest extends TestCase
     }
 
     /**
-     * Test that each driver type name maps to the expected JSON Schema type
-     * and format.
+     * Test that each driver type name maps to the expected JSON Schema type and
+     * format.
      *
      * @param  string  $typeName
      * @param  string  $expectedType
@@ -141,8 +141,8 @@ final class ColumnTypeMapperTest extends TestCase
     }
 
     /**
-     * Test that a boolean cast overrides a tinyint column, resolving the
-     * MySQL tinyint(1) ambiguity in favour of boolean.
+     * Test that a boolean cast overrides a tinyint column, resolving the MySQL
+     * tinyint(1) ambiguity in favour of boolean.
      *
      * @return void
      */
@@ -157,8 +157,7 @@ final class ColumnTypeMapperTest extends TestCase
     }
 
     /**
-     * Test that absent a cast, a tinyint column maps conservatively to
-     * integer.
+     * Test that absent a cast, a tinyint column maps conservatively to integer.
      *
      * @return void
      */
@@ -221,8 +220,8 @@ final class ColumnTypeMapperTest extends TestCase
     }
 
     /**
-     * Test that a datetime cast carrying a format argument still resolves to
-     * a date-time format.
+     * Test that a datetime cast carrying a format argument still resolves to a
+     * date-time format.
      *
      * @return void
      */
@@ -283,8 +282,8 @@ final class ColumnTypeMapperTest extends TestCase
     }
 
     /**
-     * Test that an unrecognised cast falls back to the column type-name
-     * mapping rather than producing the wrong shape.
+     * Test that an unrecognised cast falls back to the column type-name mapping
+     * rather than producing the wrong shape.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/ApiRepositoryTest.php
+++ b/tests/Unit/Repositories/ApiRepositoryTest.php
@@ -89,8 +89,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that usingResource sets the custom resource class and propagates
-     * to existing ApiCriteria.
+     * Test that usingResource sets the custom resource class and propagates to
+     * existing ApiCriteria.
      *
      * @return void
      */
@@ -359,8 +359,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that withApiCriteria propagates an already-set custom
-     * resource class onto the newly created criteria instance.
+     * Test that withApiCriteria propagates an already-set custom resource class
+     * onto the newly created criteria instance.
      *
      * @return void
      */
@@ -420,8 +420,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that paginate appends the current query string to the
-     * generated pagination URLs.
+     * Test that paginate appends the current query string to the generated
+     * pagination URLs.
      *
      * @return void
      */
@@ -450,8 +450,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that scopeByIds de-duplicates the given ids before binding
-     * them into the query.
+     * Test that scopeByIds de-duplicates the given ids before binding them into
+     * the query.
      *
      * @return void
      */
@@ -572,8 +572,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that withApiCriteria propagates an already-set custom resource
-     * class to the new criteria instance.
+     * Test that withApiCriteria propagates an already-set custom resource class
+     * to the new criteria instance.
      *
      * @return void
      */
@@ -588,8 +588,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that persist auto-discovers BelongsTo cast via reflection
-     * when the attribute is not pre-cached.
+     * Test that persist auto-discovers BelongsTo cast via reflection when the
+     * attribute is not pre-cached.
      *
      * @return void
      */
@@ -627,8 +627,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast returns true for a class-based cast
-     * that matches exactly (line 314 in ApiRepository.php).
+     * Test that castMatchesLaravelCast returns true for a class-based cast that
+     * matches exactly (line 314 in ApiRepository.php).
      *
      * Registers UserStatus::class under the 'enum' native key so that the
      * class_exists branch fires and returns true before the string-equality
@@ -659,8 +659,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that an ApiRepository subclass without the Cacheable trait
-     * reads directly from the database.
+     * Test that an ApiRepository subclass without the Cacheable trait reads
+     * directly from the database.
      *
      * @return void
      */
@@ -675,8 +675,8 @@ final class ApiRepositoryTest extends TestCase
     }
 
     /**
-     * Test that an ApiRepository subclass with the Cacheable trait
-     * returns cached data on subsequent reads.
+     * Test that an ApiRepository subclass with the Cacheable trait returns
+     * cached data on subsequent reads.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
+++ b/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
@@ -65,8 +65,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist delegates scalar string attributes to the
-     * model's setAttribute method.
+     * Test that persist delegates scalar string attributes to the model's
+     * setAttribute method.
      *
      * @return void
      */
@@ -120,8 +120,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist delegates array attributes to the model's
-     * setAttribute method.
+     * Test that persist delegates array attributes to the model's setAttribute
+     * method.
      *
      * @return void
      */
@@ -137,8 +137,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist delegates enum attributes to the model's
-     * setAttribute method.
+     * Test that persist delegates enum attributes to the model's setAttribute
+     * method.
      *
      * @return void
      */
@@ -156,8 +156,7 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist sets a falsy value to null for object cast
-     * attributes.
+     * Test that persist sets a falsy value to null for object cast attributes.
      *
      * @return void
      */
@@ -173,8 +172,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist casts truthy values to stdClass for object
-     * cast attributes.
+     * Test that persist casts truthy values to stdClass for object cast
+     * attributes.
      *
      * @return void
      */
@@ -188,8 +187,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist associates a BelongsTo relation via the
-     * associate method.
+     * Test that persist associates a BelongsTo relation via the associate
+     * method.
      *
      * @return void
      */
@@ -207,8 +206,7 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist syncs a BelongsToMany relation after
-     * saving the model.
+     * Test that persist syncs a BelongsToMany relation after saving the model.
      *
      * @return void
      */
@@ -231,8 +229,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist syncs a relation when passed a Collection
-     * of models, plucking IDs automatically.
+     * Test that persist syncs a relation when passed a Collection of models,
+     * plucking IDs automatically.
      *
      * @return void
      */
@@ -278,8 +276,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist syncs a relation when passed a plain array
-     * of integer IDs.
+     * Test that persist syncs a relation when passed a plain array of integer
+     * IDs.
      *
      * @return void
      */
@@ -298,8 +296,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist syncs a relation when passed a single
-     * Model instance, using its ID via the ArrayAccess path.
+     * Test that persist syncs a relation when passed a single Model instance,
+     * using its ID via the ArrayAccess path.
      *
      * @return void
      */
@@ -318,8 +316,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist syncing a Collection detaches relations that
-     * are not present in the new value.
+     * Test that persist syncing a Collection detaches relations that are not
+     * present in the new value.
      *
      * @return void
      */
@@ -344,8 +342,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist syncing an array of IDs detaches relations
-     * that are not present in the new value.
+     * Test that persist syncing an array of IDs detaches relations that are not
+     * present in the new value.
      *
      * @return void
      */
@@ -370,8 +368,7 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist skips attributes whose cast resolves to
-     * null.
+     * Test that persist skips attributes whose cast resolves to null.
      *
      * @return void
      */
@@ -388,8 +385,7 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist returns the boolean result of the model's
-     * save method.
+     * Test that persist returns the boolean result of the model's save method.
      *
      * @return void
      */
@@ -405,8 +401,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveAttributeCasts loads the cast map from cache when
-     * a cached value is available.
+     * Test that resolveAttributeCasts loads the cast map from cache when a
+     * cached value is available.
      *
      * @return void
      */
@@ -428,8 +424,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveAttributeCasts resolves casts from the model when
-     * the cache is empty and stores them to cache.
+     * Test that resolveAttributeCasts resolves casts from the model when the
+     * cache is empty and stores them to cache.
      *
      * @return void
      */
@@ -454,8 +450,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that persist stores the resolved casts in the memo cache
-     * under the model class key.
+     * Test that persist stores the resolved casts in the memo cache under the
+     * model class key.
      *
      * @return void
      */
@@ -473,8 +469,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForAttribute returns null when both the cast
-     * and the model are null.
+     * Test that resolveCastForAttribute returns null when both the cast and the
+     * model are null.
      *
      * @return void
      */
@@ -486,8 +482,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForAttribute resolves the native cast key
-     * from the configured cast map.
+     * Test that resolveCastForAttribute resolves the native cast key from the
+     * configured cast map.
      *
      * @return void
      */
@@ -504,8 +500,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForRelation returns 'associate' for a
-     * BelongsTo relation.
+     * Test that resolveCastForRelation returns 'associate' for a BelongsTo
+     * relation.
      *
      * @return void
      */
@@ -523,8 +519,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForRelation returns 'associate' for a
-     * MorphTo relation.
+     * Test that resolveCastForRelation returns 'associate' for a MorphTo
+     * relation.
      *
      * @return void
      */
@@ -542,8 +538,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForRelation returns 'sync' for a
-     * BelongsToMany relation.
+     * Test that resolveCastForRelation returns 'sync' for a BelongsToMany
+     * relation.
      *
      * @return void
      */
@@ -561,8 +557,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForRelation returns null when the attribute
-     * is not a recognized relation.
+     * Test that resolveCastForRelation returns null when the attribute is not a
+     * recognized relation.
      *
      * @return void
      */
@@ -579,8 +575,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForRelation returns null for a relation type
-     * that does not support associate or sync semantics.
+     * Test that resolveCastForRelation returns null for a relation type that
+     * does not support associate or sync semantics.
      *
      * @return void
      */
@@ -617,8 +613,7 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast returns true for an exact string
-     * match.
+     * Test that castMatchesLaravelCast returns true for an exact string match.
      *
      * @return void
      */
@@ -630,8 +625,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast returns true for a wildcard
-     * pattern match.
+     * Test that castMatchesLaravelCast returns true for a wildcard pattern
+     * match.
      *
      * @return void
      */
@@ -643,8 +638,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast returns true when the Laravel
-     * cast is a class and the base cast matches exactly.
+     * Test that castMatchesLaravelCast returns true when the Laravel cast is a
+     * class and the base cast matches exactly.
      *
      * @return void
      */
@@ -656,8 +651,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast matches a class-based cast that
-     * carries parameters.
+     * Test that castMatchesLaravelCast matches a class-based cast that carries
+     * parameters.
      *
      * @return void
      */
@@ -669,8 +664,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast returns false when the Laravel
-     * cast is an existing class that does not match the base cast.
+     * Test that castMatchesLaravelCast returns false when the Laravel cast is
+     * an existing class that does not match the base cast.
      *
      * @return void
      */
@@ -682,8 +677,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that castMatchesLaravelCast returns false when the casts do
-     * not match.
+     * Test that castMatchesLaravelCast returns false when the casts do not
+     * match.
      *
      * @return void
      */
@@ -695,8 +690,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that flush clears the cached casts, forcing re-resolution
-     * on the next call.
+     * Test that flush clears the cached casts, forcing re-resolution on the
+     * next call.
      *
      * @return void
      */
@@ -722,8 +717,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that flush on a fresh AttributeSetter with no prior cast
-     * resolution does not throw an exception.
+     * Test that flush on a fresh AttributeSetter with no prior cast resolution
+     * does not throw an exception.
      *
      * @return void
      */
@@ -737,8 +732,8 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that resolveCastForAttribute returns 'enum' for a cast
-     * string that is a valid enum class.
+     * Test that resolveCastForAttribute returns 'enum' for a cast string that
+     * is a valid enum class.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/CacheSizeGuardTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheSizeGuardTest.php
@@ -80,8 +80,8 @@ final class CacheSizeGuardTest extends TestCase
     }
 
     /**
-     * Test that a result whose row count exactly equals the ceiling is
-     * allowed, pinning the bound as exclusive rather than inclusive.
+     * Test that a result whose row count exactly equals the ceiling is allowed,
+     * pinning the bound as exclusive rather than inclusive.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/CacheStatusTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheStatusTest.php
@@ -37,8 +37,7 @@ final class CacheStatusTest extends TestCase
     }
 
     /**
-     * Test that isPopulated returns false when the cache is not
-     * populated.
+     * Test that isPopulated returns false when the cache is not populated.
      *
      * @return void
      */
@@ -54,8 +53,8 @@ final class CacheStatusTest extends TestCase
     }
 
     /**
-     * Test that getAge returns the number of seconds when the cache
-     * is populated.
+     * Test that getAge returns the number of seconds when the cache is
+     * populated.
      *
      * @return void
      */
@@ -87,8 +86,8 @@ final class CacheStatusTest extends TestCase
     }
 
     /**
-     * Test that getLastInvalidatedAt returns the Carbon instance
-     * when the cache has been previously invalidated.
+     * Test that getLastInvalidatedAt returns the Carbon instance when the cache
+     * has been previously invalidated.
      *
      * @return void
      */
@@ -106,8 +105,8 @@ final class CacheStatusTest extends TestCase
     }
 
     /**
-     * Test that getLastInvalidatedAt returns null when the cache has
-     * never been invalidated.
+     * Test that getLastInvalidatedAt returns null when the cache has never been
+     * invalidated.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/CacheStoreTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheStoreTest.php
@@ -430,8 +430,8 @@ final class CacheStoreTest extends TestCase
 
     /**
      * Test that invalidateTable bumps the generational version on a
-     * non-taggable store when the registry is enabled, so a previously
-     * cached entry reads back as a miss.
+     * non-taggable store when the registry is enabled, so a previously cached
+     * entry reads back as a miss.
      *
      * @return void
      */
@@ -446,8 +446,8 @@ final class CacheStoreTest extends TestCase
     }
 
     /**
-     * Test that invalidateTable leaves a non-taggable store's entry intact
-     * when the registry is disabled, because it cannot bump the version.
+     * Test that invalidateTable leaves a non-taggable store's entry intact when
+     * the registry is disabled, because it cannot bump the version.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/CacheableTest.php
+++ b/tests/Unit/Repositories/Concerns/CacheableTest.php
@@ -78,8 +78,8 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that the second read returns cached data without executing a
-     * new database query.
+     * Test that the second read returns cached data without executing a new
+     * database query.
      *
      * @return void
      */
@@ -165,8 +165,7 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that withoutCache is transient and only applies to the next
-     * read.
+     * Test that withoutCache is transient and only applies to the next read.
      *
      * @return void
      */
@@ -259,8 +258,8 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that a custom cache key prefix is used instead of the model
-     * table name.
+     * Test that a custom cache key prefix is used instead of the model table
+     * name.
      *
      * @return void
      */
@@ -279,8 +278,8 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that withoutCache reads fresh data from the database while
-     * the cached snapshot remains stale.
+     * Test that withoutCache reads fresh data from the database while the
+     * cached snapshot remains stale.
      *
      * @return void
      */
@@ -296,8 +295,8 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that boot invokes the parent boot chain so inherited
-     * repository collaborators are initialized.
+     * Test that boot invokes the parent boot chain so inherited repository
+     * collaborators are initialized.
      *
      * @return void
      */
@@ -346,8 +345,8 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that distinct scoped reads resolve distinct cached rows rather
-     * than colliding on a single whole-table entry.
+     * Test that distinct scoped reads resolve distinct cached rows rather than
+     * colliding on a single whole-table entry.
      *
      * @return void
      */
@@ -361,8 +360,8 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that a cached scoped read is served from the cache on repeat
-     * without returning a different scope's rows.
+     * Test that a cached scoped read is served from the cache on repeat without
+     * returning a different scope's rows.
      *
      * @return void
      */
@@ -463,8 +462,7 @@ final class CacheableTest extends TestCase
     }
 
     /**
-     * Test that a fresh read repopulates the cache after a write
-     * invalidation.
+     * Test that a fresh read repopulates the cache after a write invalidation.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/DeferrableTest.php
+++ b/tests/Unit/Repositories/Concerns/DeferrableTest.php
@@ -66,8 +66,8 @@ final class DeferrableTest extends TestCase
     }
 
     /**
-     * Test that boot invokes the parent boot chain so inherited
-     * repository collaborators are initialized.
+     * Test that boot invokes the parent boot chain so inherited repository
+     * collaborators are initialized.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/DeferredWriteCacheInvalidatorTest.php
+++ b/tests/Unit/Repositories/Concerns/DeferredWriteCacheInvalidatorTest.php
@@ -40,8 +40,8 @@ final class DeferredWriteCacheInvalidatorTest extends TestCase
     }
 
     /**
-     * Test that invalidating a table on a taggable store flushes the
-     * table tag, so a previously cached entry reads back as a miss.
+     * Test that invalidating a table on a taggable store flushes the table tag,
+     * so a previously cached entry reads back as a miss.
      *
      * @return void
      */
@@ -77,8 +77,8 @@ final class DeferredWriteCacheInvalidatorTest extends TestCase
 
     /**
      * Test that, on a non-taggable store with the registry disabled,
-     * invalidation cannot bump the version, so the stale entry survives
-     * until its TTL expires.
+     * invalidation cannot bump the version, so the stale entry survives until
+     * its TTL expires.
      *
      * @return void
      */
@@ -96,8 +96,7 @@ final class DeferredWriteCacheInvalidatorTest extends TestCase
     }
 
     /**
-     * Test that every table in the list is invalidated, not just the
-     * first.
+     * Test that every table in the list is invalidated, not just the first.
      *
      * @return void
      */
@@ -113,8 +112,8 @@ final class DeferredWriteCacheInvalidatorTest extends TestCase
     }
 
     /**
-     * Test that an empty table list is a no-op that leaves existing
-     * cache entries untouched.
+     * Test that an empty table list is a no-op that leaves existing cache
+     * entries untouched.
      *
      * @return void
      */
@@ -128,8 +127,8 @@ final class DeferredWriteCacheInvalidatorTest extends TestCase
     }
 
     /**
-     * Test that invalidation targets the configured repository cache
-     * store rather than only the framework default.
+     * Test that invalidation targets the configured repository cache store
+     * rather than only the framework default.
      *
      * @return void
      */
@@ -148,8 +147,8 @@ final class DeferredWriteCacheInvalidatorTest extends TestCase
     }
 
     /**
-     * Test that a non-string store configuration falls back to the array
-     * driver rather than passing a non-string to the cache manager.
+     * Test that a non-string store configuration falls back to the array driver
+     * rather than passing a non-string to the cache manager.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/QueryFingerprintTest.php
+++ b/tests/Unit/Repositories/Concerns/QueryFingerprintTest.php
@@ -191,8 +191,8 @@ final class QueryFingerprintTest extends TestCase
 
     /**
      * Test that the registered eager loads are folded into the fingerprint, so
-     * with('posts')->get() does not collide with a plain get() (the eager
-     * loads are invisible to the compiled base SQL).
+     * with('posts')->get() does not collide with a plain get() (the eager loads
+     * are invisible to the compiled base SQL).
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/ReferenceCacheTest.php
+++ b/tests/Unit/Repositories/Concerns/ReferenceCacheTest.php
@@ -94,8 +94,8 @@ final class ReferenceCacheTest extends TestCase
     }
 
     /**
-     * Test that repeated reads are served from the instance memo even after
-     * the backing store is evicted, proving the snapshot is deserialized once.
+     * Test that repeated reads are served from the instance memo even after the
+     * backing store is evicted, proving the snapshot is deserialized once.
      *
      * @return void
      */
@@ -118,8 +118,8 @@ final class ReferenceCacheTest extends TestCase
     }
 
     /**
-     * Test that loading the snapshot builds a key index for O(1) lookups,
-     * keyed by the model's primary key rather than collection position.
+     * Test that loading the snapshot builds a key index for O(1) lookups, keyed
+     * by the model's primary key rather than collection position.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/WritePoolFlushResultTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolFlushResultTest.php
@@ -55,8 +55,7 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that successCount returns the value provided to the
-     * constructor.
+     * Test that successCount returns the value provided to the constructor.
      *
      * @return void
      */
@@ -68,8 +67,7 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that failureCount returns the value provided to the
-     * constructor.
+     * Test that failureCount returns the value provided to the constructor.
      *
      * @return void
      */
@@ -81,8 +79,7 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that totalCount returns the sum of success and failure
-     * counts.
+     * Test that totalCount returns the sum of success and failure counts.
      *
      * @return void
      */
@@ -94,8 +91,7 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that failures returns an empty array when no failures were
-     * provided.
+     * Test that failures returns an empty array when no failures were provided.
      *
      * @return void
      */
@@ -107,8 +103,7 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that failures returns the failure details keyed by table
-     * name.
+     * Test that failures returns the failure details keyed by table name.
      *
      * @return void
      */
@@ -154,8 +149,8 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that the record-level count getters default to zero when no
-     * record counts are provided.
+     * Test that the record-level count getters default to zero when no record
+     * counts are provided.
      *
      * @return void
      */
@@ -170,8 +165,8 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that the record-level count getters return the values
-     * provided to the constructor.
+     * Test that the record-level count getters return the values provided to
+     * the constructor.
      *
      * @return void
      */
@@ -194,8 +189,8 @@ final class WritePoolFlushResultTest extends TestCase
     }
 
     /**
-     * Test that flushedTables defaults to an empty array when no tables
-     * are provided.
+     * Test that flushedTables defaults to an empty array when no tables are
+     * provided.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Concerns/WritePoolTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolTest.php
@@ -193,8 +193,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the default strategy continues past a chunk failure
-     * without logging an error and persists the healthy chunk.
+     * Test that the default strategy continues past a chunk failure without
+     * logging an error and persists the healthy chunk.
      *
      * @return void
      */
@@ -215,8 +215,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the default strategy retains failed records in the
-     * buffer rather than dropping them after a partial failure.
+     * Test that the default strategy retains failed records in the buffer
+     * rather than dropping them after a partial failure.
      *
      * @return void
      */
@@ -233,8 +233,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the default strategy is collect, surfacing failures
-     * loudly in the result with zero dropped records.
+     * Test that the default strategy is collect, surfacing failures loudly in
+     * the result with zero dropped records.
      *
      * @return void
      */
@@ -307,8 +307,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with LOG strategy returns a result containing
-     * failure details keyed by the failing table.
+     * Test that flush with LOG strategy returns a result containing failure
+     * details keyed by the failing table.
      *
      * @return void
      */
@@ -357,8 +357,7 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with THROW strategy throws on the first
-     * chunk failure.
+     * Test that flush with THROW strategy throws on the first chunk failure.
      *
      * @return void
      */
@@ -375,8 +374,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with THROW strategy preserves failed and
-     * unprocessed records in the buffer.
+     * Test that flush with THROW strategy preserves failed and unprocessed
+     * records in the buffer.
      *
      * @return void
      */
@@ -398,8 +397,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with THROW strategy removes successfully
-     * inserted records from the buffer.
+     * Test that flush with THROW strategy removes successfully inserted records
+     * from the buffer.
      *
      * @return void
      */
@@ -423,8 +422,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the WritePoolFlushException thrown by the THROW
-     * strategy contains a partial result with correct counts.
+     * Test that the WritePoolFlushException thrown by the THROW strategy
+     * contains a partial result with correct counts.
      *
      * @return void
      */
@@ -448,8 +447,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with COLLECT strategy continues processing
-     * after a chunk failure.
+     * Test that flush with COLLECT strategy continues processing after a chunk
+     * failure.
      *
      * @return void
      */
@@ -466,8 +465,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with COLLECT strategy retains failed records
-     * in the buffer.
+     * Test that flush with COLLECT strategy retains failed records in the
+     * buffer.
      *
      * @return void
      */
@@ -485,8 +484,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with COLLECT strategy removes successful
-     * records from the buffer while retaining failed records.
+     * Test that flush with COLLECT strategy removes successful records from the
+     * buffer while retaining failed records.
      *
      * @return void
      */
@@ -504,8 +503,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with COLLECT strategy returns a result
-     * containing failures for all failing tables.
+     * Test that flush with COLLECT strategy returns a result containing
+     * failures for all failing tables.
      *
      * @return void
      */
@@ -526,8 +525,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush accepts a per-call strategy override that
-     * takes precedence over the instance default.
+     * Test that flush accepts a per-call strategy override that takes
+     * precedence over the instance default.
      *
      * @return void
      */
@@ -547,8 +546,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that auto-flush uses the LOG strategy when the pool is
-     * configured with LOG.
+     * Test that auto-flush uses the LOG strategy when the pool is configured
+     * with LOG.
      *
      * @return void
      */
@@ -565,8 +564,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that memory-pressure auto-flush honours the throw strategy,
-     * raising a WritePoolFlushException out of add().
+     * Test that memory-pressure auto-flush honours the throw strategy, raising
+     * a WritePoolFlushException out of add().
      *
      * @return void
      */
@@ -582,8 +581,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that auto-flush uses COLLECT strategy when the pool is
-     * configured with COLLECT.
+     * Test that auto-flush uses COLLECT strategy when the pool is configured
+     * with COLLECT.
      *
      * @return void
      */
@@ -598,8 +597,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that lastAutoFlushResult returns null before any
-     * auto-flush has occurred.
+     * Test that lastAutoFlushResult returns null before any auto-flush has
+     * occurred.
      *
      * @return void
      */
@@ -609,8 +608,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that lastAutoFlushResult returns a WritePoolFlushResult
-     * instance after an auto-flush has been triggered.
+     * Test that lastAutoFlushResult returns a WritePoolFlushResult instance
+     * after an auto-flush has been triggered.
      *
      * @return void
      */
@@ -625,8 +624,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that a subsequent flush after a COLLECT flush only
-     * processes the retained failed records.
+     * Test that a subsequent flush after a COLLECT flush only processes the
+     * retained failed records.
      *
      * @return void
      */
@@ -650,8 +649,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with LOG strategy clears the buffer
-     * regardless of any failures that occurred.
+     * Test that flush with LOG strategy clears the buffer regardless of any
+     * failures that occurred.
      *
      * @return void
      */
@@ -671,8 +670,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with COLLECT strategy accumulates multiple failed
-     * chunks for the same table in the retained buffer.
+     * Test that flush with COLLECT strategy accumulates multiple failed chunks
+     * for the same table in the retained buffer.
      *
      * @return void
      */
@@ -689,9 +688,9 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that flush with THROW strategy retains exactly the failed
-     * chunk, the remaining chunks of the failing table, and the
-     * untouched subsequent tables.
+     * Test that flush with THROW strategy retains exactly the failed chunk, the
+     * remaining chunks of the failing table, and the untouched subsequent
+     * tables.
      *
      * @return void
      */
@@ -717,8 +716,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that a transactional flush rolls back the entire table when
-     * any chunk fails, leaving none of that table's rows persisted.
+     * Test that a transactional flush rolls back the entire table when any
+     * chunk fails, leaving none of that table's rows persisted.
      *
      * @return void
      */
@@ -735,8 +734,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that a non-transactional flush persists the healthy chunk
-     * even when a later chunk in the same table fails.
+     * Test that a non-transactional flush persists the healthy chunk even when
+     * a later chunk in the same table fails.
      *
      * @return void
      */
@@ -754,8 +753,8 @@ final class WritePoolTest extends TestCase
 
     /**
      * Test that a transactional collect flush retains every record of a
-     * rolled-back table for retry, including the rows that committed
-     * before the failing chunk.
+     * rolled-back table for retry, including the rows that committed before the
+     * failing chunk.
      *
      * @return void
      */
@@ -775,8 +774,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that a transactional throw flush raises and retains the
-     * whole rolled-back table along with subsequent tables.
+     * Test that a transactional throw flush raises and retains the whole
+     * rolled-back table along with subsequent tables.
      *
      * @return void
      */
@@ -822,8 +821,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the throw strategy reports record-level counts covering
-     * both the failed chunk and the unprocessed records.
+     * Test that the throw strategy reports record-level counts covering both
+     * the failed chunk and the unprocessed records.
      *
      * @return void
      */
@@ -850,8 +849,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the log strategy reports the failed records as dropped
-     * rather than retained.
+     * Test that the log strategy reports the failed records as dropped rather
+     * than retained.
      *
      * @return void
      */
@@ -873,9 +872,8 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that a successful flush reports every table it attempted to
-     * persist, so the boundary can invalidate each table's downstream
-     * per-query cache.
+     * Test that a successful flush reports every table it attempted to persist,
+     * so the boundary can invalidate each table's downstream per-query cache.
      *
      * @return void
      */
@@ -902,9 +900,9 @@ final class WritePoolTest extends TestCase
     }
 
     /**
-     * Test that the partial result carried by the throw exception reports
-     * every attempted table, so the boundary still invalidates the cache
-     * for tables that persisted before the failure.
+     * Test that the partial result carried by the throw exception reports every
+     * attempted table, so the boundary still invalidates the cache for tables
+     * that persisted before the failure.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
+++ b/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
@@ -350,8 +350,8 @@ final class ApiCriteriaTest extends TestCase
     }
 
     /**
-     * Test that apply with nested relation filters applies whereHas with
-     * nested conditions.
+     * Test that apply with nested relation filters applies whereHas with nested
+     * conditions.
      *
      * @return void
      */
@@ -792,8 +792,8 @@ final class ApiCriteriaTest extends TestCase
     }
 
     /**
-     * Test that $contains with null exercises the isValidJson null path and
-     * the defensive catch inside applyJsonContains.
+     * Test that $contains with null exercises the isValidJson null path and the
+     * defensive catch inside applyJsonContains.
      *
      * @return void
      */
@@ -810,8 +810,8 @@ final class ApiCriteriaTest extends TestCase
     }
 
     /**
-     * Test that applyEagerLoading returns early when fields resolve to an
-     * empty array.
+     * Test that applyEagerLoading returns early when fields resolve to an empty
+     * array.
      *
      * @SuppressWarnings("php:S2014")
      *
@@ -892,8 +892,7 @@ final class ApiCriteriaTest extends TestCase
     }
 
     /**
-     * Test that applyEagerLoading calls resolveFields on the metadata
-     * provider.
+     * Test that applyEagerLoading calls resolveFields on the metadata provider.
      *
      * @return void
      */
@@ -1009,8 +1008,8 @@ final class ApiCriteriaTest extends TestCase
     }
 
     /**
-     * Test that getResourceType returns null when the resolved resource
-     * class is not an ApiResource subclass.
+     * Test that getResourceType returns null when the resolved resource class
+     * is not an ApiResource subclass.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
@@ -219,9 +219,9 @@ final class ColumnProjectionApplierTest extends TestCase
     }
 
     /**
-     * Test that the parent key of every list-keyed (plain or extra) relation
-     * in the eager-load map is retained, not just the first. The relation name
-     * of a list entry lives in the value, so deriving keys via array_keys would
+     * Test that the parent key of every list-keyed (plain or extra) relation in
+     * the eager-load map is retained, not just the first. The relation name of
+     * a list entry lives in the value, so deriving keys via array_keys would
      * yield integer indices that resolve to no relation.
      *
      * @return void

--- a/tests/Unit/Repositories/Criteria/Concerns/EagerLoadApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/EagerLoadApplierTest.php
@@ -43,8 +43,7 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply with a null resource class returns the query
-     * unmodified.
+     * Test that apply with a null resource class returns the query unmodified.
      *
      * @return void
      */
@@ -83,8 +82,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply uses getAllFields when the ':all' token is
-     * present in the fields array.
+     * Test that apply uses getAllFields when the ':all' token is present in the
+     * fields array.
      *
      * @return void
      */
@@ -115,8 +114,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply uses resolveFields when the ':all' token is not
-     * present in the fields array.
+     * Test that apply uses resolveFields when the ':all' token is not present
+     * in the fields array.
      *
      * @return void
      */
@@ -147,8 +146,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply returns early without calling eagerLoadMapFor
-     * when the resolved fields array is empty.
+     * Test that apply returns early without calling eagerLoadMapFor when the
+     * resolved fields array is empty.
      *
      * @return void
      */
@@ -176,8 +175,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply calls with() on the query when the eager load
-     * map is not empty.
+     * Test that apply calls with() on the query when the eager load map is not
+     * empty.
      *
      * @return void
      */
@@ -205,8 +204,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply does not call with() on the query when the
-     * eager load map is empty.
+     * Test that apply does not call with() on the query when the eager load map
+     * is empty.
      *
      * @return void
      */
@@ -234,8 +233,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply calls withCount() on the query when the eager
-     * load count map is not empty.
+     * Test that apply calls withCount() on the query when the eager load count
+     * map is not empty.
      *
      * @return void
      */
@@ -267,8 +266,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply does not call withCount() on the query when the
-     * eager load count map is empty.
+     * Test that apply does not call withCount() on the query when the eager
+     * load count map is empty.
      *
      * @return void
      */
@@ -367,8 +366,8 @@ final class EagerLoadApplierTest extends TestCase
     }
 
     /**
-     * Test that apply passes the actual requested sums to eagerLoadSumsFor,
-     * not an empty array produced by coalescing.
+     * Test that apply passes the actual requested sums to eagerLoadSumsFor, not
+     * an empty array produced by coalescing.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Criteria/Concerns/FilterApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/FilterApplierTest.php
@@ -312,8 +312,8 @@ final class FilterApplierTest extends TestCase
     }
 
     /**
-     * Test that $contains with a comma-separated string creates multiple
-     * JSON contains conditions.
+     * Test that $contains with a comma-separated string creates multiple JSON
+     * contains conditions.
      *
      * @return void
      */
@@ -366,8 +366,8 @@ final class FilterApplierTest extends TestCase
     }
 
     /**
-     * Test that $has with a named relation and conditions applies
-     * constrained whereHas.
+     * Test that $has with a named relation and conditions applies constrained
+     * whereHas.
      *
      * @return void
      */
@@ -633,9 +633,9 @@ final class FilterApplierTest extends TestCase
     }
 
     /**
-     * Test that a $has filter is not double-applied as a column
-     * condition when a handler happens to be registered for the
-     * $has token in the operator registry.
+     * Test that a $has filter is not double-applied as a column condition when
+     * a handler happens to be registered for the $has token in the operator
+     * registry.
      *
      * @return void
      */
@@ -679,8 +679,8 @@ final class FilterApplierTest extends TestCase
     }
 
     /**
-     * Apply filters using the FilterApplier and return the resulting
-     * query builder.
+     * Apply filters using the FilterApplier and return the resulting query
+     * builder.
      *
      * @param  array<string, mixed>|null  $filters
      * @return \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User>

--- a/tests/Unit/Repositories/Criteria/Concerns/OrderApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/OrderApplierTest.php
@@ -48,8 +48,7 @@ final class OrderApplierTest extends TestCase
     }
 
     /**
-     * Test that apply with an empty order array returns the query
-     * unmodified.
+     * Test that apply with an empty order array returns the query unmodified.
      *
      * @return void
      */
@@ -79,8 +78,8 @@ final class OrderApplierTest extends TestCase
     }
 
     /**
-     * Test that apply with multiple columns adds multiple orderBy
-     * clauses in order.
+     * Test that apply with multiple columns adds multiple orderBy clauses in
+     * order.
      *
      * @return void
      */
@@ -115,8 +114,7 @@ final class OrderApplierTest extends TestCase
     }
 
     /**
-     * Test that apply with an invalid direction silently skips the
-     * column.
+     * Test that apply with an invalid direction silently skips the column.
      *
      * @return void
      */
@@ -129,8 +127,7 @@ final class OrderApplierTest extends TestCase
     }
 
     /**
-     * Test that apply with a non-searchable column silently skips
-     * it.
+     * Test that apply with a non-searchable column silently skips it.
      *
      * @return void
      */
@@ -143,8 +140,8 @@ final class OrderApplierTest extends TestCase
     }
 
     /**
-     * Test that apply with both random and regular columns applies
-     * both ordering types.
+     * Test that apply with both random and regular columns applies both
+     * ordering types.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Criteria/OperatorRegistryTest.php
+++ b/tests/Unit/Repositories/Criteria/OperatorRegistryTest.php
@@ -194,8 +194,8 @@ final class OperatorRegistryTest extends TestCase
     }
 
     /**
-     * Test that the exception message from duplicate registration
-     * contains the token string.
+     * Test that the exception message from duplicate registration contains the
+     * token string.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Criteria/Operators/ContainsOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/ContainsOperatorTest.php
@@ -87,8 +87,8 @@ final class ContainsOperatorTest extends TestCase
     }
 
     /**
-     * Test that apply with a comma-separated string creates
-     * multiple conditions.
+     * Test that apply with a comma-separated string creates multiple
+     * conditions.
      *
      * @return void
      */
@@ -116,8 +116,8 @@ final class ContainsOperatorTest extends TestCase
     }
 
     /**
-     * Test that apply with a comma-separated string trims items and
-     * drops empty segments.
+     * Test that apply with a comma-separated string trims items and drops empty
+     * segments.
      *
      * @return void
      */
@@ -138,8 +138,7 @@ final class ContainsOperatorTest extends TestCase
     }
 
     /**
-     * Test that apply with a string containing only commas adds no
-     * constraints.
+     * Test that apply with a string containing only commas adds no constraints.
      *
      * @return void
      */
@@ -228,8 +227,8 @@ final class ContainsOperatorTest extends TestCase
     }
 
     /**
-     * Test that a grammar rejection of the JSON-contains clause is logged
-     * with diagnostic context rather than dropped without a trace.
+     * Test that a grammar rejection of the JSON-contains clause is logged with
+     * diagnostic context rather than dropped without a trace.
      *
      * @return void
      */
@@ -256,8 +255,8 @@ final class ContainsOperatorTest extends TestCase
     }
 
     /**
-     * Test that the comma-split conditions are grouped inside a single
-     * nested where on the parent query.
+     * Test that the comma-split conditions are grouped inside a single nested
+     * where on the parent query.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Criteria/Operators/LikeOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/LikeOperatorTest.php
@@ -99,8 +99,8 @@ final class LikeOperatorTest extends TestCase
     }
 
     /**
-     * Test that apply with a non-scalar, non-Stringable value falls
-     * back to an empty search term.
+     * Test that apply with a non-scalar, non-Stringable value falls back to an
+     * empty search term.
      *
      * @return void
      */

--- a/tests/Unit/Repositories/Traits/ResolvesResourceTest.php
+++ b/tests/Unit/Repositories/Traits/ResolvesResourceTest.php
@@ -101,8 +101,7 @@ final class ResolvesResourceTest extends TestCase
     }
 
     /**
-     * Test that flushResourceCache clears the memo-cached resource
-     * mappings.
+     * Test that flushResourceCache clears the memo-cached resource mappings.
      *
      * @return void
      */
@@ -122,8 +121,8 @@ final class ResolvesResourceTest extends TestCase
     }
 
     /**
-     * Test that flushResourceCache on an empty memo store does not
-     * throw an exception.
+     * Test that flushResourceCache on an empty memo store does not throw an
+     * exception.
      *
      * @return void
      */
@@ -137,8 +136,8 @@ final class ResolvesResourceTest extends TestCase
     }
 
     /**
-     * Test that resolveResource prefers the custom resource class over
-     * the configured mapping.
+     * Test that resolveResource prefers the custom resource class over the
+     * configured mapping.
      *
      * @return void
      */
@@ -156,8 +155,8 @@ final class ResolvesResourceTest extends TestCase
     }
 
     /**
-     * Test that resource resolution caches mappings per model class
-     * rather than sharing a single cache entry.
+     * Test that resource resolution caches mappings per model class rather than
+     * sharing a single cache entry.
      *
      * @return void
      */
@@ -213,8 +212,8 @@ final class ResolvesResourceTest extends TestCase
     }
 
     /**
-     * Test that resolving a model resource registers the MODEL_RESOURCES key
-     * in the MetadataKeyRegistry.
+     * Test that resolving a model resource registers the MODEL_RESOURCES key in
+     * the MetadataKeyRegistry.
      *
      * @return void
      */

--- a/tests/Unit/Services/Actors/AnonymousActorTest.php
+++ b/tests/Unit/Services/Actors/AnonymousActorTest.php
@@ -20,8 +20,8 @@ use SineMacula\ApiToolkit\Services\Actors\AnonymousActor;
 final class AnonymousActorTest extends TestCase
 {
     /**
-     * Test anonymous semantics: identifier is null, type is 'anonymous',
-     * label is 'Anonymous', and toAuthenticatable() returns null.
+     * Test anonymous semantics: identifier is null, type is 'anonymous', label
+     * is 'Anonymous', and toAuthenticatable() returns null.
      *
      * @return void
      */

--- a/tests/Unit/Services/Actors/EloquentActorTest.php
+++ b/tests/Unit/Services/Actors/EloquentActorTest.php
@@ -35,8 +35,8 @@ final class EloquentActorTest extends TestCase
     }
 
     /**
-     * Test identifier, type, label, and toAuthenticatable() reflect the
-     * wrapped model.
+     * Test identifier, type, label, and toAuthenticatable() reflect the wrapped
+     * model.
      *
      * @return void
      */
@@ -67,8 +67,8 @@ final class EloquentActorTest extends TestCase
     }
 
     /**
-     * Test that the label snapshot is taken at construction time and does
-     * not change when the underlying record is updated afterwards.
+     * Test that the label snapshot is taken at construction time and does not
+     * change when the underlying record is updated afterwards.
      *
      * @return void
      */
@@ -84,8 +84,8 @@ final class EloquentActorTest extends TestCase
     }
 
     /**
-     * Test that serialize() persists morph type, id, and label snapshot
-     * but not the full model instance.
+     * Test that serialize() persists morph type, id, and label snapshot but not
+     * the full model instance.
      *
      * @return void
      */
@@ -105,8 +105,8 @@ final class EloquentActorTest extends TestCase
 
     /**
      * Test that a serialize()/unserialize() round trip preserves the morph
-     * type, identifier, and label, and the deserialised actor re-resolves
-     * the model via the morph map.
+     * type, identifier, and label, and the deserialised actor re-resolves the
+     * model via the morph map.
      *
      * @return void
      */
@@ -130,8 +130,8 @@ final class EloquentActorTest extends TestCase
     }
 
     /**
-     * Test that label and identifier are retained when the underlying
-     * record is changed or removed after the actor was captured.
+     * Test that label and identifier are retained when the underlying record is
+     * changed or removed after the actor was captured.
      *
      * @return void
      */
@@ -163,8 +163,8 @@ final class EloquentActorTest extends TestCase
     }
 
     /**
-     * Test that the email attribute is used as the label fallback when
-     * there is no name attribute on the model.
+     * Test that the email attribute is used as the label fallback when there is
+     * no name attribute on the model.
      *
      * @return void
      */
@@ -177,9 +177,8 @@ final class EloquentActorTest extends TestCase
     }
 
     /**
-     * Test that a second call to toAuthenticatable() after unserialisation
-     * does not re-query the database (resolved flag prevents repeated
-     * lookups).
+     * Test that a second call to toAuthenticatable() after unserialisation does
+     * not re-query the database (resolved flag prevents repeated lookups).
      *
      * @return void
      */

--- a/tests/Unit/Services/Actors/SystemActorTest.php
+++ b/tests/Unit/Services/Actors/SystemActorTest.php
@@ -20,8 +20,8 @@ use SineMacula\ApiToolkit\Services\Actors\SystemActor;
 final class SystemActorTest extends TestCase
 {
     /**
-     * Test null-object semantics: identifier is null, type is 'system',
-     * and toAuthenticatable() returns null.
+     * Test null-object semantics: identifier is null, type is 'system', and
+     * toAuthenticatable() returns null.
      *
      * @return void
      */

--- a/tests/Unit/Services/Contracts/ServiceConcernTest.php
+++ b/tests/Unit/Services/Contracts/ServiceConcernTest.php
@@ -22,8 +22,8 @@ use Tests\Fixtures\Services\StubActor;
 final class ServiceConcernTest extends TestCase
 {
     /**
-     * Test that an implementer receives a ServiceContext and next closure
-     * and returns the (possibly transformed) value.
+     * Test that an implementer receives a ServiceContext and next closure and
+     * returns the (possibly transformed) value.
      *
      * @return void
      */

--- a/tests/Unit/Services/SchemaIntrospectorTest.php
+++ b/tests/Unit/Services/SchemaIntrospectorTest.php
@@ -193,8 +193,8 @@ final class SchemaIntrospectorTest extends TestCase
     }
 
     /**
-     * Test that getColumnDefinitions normalises the driver type name to
-     * lower case.
+     * Test that getColumnDefinitions normalises the driver type name to lower
+     * case.
      *
      * @return void
      */
@@ -230,8 +230,8 @@ final class SchemaIntrospectorTest extends TestCase
     }
 
     /**
-     * Test that getColumnDefinitions stores the result in the memo cache
-     * under a key scoped to the model class.
+     * Test that getColumnDefinitions stores the result in the memo cache under
+     * a key scoped to the model class.
      *
      * @return void
      */
@@ -268,8 +268,7 @@ final class SchemaIntrospectorTest extends TestCase
     }
 
     /**
-     * Test that getSearchableColumns returns columns with exclusions
-     * applied.
+     * Test that getSearchableColumns returns columns with exclusions applied.
      *
      * @return void
      */

--- a/tests/Unit/Services/SchemaValidatorTest.php
+++ b/tests/Unit/Services/SchemaValidatorTest.php
@@ -54,8 +54,8 @@ final class SchemaValidatorTest extends TestCase
     }
 
     /**
-     * Test that validate passes with no errors when all rules return
-     * empty arrays.
+     * Test that validate passes with no errors when all rules return empty
+     * arrays.
      *
      * @return void
      */
@@ -75,8 +75,8 @@ final class SchemaValidatorTest extends TestCase
     }
 
     /**
-     * Test that validate throws InvalidSchemaException when a rule
-     * returns errors.
+     * Test that validate throws InvalidSchemaException when a rule returns
+     * errors.
      *
      * @return void
      */
@@ -129,8 +129,8 @@ final class SchemaValidatorTest extends TestCase
     }
 
     /**
-     * Test that validate with an empty resource map does not call any
-     * rules and does not throw.
+     * Test that validate with an empty resource map does not call any rules and
+     * does not throw.
      *
      * @return void
      */
@@ -178,8 +178,8 @@ final class SchemaValidatorTest extends TestCase
     }
 
     /**
-     * Test that validate with no rules passes without errors for a
-     * non-empty resource map.
+     * Test that validate with no rules passes without errors for a non-empty
+     * resource map.
      *
      * @return void
      */
@@ -193,8 +193,8 @@ final class SchemaValidatorTest extends TestCase
     }
 
     /**
-     * Test that errors from multiple resources are aggregated into a
-     * single exception.
+     * Test that errors from multiple resources are aggregated into a single
+     * exception.
      *
      * @return void
      */

--- a/tests/Unit/Services/ServiceResultTest.php
+++ b/tests/Unit/Services/ServiceResultTest.php
@@ -88,9 +88,9 @@ final class ServiceResultTest extends TestCase
     /**
      * Test that outputOr() returns the default value for a failed result.
      *
-     * A failed result returns the default even when a non-null output
-     * was captured alongside the failure, letting the caller distinguish
-     * failure from a null output without inspecting the status.
+     * A failed result returns the default even when a non-null output was
+     * captured alongside the failure, letting the caller distinguish failure
+     * from a null output without inspecting the status.
      *
      * @return void
      */

--- a/tests/Unit/Services/ServiceRunnerTest.php
+++ b/tests/Unit/Services/ServiceRunnerTest.php
@@ -35,8 +35,8 @@ use Tests\TestCase;
 final class ServiceRunnerTest extends TestCase
 {
     /**
-     * Test that the lifecycle hooks execute in the fixed order:
-     * authorize -> validate -> prepare -> handle -> afterCommit.
+     * Test that the lifecycle hooks execute in the fixed order: authorize ->
+     * validate -> prepare -> handle -> afterCommit.
      *
      * @return void
      */
@@ -111,8 +111,8 @@ final class ServiceRunnerTest extends TestCase
     }
 
     /**
-     * Test that a domain failure thrown from handle() is captured in the
-     * result and never propagated to the caller.
+     * Test that a domain failure thrown from handle() is captured in the result
+     * and never propagated to the caller.
      *
      * @return void
      */
@@ -141,9 +141,9 @@ final class ServiceRunnerTest extends TestCase
     }
 
     /**
-     * Test that afterCommit receives the output from handle() and that a
-     * throw from afterCommit is captured as a side-effect error while
-     * leaving the committed result as succeeded.
+     * Test that afterCommit receives the output from handle() and that a throw
+     * from afterCommit is captured as a side-effect error while leaving the
+     * committed result as succeeded.
      *
      * @return void
      */

--- a/tests/Unit/Traits/LockableTest.php
+++ b/tests/Unit/Traits/LockableTest.php
@@ -115,8 +115,8 @@ final class LockableTest extends TestCase
     }
 
     /**
-     * Test that the Lockable trait works in a standalone class that does
-     * not extend Service.
+     * Test that the Lockable trait works in a standalone class that does not
+     * extend Service.
      *
      * @return void
      */
@@ -138,8 +138,7 @@ final class LockableTest extends TestCase
     }
 
     /**
-     * Test that the lock expiration can be customized at construction
-     * time.
+     * Test that the lock expiration can be customized at construction time.
      *
      * @return void
      */
@@ -209,8 +208,8 @@ final class LockableTest extends TestCase
     }
 
     /**
-     * Test that getLockExpiration remains callable from a subclass of the
-     * trait consumer.
+     * Test that getLockExpiration remains callable from a subclass of the trait
+     * consumer.
      *
      * @return void
      */
@@ -232,8 +231,8 @@ final class LockableTest extends TestCase
     }
 
     /**
-     * Test that a preset lock key property is respected without requiring
-     * the LockKeyProvider contract.
+     * Test that a preset lock key property is respected without requiring the
+     * LockKeyProvider contract.
      *
      * @return void
      */

--- a/tests/Unit/Traits/OrdersFieldsTest.php
+++ b/tests/Unit/Traits/OrdersFieldsTest.php
@@ -195,8 +195,8 @@ final class OrdersFieldsTest extends TestCase
     }
 
     /**
-     * Test that the ordering helpers remain callable from subclasses of a
-     * trait consumer (protected visibility contract).
+     * Test that the ordering helpers remain callable from subclasses of a trait
+     * consumer (protected visibility contract).
      *
      * @return void
      */


### PR DESCRIPTION
## Summary
- reflow PHPDoc prose so lines use the available 80-character budget more consistently
- replace the wrapped `Service::serviceHooks()` return array shape with the existing `ServiceHooks` PHPStan alias
- preserve `phpcs:disable` directives as single-line tokens so sniff scopes are not widened accidentally
- remove an unused `->end()` call in `AggregateDefinitionTest` so `composer check` stays green

## Audit notes
- prose underwrap audit: 0 findings after formatting
- wrapped `@param`/`@return` audit: 0 findings after formatting
- split `phpcs:*` directive audit in this repo: 0 findings after fix
- split `phpcs:*` directive audit in `laravel-resource-exporter`: 0 findings
- promoted-constructor blank-line audit: attempted across all 68 promoted constructors, but `qlty fmt`/php-cs-fixer removed the blank lines again, so that convention is not retained by current tooling

## Verification
- `qlty fmt`
- `composer check`
- `composer test` (1966 tests, 4291 assertions, 1 skipped)
