### PR TITLE
refactor: tidy service action-layer runtime wiring

### DIFF
--- a/src/Services/Jobs/ServiceJob.php
+++ b/src/Services/Jobs/ServiceJob.php
@@ -61,15 +61,15 @@ final class ServiceJob implements ShouldQueue
      * Re-hydrate and run the service on the worker.
      *
      * Builds the service from the serialised class-string and input, attaches
-     * the serialised context, then runs it through ServiceRunner with the
-     * source forced to QUEUE.
+     * the dispatched actor, then runs it through ServiceRunner with a fresh
+     * context whose source is forced to QUEUE.
      *
      * @param  \SineMacula\ApiToolkit\Services\ServiceRunner  $runner
      * @return void
      */
     public function handle(ServiceRunner $runner): void
     {
-        $service = ($this->service)::make($this->input)->withContext($this->context); // @phpstan-ignore staticMethod.dynamicName
+        $service = ($this->service)::make($this->input)->by($this->context->actor); // @phpstan-ignore staticMethod.dynamicName
 
         $context = new ServiceContext(
             actor: $this->context->actor,

--- a/src/Services/ServiceRunner.php
+++ b/src/Services/ServiceRunner.php
@@ -70,7 +70,7 @@ final class ServiceRunner
             $this->runOnFailure($hooks, $exception);
             $result = ServiceResult::failure($exception);
         } finally {
-            $this->dispatchEvent($service, $context, $result, $start);
+            $this->dispatchEvent($service, $context, $result, $start, $hooks['inputSummary']);
         }
 
         return $result; // @phpstan-ignore return.type
@@ -254,14 +254,14 @@ final class ServiceRunner
      * @param  \SineMacula\ApiToolkit\Services\ServiceContext  $context
      * @param  \SineMacula\ApiToolkit\Services\ServiceResult<mixed>  $result
      * @param  float  $startTime
+     * @param  array<string, mixed>  $inputSummary
      * @return void
      *
      * @phpstan-ignore missingType.generics
      */
-    private function dispatchEvent(Service $service, ServiceContext $context, ServiceResult $result, float $startTime): void
+    private function dispatchEvent(Service $service, ServiceContext $context, ServiceResult $result, float $startTime, array $inputSummary): void
     {
         $duration      = microtime(true) - $startTime;
-        $inputSummary  = $service->serviceHooks()['inputSummary'];
         $actor         = $service->actor();
         $serviceClass  = $service::class;
         $correlationId = $context->correlationId;


### PR DESCRIPTION
Part of the v2 deep-review hardening (non-breaking, behaviour-equivalent).

- **`ServiceRunner`** threads the `inputSummary` it already builds at the start of `run()` into the lifecycle-event dispatch, instead of re-invoking `serviceHooks()` a second time in the `finally` block. For a hand-rolled mutable `ServiceInput` this snapshots the input at start (the more correct semantic); identical for the immutable `InputData` DTO.
- **`ServiceJob::handle()`** attaches the dispatched actor via `->by($this->context->actor)` rather than storing a context with `->withContext()` that the queue path never read (`run()` builds a fresh `QUEUE`-sourced context regardless, so the stored context was inert). The actor flows identically via `actor()`. `withContext()` is retained - the synchronous `run()` context-reuse path still depends on it.

`composer check --all --no-cache` clean, `composer test` green (1981), `composer smells` clean. No test changes needed.