### PR TITLE
refactor!: schema value-object refinements

### DIFF
--- a/src/Schema/AggregateDefinition.php
+++ b/src/Schema/AggregateDefinition.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace SineMacula\ApiToolkit\Schema;
 
-use Illuminate\Contracts\Support\Arrayable;
-
 /**
  * Abstract base for relation aggregate (sum / average) schema definitions.
  *
@@ -15,10 +13,8 @@ use Illuminate\Contracts\Support\Arrayable;
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
- *
- * @implements \Illuminate\Contracts\Support\Arrayable<string, array<string, mixed>>
  */
-abstract class AggregateDefinition extends BaseDefinition implements Arrayable
+abstract class AggregateDefinition extends BaseDefinition
 {
     /** @var (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null Optional eager-load constraint for this aggregate */
     private ?\Closure $constraint = null;

--- a/src/Schema/BaseDefinition.php
+++ b/src/Schema/BaseDefinition.php
@@ -81,9 +81,9 @@ abstract class BaseDefinition implements Arrayable
      * Provide additional eager-load paths required by this field.
      *
      * @param  string  ...$paths
-     * @return self
+     * @return static
      */
-    public function extras(string ...$paths): self
+    public function extras(string ...$paths): static
     {
         $this->extras = array_values(array_unique([...$this->extras, ...$paths]));
 

--- a/src/Schema/CompiledSchema.php
+++ b/src/Schema/CompiledSchema.php
@@ -105,17 +105,6 @@ final readonly class CompiledSchema
     }
 
     /**
-     * Determine whether a field key exists in the compiled fields.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function hasField(string $key): bool
-    {
-        return isset($this->fields[$key]);
-    }
-
-    /**
      * Return the declared filterable column names.
      *
      * @return array<int, string>

--- a/src/Schema/Count.php
+++ b/src/Schema/Count.php
@@ -4,17 +4,13 @@ declare(strict_types = 1);
 
 namespace SineMacula\ApiToolkit\Schema;
 
-use Illuminate\Contracts\Support\Arrayable;
-
 /**
  * Count schema helper for metric definitions.
  *
  * @author      Ben Carey <ben.carey@verifast.com>
  * @copyright   2026 Sine Macula Limited.
- *
- * @implements \Illuminate\Contracts\Support\Arrayable<string, array<string, mixed>>
  */
-final class Count extends BaseDefinition implements Arrayable
+final class Count extends BaseDefinition
 {
     /** @var (\Closure(\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null Optional eager-load constraint for this count */
     private ?\Closure $constraint = null;

--- a/src/Schema/Relation.php
+++ b/src/Schema/Relation.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace SineMacula\ApiToolkit\Schema;
 
-use Illuminate\Contracts\Support\Arrayable;
-
 /**
  * Relation schema helper for nested resource fields.
  *
@@ -15,10 +13,8 @@ use Illuminate\Contracts\Support\Arrayable;
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
- *
- * @implements \Illuminate\Contracts\Support\Arrayable<string, array<string, mixed>>
  */
-final class Relation extends BaseDefinition implements Arrayable
+final class Relation extends BaseDefinition
 {
     /** @var class-string|null Child ApiResource class */
     private ?string $resource = null;

--- a/tests/Unit/Http/Resources/Schema/CompiledSchemaTest.php
+++ b/tests/Unit/Http/Resources/Schema/CompiledSchemaTest.php
@@ -137,43 +137,6 @@ final class CompiledSchemaTest extends TestCase
     }
 
     /**
-     * Test that hasField returns true for an existing field.
-     *
-     * @return void
-     */
-    public function testCompiledSchemaHasFieldReturnsTrueForExistingField(): void
-    {
-        $field = new CompiledFieldDefinition(
-            accessor: null,
-            compute: null,
-            relation: null,
-            resource: null,
-            fields: null,
-            constraint: null,
-            extras: [],
-            needs: [],
-            guards: [],
-            transformers: [],
-        );
-
-        $schema = new CompiledSchema(['name' => $field], []);
-
-        self::assertTrue($schema->hasField('name'));
-    }
-
-    /**
-     * Test that hasField returns false for a missing field.
-     *
-     * @return void
-     */
-    public function testCompiledSchemaHasFieldReturnsFalseForMissingField(): void
-    {
-        $schema = new CompiledSchema([], []);
-
-        self::assertFalse($schema->hasField('nonexistent'));
-    }
-
-    /**
      * Test that getAggregateDefinitions returns all aggregate definitions.
      *
      * @return void


### PR DESCRIPTION
Part of the v2 deep-review hardening. **Breaking** for the `hasField()` removal.

- **Remove `CompiledSchema::hasField()`** (breaking) - unused and redundant with `getField()` (callers already use `getField()` + null-check). Its two dedicated tests are removed too. Shifts the Infection mutant population for `CompiledSchema` (flagged for the MSI gate; mutation not run here).
- **`BaseDefinition::extras()` returns `static`** instead of `self`, so methods chained after `extras()` on a subclass stay correctly typed. Body unchanged (`return $this`).
- **Drop redundant `implements Arrayable`** (and the orphaned import / `@implements` tag) from `Relation`, `Count`, and `AggregateDefinition` - they already inherit `Arrayable` from `BaseDefinition`, matching the `Field` pattern. Verified at runtime that all four still resolve as `Arrayable`, so `Field::set()`'s `instanceof Arrayable` branch is unaffected.

`composer check --all --no-cache` clean, `composer test` green (1979), `composer smells` clean.