### PR TITLE
refactor: remove redundant recomputation on the request/response hot path

### DIFF
--- a/src/Http/Middleware/JsonPrettyPrint.php
+++ b/src/Http/Middleware/JsonPrettyPrint.php
@@ -69,7 +69,6 @@ final class JsonPrettyPrint
     private function prettyPrintJsonResponse(JsonResponse $response): void
     {
         $response->setEncodingOptions($response->getEncodingOptions() | JSON_PRETTY_PRINT);
-        $response->setData($response->getData());
     }
 
     /**

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -6,7 +6,6 @@ namespace SineMacula\ApiToolkit\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
-use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Concerns\OrdersFields;
 use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
@@ -405,7 +404,6 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
      */
     private function getFixedFields(): array
     {
-        /** @var array<int, string> */
-        return array_merge(Config::get('api-toolkit.resources.fixed_fields', []), $this->fixed);
+        return $this->fixed;
     }
 }


### PR DESCRIPTION
Part of the v2 deep-review hardening (non-breaking, behaviour-preserving).

- **`ApiResource::getFixedFields()`** stopped re-reading `api-toolkit.resources.fixed_fields`. `FieldResolver::getFields()` already reads and merges that key, so it was being loaded and merged twice on every `resolve()` (saved only by the trailing `array_unique`). `getFixedFields()` now returns just the per-resource `$this->fixed`; `FieldResolver` is the single owner of the config read. Output is byte-identical.
- **`JsonPrettyPrint`** drops the redundant `$response->setData($response->getData())` after `setEncodingOptions()` - Laravel's `setEncodingOptions()` already re-encodes with the OR-ed `JSON_PRETTY_PRINT` flag. Also kills a surviving equivalent mutant.

`composer check --all --no-cache` clean, `composer test` green (1981), `composer smells` clean.