### PR TITLE
docs: docblock hygiene and removal of external-org author leaks

### DIFF
--- a/src/Concerns/OrdersFields.php
+++ b/src/Concerns/OrdersFields.php
@@ -9,8 +9,8 @@ use SineMacula\ApiToolkit\Enums\FieldOrderingStrategy;
 /**
  * Provides consistent field-ordering utilities for API resources.
  *
- * @author      Michael Stivala <michael.stivala@verifast.com>
- * @copyright   2025 Verifast, Inc.
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
  */
 trait OrdersFields
 {

--- a/src/Enums/FieldOrderingStrategy.php
+++ b/src/Enums/FieldOrderingStrategy.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Enums;
 /**
  * Defines the strategies available for ordering resolved API fields.
  *
- * @author      Michael Stivala <michael.stivala@verifast.app>
- * @copyright   2025 Verifast, Inc.
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
  */
 enum FieldOrderingStrategy: string
 {

--- a/src/Http/Resources/Concerns/DerivesTabularSchema.php
+++ b/src/Http/Resources/Concerns/DerivesTabularSchema.php
@@ -18,11 +18,14 @@ use SineMacula\Exporter\Schema\TabularSchema;
  * Intended for use on {@see \SineMacula\ApiToolkit\Http\Resources\ApiResource}
  * subclasses that also implement
  * {@see \SineMacula\Exporter\Contracts\ProvidesTabularExport}. When mixed in,
- * the `tabular()` method is satisfied for free: it compiles the resource
- * schema and maps each non-relation field to a typed Column, routing accessor
- * and computed fields through a fresh resource instance so guards and
- * transformers are honoured in the export. Plain scalar fields fall through to
- * the default raw-attribute read via `data_get`.
+ * the `tabular()` method is satisfied for free: it compiles the resource schema
+ * and maps each non-relation field to a typed Column. Accessor and computed
+ * fields are resolved through a fresh resource instance, and plain scalar
+ * fields fall through to the default raw-attribute read via `data_get`. The
+ * resource's per-field guards and transformers are NOT applied to exported
+ * values: a guarded or transformed field still emits its underlying attribute
+ * or accessor result. Use the exporter's `->visible()` gate to keep a column
+ * out of an export; a schema-declared guard does not.
  *
  * The schema returned is request-aware so column visibility and field
  * selection can be narrowed by the active API query.
@@ -75,10 +78,12 @@ trait DerivesTabularSchema
     /**
      * Build a single tabular column for the given field definition.
      *
-     * Routes accessor and computed fields through a fresh resource instance
-     * so closures and method logic that the JSON response applies are honoured
-     * identically in the export. Plain scalar fields use the default
-     * raw-attribute read via data_get on the underlying model.
+     * Routes accessor and computed fields through a fresh resource instance so
+     * the field's own compute or accessor closure runs, and plain scalar fields
+     * use the default raw-attribute read via data_get on the underlying model.
+     * The resource's per-field guards and transformers are NOT applied here, so
+     * the column emits the raw resolved value; use the exporter's `->visible()`
+     * gate to exclude a column from an export.
      *
      * @param  string  $key
      * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition

--- a/src/Repositories/Concerns/ResolvesResource.php
+++ b/src/Repositories/Concerns/ResolvesResource.php
@@ -14,8 +14,8 @@ use SineMacula\ApiToolkit\Enums\CacheKeys;
 /**
  * Provides automatic resolution of API resource classes for Eloquent models.
  *
- * @author      Michael Stivala <michael.stivala@verifast.com>
- * @copyright   2025 Verifast, Inc.
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
  */
 trait ResolvesResource
 {

--- a/src/Schema/CompiledAggregateDefinition.php
+++ b/src/Schema/CompiledAggregateDefinition.php
@@ -8,9 +8,8 @@ namespace SineMacula\ApiToolkit\Schema;
  * Typed representation of a single compiled aggregate (sum / average)
  * definition.
  *
- * Replaces the untyped associative arrays previously used in the schema cache,
- * providing typed access to all resolved aggregate properties alongside the
- * column and metric discriminator.
+ * Provides typed access to all resolved aggregate properties stored in the
+ * schema cache, alongside the column and metric discriminator.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/CompiledCountDefinition.php
+++ b/src/Schema/CompiledCountDefinition.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Schema;
 /**
  * Typed representation of a single compiled count definition.
  *
- * Replaces the untyped associative arrays previously used in the schema cache,
- * providing typed access to all resolved count properties.
+ * Provides typed access to all resolved count properties stored in the schema
+ * cache.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/CompiledFieldDefinition.php
+++ b/src/Schema/CompiledFieldDefinition.php
@@ -7,8 +7,8 @@ namespace SineMacula\ApiToolkit\Schema;
 /**
  * Typed representation of a single compiled field definition.
  *
- * Replaces the untyped associative arrays previously used in the schema cache,
- * providing typed access to all resolved field properties.
+ * Provides typed access to all resolved field properties stored in the schema
+ * cache.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/CompiledSchema.php
+++ b/src/Schema/CompiledSchema.php
@@ -7,8 +7,7 @@ namespace SineMacula\ApiToolkit\Schema;
 /**
  * Typed value object holding compiled field, count, and aggregate definitions.
  *
- * Provides typed access to the compiled schema data, replacing the untyped
- * associative arrays previously used in the schema cache.
+ * Provides typed access to the compiled schema data stored in the schema cache.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/Count.php
+++ b/src/Schema/Count.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 /**
  * Count schema helper for metric definitions.
  *
- * @author      Ben Carey <ben.carey@verifast.com>
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  *
  * @implements \Illuminate\Contracts\Support\Arrayable<string, array<string, mixed>>

--- a/src/Schema/OpenApiFieldDeclaration.php
+++ b/src/Schema/OpenApiFieldDeclaration.php
@@ -11,8 +11,8 @@ namespace SineMacula\ApiToolkit\Schema;
  * nullability, enumerated values, example, and description through chainable
  * setters, then freezes into an immutable OpenApiFieldSchema. The carrier is
  * additive: it exists only when openapi() is called and is omitted from the
- * definition's toArray() output otherwise, preserving byte-for-byte backward
- * compatibility.
+ * definition's toArray() output otherwise, leaving that output unchanged for
+ * definitions that declare no OpenAPI contract.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Jobs/ServiceJob.php
+++ b/src/Services/Jobs/ServiceJob.php
@@ -20,16 +20,14 @@ use SineMacula\ApiToolkit\Services\ServiceRunner;
  * Serialises the service class-string, the typed input, and the execution
  * context (including the actor reference) onto the queue. On the worker,
  * re-hydrates and runs the service identically via ServiceRunner with the
- * source forced to QUEUE - no Auth or Request is consulted (NFR-07).
+ * source forced to QUEUE - no Auth or Request is consulted.
  *
  * Naming deviation: jobs are normally named with a leading verb; this generic
- * bridge runs an arbitrary service so the Job suffix is used instead
- * (#php-nam-063).
+ * bridge runs an arbitrary service so the Job suffix is used instead.
  *
  * Limitation: subject-bearing services that require a Model constructor
  * argument beyond the input are out of scope for this bridge; the subject
- * identifier should ride in the input. See UPGRADE.md for the planned
- * subject-aware variant.
+ * identifier should ride in the input.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/ServiceContext.php
+++ b/src/Services/ServiceContext.php
@@ -14,7 +14,7 @@ use SineMacula\ApiToolkit\Services\Enums\ServiceSource;
  * Carries the actor that initiated the service, a correlation id (generated
  * when absent), the execution source, and captured ambient metadata such as IP
  * address, user-agent, or request id. Metadata is supplied explicitly at the
- * capture site and never read ambiently inside services (NFR-07).
+ * capture site and never read ambiently inside services.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/LifecycleFlushDefaultsTest.php
+++ b/tests/Integration/LifecycleFlushDefaultsTest.php
@@ -74,9 +74,8 @@ final class LifecycleFlushDefaultsTest extends TestCase
      * Test that an Octane boundary flushes stale metadata so request 2 reads
      * the new shape rather than the memoised old shape.
      *
-     * Validates AC-03 / AC-04: under a long-lived Octane worker, metadata
-     * written before the request boundary must not survive into the next
-     * request.
+     * Under a long-lived Octane worker, metadata written before the request
+     * boundary must not survive into the next request.
      *
      * @return void
      */
@@ -111,8 +110,8 @@ final class LifecycleFlushDefaultsTest extends TestCase
      * Test that a queue worker boundary flushes stale metadata so job 2 reads
      * the new shape rather than the memoised old shape.
      *
-     * Validates AC-06: under a long-lived queue worker, metadata must not leak
-     * across job boundaries.
+     * Under a long-lived queue worker, metadata must not leak across job
+     * boundaries.
      *
      * @return void
      */
@@ -148,8 +147,8 @@ final class LifecycleFlushDefaultsTest extends TestCase
      * Test that under php-fpm (no LARAVEL_OCTANE signal), the Octane listener
      * does not perform a flush even when the config flag is on.
      *
-     * Validates AC-09: the runtime gate, not the config flag, prevents flush
-     * engagement outside a long-lived Octane worker.
+     * The runtime gate, not the config flag, prevents flush engagement outside
+     * a long-lived Octane worker.
      *
      * @return void
      */
@@ -178,9 +177,9 @@ final class LifecycleFlushDefaultsTest extends TestCase
      * Test that the opt-out flag prevents the lifecycle flush from being wired
      * to its boundary at all.
      *
-     * Validates AC-02: with the lifecycle flag off, LifecycleRegistrar does not
-     * subscribe the flush, so no boundary can fire it. The queue path is the
-     * representative opt-out oracle - the Octane path additionally gates on
+     * With the lifecycle flag off, LifecycleRegistrar does not subscribe the
+     * flush, so no boundary can fire it. The queue path is the representative
+     * opt-out oracle - the Octane path additionally gates on
      * class_exists(OperationTerminated), which is always false here because
      * laravel/octane is not installed, so the queue gate is the one that can be
      * isolated. The enabled control proves the assertion tracks the flag rather
@@ -221,8 +220,7 @@ final class LifecycleFlushDefaultsTest extends TestCase
      * Test that a non-toolkit key written directly to the shared memo store
      * survives the scoped metadata flush while the toolkit key is cleared.
      *
-     * Validates NFR-01 / AC-08: the flush must not blast non-toolkit keys off
-     * the shared memo store.
+     * The flush must not blast non-toolkit keys off the shared memo store.
      *
      * @return void
      */

--- a/tests/Integration/ServiceQueueIntegrationTest.php
+++ b/tests/Integration/ServiceQueueIntegrationTest.php
@@ -22,8 +22,8 @@ use Tests\TestCase;
  * Queue integration tests for ServiceJob and the actor serialisation path.
  *
  * Proves that a queued run re-hydrates identically, the actor survives
- * serialisation without consulting Auth or Request (NFR-07, AC-36), and the
- * worker run carries source = QUEUE.
+ * serialisation without consulting Auth or Request, and the worker run carries
+ * source = QUEUE.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -238,8 +238,8 @@ final class CacheManagerTest extends TestCase
     /**
      * Test that flush leaves an unregistered non-toolkit key intact.
      *
-     * Pins NFR-01/AC-08: keys written directly to the memo store without going
-     * through the MetadataKeyRegistry must survive the scoped flush.
+     * Keys written directly to the memo store without going through the
+     * MetadataKeyRegistry must survive the scoped flush.
      *
      * @return void
      */


### PR DESCRIPTION
Part of the v2 deep-review hardening. Documentation-prose-only (no executable code, signatures, or assertions changed).

- **External-org leaks removed (confidentiality).** Four `@author` tags pointed at `verifast.com`/`verifast.app` addresses, and three carried `@copyright 2025 Verifast, Inc.` - normalised to the repo-standard Sine Macula attribution (column-14 alignment preserved):
  - `src/Schema/Count.php`, `src/Enums/FieldOrderingStrategy.php`, `src/Repositories/Concerns/ResolvesResource.php`, `src/Concerns/OrdersFields.php`.
- **Requirement-ID tokens stripped** (`NFR-*`, `AC-*`, `#php-nam-*`) plus a dangling "see UPGRADE.md for the planned subject-aware variant" pointer, from the `ServiceContext`/`ServiceJob` docblocks and three test docblocks.
- **Present-tense VO docblocks** - the `Compiled*` value objects and `OpenApiFieldDeclaration` were reworded from "replaces the untyped arrays / byte-for-byte backward compatibility" migration-history framing to describe what they do now.
- **`DerivesTabularSchema` correction (security-relevant).** The class and `buildTabularColumn()` docblocks implied schema field guards and transformers are honoured in tabular exports. They are not - the export runs only the field's own compute/accessor closure or a raw attribute read. The docblocks now say so plainly and point to the exporter's `->visible()` as the required column-exclusion gate. (Whether to *close* that gap is a separate maintainer decision.)

Note: a repo-wide sweep found other test docblocks still carrying `AC-`/`NFR-` spec tokens and "backward-compatibility oracle" framing - left out of scope here and flagged for a possible follow-up.

`composer check --all --no-cache` clean, `composer test` green (1981).