### PR TITLE
refactor: repository-layer cleanups (dead flush, cache-key prefix)

### DIFF
--- a/src/Enums/CacheKeys.php
+++ b/src/Enums/CacheKeys.php
@@ -51,8 +51,8 @@ enum CacheKeys: string
      */
     public function resolveKey(array $replacements = []): string
     {
-        $prefix = Config::get('api-toolkit.cache.prefix', 'sm-api-toolkit');
-        $prefix = is_string($prefix) ? $prefix : 'sm-api-toolkit';
+        $prefix = Config::get('api-toolkit.cache.prefix', 'api-toolkit');
+        $prefix = is_string($prefix) ? $prefix : 'api-toolkit';
 
         $key = $prefix . ':' . $this->value;
 

--- a/src/Repositories/Concerns/AttributeSetter.php
+++ b/src/Repositories/Concerns/AttributeSetter.php
@@ -87,17 +87,6 @@ final class AttributeSetter
     }
 
     /**
-     * Flush the instance-level cast cache, forcing re-resolution on the next
-     * access.
-     *
-     * @return void
-     */
-    public function flush(): void
-    {
-        $this->casts = [];
-    }
-
-    /**
      * Resolve the attribute casts for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model

--- a/tests/Unit/Enums/CacheKeysTest.php
+++ b/tests/Unit/Enums/CacheKeysTest.php
@@ -66,8 +66,8 @@ final class CacheKeysTest extends TestCase
     {
         $result = CacheKeys::REPOSITORY_MODEL_CASTS->resolveKey(['User']);
 
-        self::assertStringStartsWith('sm-api-toolkit:', $result);
-        self::assertSame('sm-api-toolkit:repository-model-casts:User', $result);
+        self::assertStringStartsWith('api-toolkit:', $result);
+        self::assertSame('api-toolkit:repository-model-casts:User', $result);
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
+++ b/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
@@ -690,48 +690,6 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
-     * Test that flush clears the cached casts, forcing re-resolution on the
-     * next call.
-     *
-     * @return void
-     */
-    public function testFlushClearsCasts(): void
-    {
-        $model = new User;
-
-        Config::set('api-toolkit.repositories.cast_map', [
-            'enum' => [UserStatus::class],
-        ]);
-
-        $this->attributeSetter->resolveAttributeCasts($model, User::class);
-
-        $castsBeforeFlush = $this->getProperty($this->attributeSetter, 'casts');
-
-        self::assertNotEmpty($castsBeforeFlush);
-
-        $this->attributeSetter->flush();
-
-        $castsAfterFlush = $this->getProperty($this->attributeSetter, 'casts');
-
-        self::assertSame([], $castsAfterFlush);
-    }
-
-    /**
-     * Test that flush on a fresh AttributeSetter with no prior cast resolution
-     * does not throw an exception.
-     *
-     * @return void
-     */
-    public function testFlushOnEmptyCastsIsHarmless(): void
-    {
-        $this->attributeSetter->flush();
-
-        $casts = $this->getProperty($this->attributeSetter, 'casts');
-
-        self::assertSame([], $casts);
-    }
-
-    /**
      * Test that resolveCastForAttribute returns 'enum' for a cast string that
      * is a valid enum class.
      *


### PR DESCRIPTION
Part of the v2 deep-review hardening (non-breaking).

- **Remove dead `AttributeSetter::flush()`** and its two reflection tests. The method is on a `final` class, belongs to no contract, and has no production caller (`ApiRepository`, the only `AttributeSetter` consumer, never calls it). Deleted outright per the v2 prefer-removal stance.
- **Align the `CacheKeys` fallback prefix** from `sm-api-toolkit` to the shipped config default `api-toolkit`. The fallback only fires when `cache.prefix` config is absent, so there is no production cache-key churn; `CacheKeysTest` expectations updated in lockstep.

`composer check --all --no-cache` clean, `composer test` green (1979), `composer smells` clean.