### PR TITLE
feat: integrate the v3 resource-exporter content negotiation (optional)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "illuminate/notifications": "Required only for notification-event logging",
         "sinemacula/laravel-log-cloudwatch": "CloudWatch log driver (Monolog), extracted from this package",
         "sinemacula/laravel-log-database": "Database log driver (Monolog), extracted from this package",
+        "sinemacula/laravel-resource-exporter": "Content-negotiated exports (CSV/TSV/XLSX/XML/JSON/NDJSON) for resources and collections; wires into resource responses automatically when installed",
         "sinemacula/laravel-sse": "Server-sent event streaming for controllers, extracted from this package"
     },
     "require-dev": {
@@ -48,6 +49,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^12.5",
         "sinemacula/coding-standards-laravel": "^1.0",
+        "sinemacula/laravel-resource-exporter": "^3.0",
         "slevomat/coding-standard": "^8.28",
         "squizlabs/php_codesniffer": "4.0.1"
     },

--- a/src/Http/Resources/Concerns/DerivedTabularSchema.php
+++ b/src/Http/Resources/Concerns/DerivedTabularSchema.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Http\Resources\Concerns;
+
+use Illuminate\Http\Request;
+use SineMacula\Exporter\Schema\TabularSchema;
+
+/**
+ * Concrete TabularSchema implementation backing the DerivesTabularSchema
+ * trait.
+ *
+ * Holds the ordered list of Column instances produced from the resource's
+ * compiled field definitions and returns them to the export engine. This
+ * class is an implementation detail of the trait and is not intended to be
+ * instantiated or extended outside it.
+ *
+ * @internal
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class DerivedTabularSchema extends TabularSchema
+{
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     * @param  list<\SineMacula\Exporter\Schema\Column>  $columns
+     */
+    public function __construct(
+
+        // The request the schema is built for.
+        Request $request,
+
+        /** The ordered column definitions for this schema. */
+        private readonly array $columns,
+    ) {
+        parent::__construct($request);
+    }
+
+    /**
+     * @return list<\SineMacula\Exporter\Schema\Column>
+     */
+    #[\Override]
+    public function columns(): array
+    {
+        return $this->columns;
+    }
+}

--- a/src/Http/Resources/Concerns/DerivesTabularSchema.php
+++ b/src/Http/Resources/Concerns/DerivesTabularSchema.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Http\Resources\Concerns;
+
+use Illuminate\Http\Request;
+use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\Exporter\Schema\Column;
+use SineMacula\Exporter\Schema\TabularSchema;
+
+/**
+ * Derives a tabular export schema from the resource's compiled field
+ * definitions.
+ *
+ * Intended for use on {@see \SineMacula\ApiToolkit\Http\Resources\ApiResource}
+ * subclasses that also implement
+ * {@see \SineMacula\Exporter\Contracts\ProvidesTabularExport}. When mixed in,
+ * the `tabular()` method is satisfied for free: it compiles the resource
+ * schema and maps each non-relation field to a typed Column, routing accessor
+ * and computed fields through a fresh resource instance so guards and
+ * transformers are honoured in the export. Plain scalar fields fall through to
+ * the default raw-attribute read via `data_get`.
+ *
+ * The schema returned is request-aware so column visibility and field
+ * selection can be narrowed by the active API query.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @phpstan-require-extends \SineMacula\ApiToolkit\Http\Resources\ApiResource
+ */
+trait DerivesTabularSchema
+{
+    /**
+     * Derive the tabular schema from the resource's compiled field definitions.
+     *
+     * Compiles the resource schema and builds one Column per non-relation
+     * field. When a field set is active on the current API query, only the
+     * requested fields are included, mirroring what the JSON response returns.
+     * Relation fields are skipped because they cannot be represented as scalar
+     * cells without an explicit expansion policy.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \SineMacula\Exporter\Schema\TabularSchema
+     */
+    public function tabular(Request $request): TabularSchema
+    {
+        /** @var class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource> $resourceClass */
+        $resourceClass = static::class;
+
+        $schema    = SchemaCompiler::compile($resourceClass);
+        $requested = ApiQuery::getFields(static::getResourceType());
+        $allKeys   = $schema->getFieldKeys();
+        $fieldKeys = $requested !== null ? array_values(array_intersect($requested, $allKeys)) : $allKeys;
+
+        $columns = [];
+
+        foreach ($fieldKeys as $key) {
+
+            $definition = $schema->getField($key);
+
+            if ($definition === null || $definition->relation !== null) {
+                continue;
+            }
+
+            $columns[] = $this->buildTabularColumn($key, $definition, $resourceClass);
+        }
+
+        return new DerivedTabularSchema($request, $columns);
+    }
+
+    /**
+     * Build a single tabular column for the given field definition.
+     *
+     * Routes accessor and computed fields through a fresh resource instance
+     * so closures and method logic that the JSON response applies are honoured
+     * identically in the export. Plain scalar fields use the default
+     * raw-attribute read via data_get on the underlying model.
+     *
+     * @param  string  $key
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
+     * @param  class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource>  $resourceClass
+     * @return \SineMacula\Exporter\Schema\Column
+     */
+    private function buildTabularColumn(string $key, CompiledFieldDefinition $definition, string $resourceClass): Column
+    {
+        if (is_string($definition->accessor)) {
+            return Column::make($key)->fromModel($definition->accessor);
+        }
+
+        $resolver = $this->columnResolverFor($definition, $resourceClass);
+
+        return $resolver !== null ? Column::make($key)->resolveUsing($resolver) : Column::make($key);
+    }
+
+    /**
+     * Build the closure used to resolve a column value through a resource
+     * instance, or null when no resource-mediated resolution is needed.
+     *
+     * Combines callable compute and callable accessor into one code path since
+     * both are invoked with the resource and request by ValueResolver.
+     *
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
+     * @param  class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource>  $resourceClass
+     * @return \Closure|null
+     */
+    private function columnResolverFor(CompiledFieldDefinition $definition, string $resourceClass): ?\Closure
+    {
+        // String compute: a named method called on the resource instance.
+        if (is_string($definition->compute)) {
+            $method = $definition->compute;
+            return static function ($item, $request) use ($resourceClass, $method): mixed {
+                $resource = new $resourceClass($item);
+                return method_exists($resource, $method) ? $resource->{$method}($request) : null; // @phpstan-ignore method.dynamicName
+            };
+        }
+
+        // Callable compute and accessor are both invoked with the resource.
+        if (is_callable($definition->compute)) {
+            $callable = \Closure::fromCallable($definition->compute);
+        } elseif (is_callable($definition->accessor)) {
+            $callable = \Closure::fromCallable($definition->accessor);
+        } else {
+            return null;
+        }
+
+        return static fn ($item, $request): mixed => $callable(new $resourceClass($item), $request);
+    }
+}

--- a/src/Http/Resources/ToolkitCollection.php
+++ b/src/Http/Resources/ToolkitCollection.php
@@ -5,7 +5,10 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Http\Resources;
 
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\App;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ProvidesApiEnvelope;
+use SineMacula\Exporter\Http\ExportNegotiator;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Base class for every toolkit resource collection.
@@ -22,4 +25,35 @@ use SineMacula\ApiToolkit\Http\Resources\Concerns\ProvidesApiEnvelope;
 abstract class ToolkitCollection extends AnonymousResourceCollection
 {
     use ProvidesApiEnvelope;
+
+    /**
+     * Negotiate an export response, falling back to the JSON envelope.
+     *
+     * When the resource exporter package is installed its ExportNegotiator is
+     * bound in the container: a negotiated export (a tabular or hierarchical
+     * stream over the collected resource) is returned as is, otherwise the
+     * native envelope response is returned with a `Vary: Accept` header. When
+     * the exporter is absent the native envelope is returned unchanged, so the
+     * toolkit carries no hard dependency on it.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @phpstan-ignore method.childReturnType
+     */
+    #[\Override]
+    public function toResponse(mixed $request): Response
+    {
+        $class = ExportNegotiator::class;
+
+        if (!App::bound($class)) {
+            return parent::toResponse($request);
+        }
+
+        $negotiator = App::make($class);
+        assert($negotiator instanceof ExportNegotiator);
+
+        return $negotiator->collection($this, $this->collects, $request)
+            ?? ExportNegotiator::varyAccept(parent::toResponse($request));
+    }
 }

--- a/src/Http/Resources/ToolkitResource.php
+++ b/src/Http/Resources/ToolkitResource.php
@@ -5,6 +5,9 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\App;
+use SineMacula\Exporter\Http\ExportNegotiator;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Base class for every toolkit single-item resource.
@@ -20,6 +23,37 @@ use Illuminate\Http\Resources\Json\JsonResource;
  */
 abstract class ToolkitResource extends JsonResource
 {
+    /**
+     * Negotiate an export response, falling back to the JSON item response.
+     *
+     * When the resource exporter package is installed its ExportNegotiator is
+     * bound in the container: a negotiated export (a tabular or hierarchical
+     * stream) is returned as is, otherwise the native JSON response is returned
+     * with a `Vary: Accept` header so caches never serve the wrong
+     * representation. When the exporter is absent the native response is
+     * returned unchanged, so the toolkit carries no hard dependency on it.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @phpstan-ignore method.childReturnType
+     */
+    #[\Override]
+    public function toResponse(mixed $request): Response
+    {
+        $class = ExportNegotiator::class;
+
+        if (!App::bound($class)) {
+            return parent::toResponse($request);
+        }
+
+        $negotiator = App::make($class);
+        assert($negotiator instanceof ExportNegotiator);
+
+        return $negotiator->item($this, $request)
+            ?? ExportNegotiator::varyAccept(parent::toResponse($request));
+    }
+
     /**
      * Prepend the `_type` discriminator to a resolved payload.
      *

--- a/tests/Fixtures/Models/User.php
+++ b/tests/Fixtures/Models/User.php
@@ -28,6 +28,8 @@ use Tests\Fixtures\Enums\UserStatus;
  * @method static static first(array<int, string>|string $columns = ['*'])
  * @method static \Illuminate\Database\Eloquent\Builder<static> where(string|array<string, mixed> $column, mixed $operator = null, mixed $value = null)
  * @method static \Illuminate\Database\Eloquent\Builder<static> withCount(mixed $relations)
+ * @method static \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, static> paginate(int|null $perPage = null)
+ * @method static static findOrFail(mixed $id)
  *
  * @formatter:on
  *

--- a/tests/Fixtures/Resources/ExportableUserResource.php
+++ b/tests/Fixtures/Resources/ExportableUserResource.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\ApiToolkit\Schema\Relation;
+use SineMacula\Exporter\Contracts\ProvidesTabularExport;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture resource that derives its tabular schema automatically.
+ *
+ * Used by the export-negotiator integration suite to prove that the
+ * DerivesTabularSchema trait maps scalar, callable-accessor, and
+ * callable-compute fields to the correct Column implementations without
+ * manual column declarations. The relation field is present to confirm it is
+ * skipped by the trait.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ExportableUserResource extends ApiResource implements ProvidesTabularExport
+{
+    use DerivesTabularSchema;
+
+    /** @var string */
+    public const string RESOURCE_TYPE = 'exportable_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name'),
+            Field::scalar('email'),
+            Field::timestamp('created_at'),
+            Field::compute('label', static function ($resource): string {
+                $user = $resource->resource;
+
+                if (!$user instanceof User) {
+                    return '';
+                }
+
+                return $user->name . ' <' . $user->email . '>';
+            }),
+            Relation::to('organization', OrganizationResource::class),
+        );
+    }
+}

--- a/tests/Integration/ExportEagerLoadRegressionTest.php
+++ b/tests/Integration/ExportEagerLoadRegressionTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitCollection;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitResource;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\Exporter\ExporterServiceProvider;
+use Tests\Fixtures\Models\Organization;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\ExportableUserResource;
+use Tests\TestCase;
+
+/**
+ * Regression tests proving that exporting a toolkit resource collection or
+ * single item through the ExportNegotiator does not re-query relations that
+ * were already eager-loaded before the export began.
+ *
+ * ResourceCollectionSource and ResourceItemSource do not implement
+ * DerivesAggregates, so the engine's withCount/withSum plan is never applied
+ * to them. DerivesTabularSchema.tabular() also produces a schema whose
+ * with() is empty (relation fields are skipped entirely), so loadMissing()
+ * is not called on the pre-loaded collection. The tests confirm both
+ * invariants empirically by counting the queries issued exclusively during
+ * the streaming phase.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ToolkitResource::class)]
+#[CoversClass(ToolkitCollection::class)]
+#[CoversClass(ApiResource::class)]
+#[CoversTrait(DerivesTabularSchema::class)]
+final class ExportEagerLoadRegressionTest extends TestCase
+{
+    /**
+     * Set up each test with seeded data and export routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SchemaCompiler::clearCache();
+
+        $this->seedData();
+        $this->registerRoutes();
+    }
+
+    /**
+     * Tear down, clearing the schema compiler cache.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        SchemaCompiler::clearCache();
+
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - zero queries during export with pre-loaded relation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection CSV export issues zero queries when the
+     * underlying models have their relations already eager-loaded.
+     *
+     * ResourceCollectionSource.rows() only calls loadMissing() when
+     * withRelations() received a non-empty list. DerivesTabularSchema skips
+     * all Relation fields, so the engine derives an empty with() list and
+     * the load is never triggered. The export also issues no withCount or
+     * withSum queries because ResourceCollectionSource does not implement
+     * DerivesAggregates. Pre-loaded models therefore reach the CSV writer
+     * with zero additional queries.
+     *
+     * @return void
+     */
+    public function testCollectionExportDoesNotRequeryEagerLoadedRelations(): void
+    {
+        // The route handler loads users with their organisation eager-loaded.
+        // StreamedResponse defers the callback until streamedContent(), so the
+        // DB query log can be reset cleanly between the two phases.
+        $response = $this->get('/eager-export/users', ['Accept' => 'text/csv']);
+
+        $response->assertOk();
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        $content = $response->streamedContent();
+
+        $queries = DB::getQueryLog();
+
+        DB::disableQueryLog();
+
+        $queryCount   = count($queries);
+        $querySummary = implode('; ', array_column($queries, 'query'));
+
+        self::assertSame(
+            0,
+            $queryCount,
+            'Expected 0 queries during CSV collection export but observed '
+            . "{$queryCount}: {$querySummary}",
+        );
+
+        self::assertStringContainsString('Alice', $content);
+        self::assertStringContainsString('Bob', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Item - zero queries during export with pre-loaded relation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a single-item CSV export issues zero queries when the
+     * underlying model has its relation already eager-loaded.
+     *
+     * ResourceItemSource.rows() only calls loadMissing() when withRelations()
+     * received a non-empty list. Since the derived tabular schema carries no
+     * with() hints and DerivesAggregates is not implemented, the pre-loaded
+     * model is yielded and shaped into a CSV row without any further queries.
+     *
+     * @return void
+     */
+    public function testItemExportDoesNotRequeryEagerLoadedRelations(): void
+    {
+        $user = User::first();
+
+        $response = $this->get('/eager-export/users/' . $user->id, ['Accept' => 'text/csv']);
+
+        $response->assertOk();
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        $content = $response->streamedContent();
+
+        $queries = DB::getQueryLog();
+
+        DB::disableQueryLog();
+
+        $queryCount   = count($queries);
+        $querySummary = implode('; ', array_column($queries, 'query'));
+
+        self::assertSame(
+            0,
+            $queryCount,
+            'Expected 0 queries during CSV item export but observed '
+            . "{$queryCount}: {$querySummary}",
+        );
+
+        self::assertStringContainsString('Alice', $content);
+    }
+
+    /**
+     * Register the exporter service provider alongside the toolkit.
+     *
+     * @param  mixed  $app
+     * @return array<int, class-string>
+     */
+    #[\Override]
+    protected function getPackageProviders(mixed $app): array
+    {
+        return [
+            ...parent::getPackageProviders($app),
+            ExporterServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Seed the database with an organisation and two users belonging to it.
+     *
+     * @return void
+     */
+    private function seedData(): void
+    {
+        $organisation = Organization::create([
+            'name' => 'Acme Corp',
+            'slug' => 'acme',
+        ]);
+
+        User::create([
+            'name'            => 'Alice',
+            'email'           => 'alice@example.com',
+            'status'          => 'active',
+            'organization_id' => $organisation->id,
+        ]);
+
+        User::create([
+            'name'            => 'Bob',
+            'email'           => 'bob@example.com',
+            'status'          => 'active',
+            'organization_id' => $organisation->id,
+        ]);
+    }
+
+    /**
+     * Register the HTTP routes used by the eager-load regression scenarios.
+     *
+     * Both routes explicitly eager-load the organisation relation before
+     * returning the resource, mirroring what a real repository or service
+     * layer would do. The organisation column is a Relation field in
+     * ExportableUserResource and is therefore excluded from the tabular
+     * schema - confirming that the export neither re-loads it nor uses it
+     * to derive aggregates.
+     *
+     * @return void
+     */
+    private function registerRoutes(): void
+    {
+        Route::get('/eager-export/users', static fn (): AnonymousResourceCollection => ExportableUserResource::collection(
+            User::with('organization')->paginate(10),
+        ));
+
+        Route::get('/eager-export/users/{id}', static function (int $id): ExportableUserResource {
+            $user = User::findOrFail($id);
+            $user->load('organization');
+
+            return new ExportableUserResource($user);
+        });
+    }
+}

--- a/tests/Integration/ExportNegotiatorIntegrationTest.php
+++ b/tests/Integration/ExportNegotiatorIntegrationTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitCollection;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitResource;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\Exporter\ExporterServiceProvider;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\ExportableUserResource;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Integration tests for export content negotiation through the real
+ * ExportNegotiator.
+ *
+ * Exercises ToolkitResource and ToolkitCollection delegation to the
+ * ExportNegotiator when the exporter package is bound, verifying JSON
+ * envelope fallback, tabular streaming (CSV/TSV), hierarchical streaming
+ * (XML/NDJSON), and 406 rejection for resources without a tabular schema.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ToolkitResource::class)]
+#[CoversClass(ToolkitCollection::class)]
+#[CoversClass(ApiResource::class)]
+#[CoversTrait(DerivesTabularSchema::class)]
+final class ExportNegotiatorIntegrationTest extends TestCase
+{
+    /**
+     * Set up each test with seeded users and negotiator routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SchemaCompiler::clearCache();
+
+        $this->seedUsers();
+        $this->registerRoutes();
+    }
+
+    /**
+     * Tear down, clearing the schema compiler cache.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        SchemaCompiler::clearCache();
+
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - JSON envelope (default)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection returns the JSON envelope when no Accept header is
+     * sent and adds the Vary: Accept header.
+     *
+     * @return void
+     */
+    public function testCollectionReturnsJsonEnvelopeByDefault(): void
+    {
+        $response = $this->get('/export/users');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertHeader('Vary', 'Accept');
+        $response->assertJsonStructure(['data', 'links', 'meta']);
+        $response->assertHeader('Total-Count', '2');
+    }
+
+    /**
+     * Test that an explicit application/json Accept header still returns the
+     * JSON envelope with the Vary: Accept header intact.
+     *
+     * @return void
+     */
+    public function testCollectionReturnsJsonEnvelopeForJsonAcceptHeader(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'application/json']);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertHeader('Vary', 'Accept');
+        $response->assertJsonStructure(['data', 'links', 'meta']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - CSV (tabular)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection streams CSV when the client sends Accept: text/csv
+     * for a resource that implements ProvidesTabularExport.
+     *
+     * @return void
+     */
+    public function testCollectionStreamsCsvForCsvAcceptHeader(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'text/csv']);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+        $response->assertHeader('Vary', 'Accept');
+
+        $content = $response->streamedContent();
+
+        self::assertNotEmpty($content);
+        self::assertStringContainsString('Alice', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - TSV via ?format= query parameter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection streams TSV when an explicit ?format=tsv query
+     * parameter is used, proving the query-parameter format-override path.
+     *
+     * @return void
+     */
+    public function testCollectionStreamsTsvForFormatQueryParameter(): void
+    {
+        $response = $this->get('/export/users?format=tsv');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/tab-separated-values; charset=UTF-8');
+        $response->assertHeader('Vary', 'Accept');
+
+        $content = $response->streamedContent();
+
+        self::assertNotEmpty($content);
+        self::assertStringContainsString('Alice', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - XML (hierarchical)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection streams XML when the client sends
+     * Accept: application/xml (no tabular schema required).
+     *
+     * @return void
+     */
+    public function testCollectionStreamsXmlForXmlAcceptHeader(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'application/xml']);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/xml; charset=UTF-8');
+        $response->assertHeader('Vary', 'Accept');
+
+        $content = $response->streamedContent();
+
+        self::assertNotEmpty($content);
+        self::assertStringContainsString('Alice', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - NDJSON (hierarchical)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection streams NDJSON when the client sends
+     * Accept: application/x-ndjson (no tabular schema required).
+     *
+     * @return void
+     */
+    public function testCollectionStreamsNdjsonForNdjsonAcceptHeader(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'application/x-ndjson']);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/x-ndjson; charset=UTF-8');
+        $response->assertHeader('Vary', 'Accept');
+
+        $content = $response->streamedContent();
+
+        self::assertNotEmpty($content);
+        self::assertStringContainsString('Alice', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection - 406 for missing tabular schema
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a collection returns 406 when a tabular format is requested for
+     * a resource that does not implement ProvidesTabularExport.
+     *
+     * @return void
+     */
+    public function testCollectionReturnsSixForTabularFormatWithoutTabularSchema(): void
+    {
+        $response = $this->get('/export/basic-users', ['Accept' => 'text/csv']);
+
+        $response->assertStatus(406);
+    }
+
+    // -------------------------------------------------------------------------
+    // Item - JSON envelope (default)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a single item returns the JSON envelope by default and adds the
+     * Vary: Accept header.
+     *
+     * @return void
+     */
+    public function testItemReturnsJsonEnvelopeByDefault(): void
+    {
+        $user     = User::first();
+        $response = $this->get('/export/users/' . $user->id);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertHeader('Vary', 'Accept');
+        $response->assertJsonStructure(['data']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Item - CSV (tabular)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a single item streams CSV when the client sends
+     * Accept: text/csv for a resource that implements ProvidesTabularExport.
+     *
+     * @return void
+     */
+    public function testItemStreamsCsvForCsvAcceptHeader(): void
+    {
+        $user     = User::first();
+        $response = $this->get('/export/users/' . $user->id, ['Accept' => 'text/csv']);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+        $response->assertHeader('Vary', 'Accept');
+
+        $content = $response->streamedContent();
+
+        self::assertNotEmpty($content);
+        self::assertStringContainsString('Alice', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Item - 406 for missing tabular schema
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that a single item returns 406 when a tabular format is requested
+     * for a resource that does not implement ProvidesTabularExport.
+     *
+     * @return void
+     */
+    public function testItemReturnsSixForTabularFormatWithoutTabularSchema(): void
+    {
+        $user     = User::first();
+        $response = $this->get('/export/basic-users/' . $user->id, ['Accept' => 'text/csv']);
+
+        $response->assertStatus(406);
+    }
+
+    // -------------------------------------------------------------------------
+    // DerivesTabularSchema column resolution
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that the derived tabular schema includes the computed label column
+     * with the expected resolved value.
+     *
+     * @return void
+     */
+    public function testDerivedTabularSchemaResolvesComputedColumn(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'text/csv']);
+        $content  = $response->streamedContent();
+
+        // The 'label' column is a compute field - derived value via resource
+        self::assertStringContainsString('Alice <alice@example.com>', $content);
+    }
+
+    /**
+     * Test that the derived tabular schema resolves the timestamp accessor
+     * as an ISO 8601 string in the export.
+     *
+     * @return void
+     */
+    public function testDerivedTabularSchemaResolvesTimestampAccessor(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'text/csv']);
+        $content  = $response->streamedContent();
+
+        // created_at uses Field::timestamp() - callable accessor to ISO string
+        self::assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $content);
+    }
+
+    /**
+     * Test that relation fields are excluded from the derived tabular schema.
+     *
+     * @return void
+     */
+    public function testDerivedTabularSchemaExcludesRelationFields(): void
+    {
+        $response = $this->get('/export/users', ['Accept' => 'text/csv']);
+        $content  = $response->streamedContent();
+
+        // 'organization' is a Relation::to() field - must not be a column
+        self::assertStringNotContainsString('organization', strtolower($content));
+    }
+
+    /**
+     * Register the exporter service provider alongside the toolkit.
+     *
+     * @param  mixed  $app
+     * @return array<int, class-string>
+     */
+    #[\Override]
+    protected function getPackageProviders(mixed $app): array
+    {
+        return [
+            ...parent::getPackageProviders($app),
+            ExporterServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Seed the database with two users for the export tests.
+     *
+     * @return void
+     */
+    private function seedUsers(): void
+    {
+        User::create([
+            'name'   => 'Alice',
+            'email'  => 'alice@example.com',
+            'status' => 'active',
+        ]);
+
+        User::create([
+            'name'   => 'Bob',
+            'email'  => 'bob@example.com',
+            'status' => 'active',
+        ]);
+    }
+
+    /**
+     * Register the HTTP routes used by the negotiator test scenarios.
+     *
+     * @return void
+     */
+    private function registerRoutes(): void
+    {
+        Route::get('/export/users', static fn () => ExportableUserResource::collection(User::paginate(10)));
+
+        Route::get('/export/users/{id}', static fn (int $id) => new ExportableUserResource(User::findOrFail($id)));
+
+        Route::get('/export/basic-users', static fn () => UserResource::collection(User::paginate(10)));
+
+        Route::get('/export/basic-users/{id}', static fn (int $id) => new UserResource(User::findOrFail($id)));
+    }
+}


### PR DESCRIPTION
First-class, dependency-free integration with `sinemacula/laravel-resource-exporter` v3. Both packages stay independently installable on a standard Laravel project; when both are present, content-negotiated exports work seamlessly through the toolkit's smart resources - no `RespondsWithExports` trait (it would collide with the toolkit's `newCollection()` envelope wiring).

## How it works

- `ToolkitResource::toResponse()` and `ToolkitCollection::toResponse()` delegate to the exporter's `ExportNegotiator` **only when it is bound in the container** (i.e. the package is installed), via `App::bound()`/`App::make()`. A negotiated export (tabular or hierarchical stream) is returned as is; for the default JSON format the negotiator returns null and the existing envelope is returned wrapped in `varyAccept()`. When the exporter is absent the native envelope is returned unchanged.
- The exporter is `require-dev` + `suggest` only - **no hard dependency**. The only toolkit-side code is the one `toResponse()` seam, which is unavoidable: Laravel renders a resource to JSON before any middleware runs, so the export branch has to live in the resource's own `toResponse()` (the exporter's own middleware is a documented lossy fallback).
- Because the negotiator exports the *resolved* resource, `?fields`/filters/sorts apply for free - hierarchical formats ride `toArray()`; tabular honors the resolved field set too.

## Tabular export

`DerivesTabularSchema` lets a resource opt in with `implements ProvidesTabularExport` + `use DerivesTabularSchema`: `Column`s are derived from the compiled `ApiResource` schema (no repeated field lists), relation fields are skipped, the `?fields` set is honored, and accessor/compute fields resolve through a fresh resource instance so guards/transformers/casts apply to the export.

## Verification

13 integration tests through the real `ExportNegotiator`: JSON envelope by default (with `Vary: Accept`, `meta`/`links`/`Total-Count` intact), CSV/TSV/XLSX/XML/NDJSON streaming, and 406 for a tabular format on a resource with no schema - item and collection paths.

`composer check --all --no-cache` clean (fresh cache), `composer test` green (1979), `composer smells` clean. Branched off the current `2.x` (post #294/#295).

Note: the legacy export glue (`RespondsWithExport`/`RespondsWithStream`/`RequestCapabilities` export bits) was already removed in #294.