### PR TITLE
fix: make error rendering resilient to statuses without a title

### DIFF
--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -69,10 +69,13 @@ abstract class ApiException extends \Exception
      * Get HTTP status code.
      *
      * @return int
+     *
+     * @throws \LogicException
      */
     public static function getHttpStatusCode(): int
     {
-        return self::getHttpStatus()->getCode();
+        return self::getHttpStatus()?->getCode()
+            ?? throw new \LogicException('The HTTP_STATUS constant must be defined on the exception');
     }
 
     /**
@@ -93,12 +96,14 @@ abstract class ApiException extends \Exception
     /**
      * Get the HTTP status for this exception instance.
      *
-     * Defaults to the HTTP_STATUS constant. Used to derive the default title
-     * when no translation exists for the error code.
+     * Defaults to the HTTP_STATUS constant, or null for exceptions whose status
+     * has no corresponding case in the shared HTTP status enum (e.g. the
+     * non-standard 419). Used to derive the default title when no translation
+     * exists for the error code.
      *
-     * @return \SineMacula\Http\Enums\HttpStatus
+     * @return \SineMacula\Http\Enums\HttpStatus|null
      */
-    public function getStatus(): HttpStatus
+    public function getStatus(): ?HttpStatus
     {
         return self::getHttpStatus();
     }
@@ -144,9 +149,9 @@ abstract class ApiException extends \Exception
     /**
      * Get the namespace of the current exception.
      *
-     * @return string|null
+     * @return string
      */
-    protected function getNamespace(): ?string
+    protected function getNamespace(): string
     {
         return 'api-toolkit';
     }
@@ -171,14 +176,15 @@ abstract class ApiException extends \Exception
     /**
      * Get HTTP status.
      *
-     * @return \SineMacula\Http\Enums\HttpStatus
+     * Returns null for exceptions that declare no HTTP_STATUS constant, such as
+     * those whose status has no case in the shared HTTP status enum.
      *
-     * @throws \LogicException
+     * @return \SineMacula\Http\Enums\HttpStatus|null
      */
-    private static function getHttpStatus(): HttpStatus
+    private static function getHttpStatus(): ?HttpStatus
     {
         if (!defined(static::class . '::HTTP_STATUS')) {
-            throw new \LogicException('The HTTP_STATUS constant must be defined on the exception');
+            return null;
         }
 
         /** @var \SineMacula\Http\Enums\HttpStatus */
@@ -188,11 +194,21 @@ abstract class ApiException extends \Exception
     /**
      * Derive a human-readable title from the HTTP status enum case name.
      *
+     * Falls back to a generic title for exceptions whose status has no
+     * corresponding enum case, ensuring rendering never fails for a missing
+     * title.
+     *
      * @return string
      */
     private function getDefaultTitle(): string
     {
-        return ucwords(strtolower(str_replace('_', ' ', $this->getStatus()->name)));
+        $status = $this->getStatus();
+
+        if ($status === null) {
+            return 'Unknown Error';
+        }
+
+        return ucwords(strtolower(str_replace('_', ' ', $status->name)));
     }
 
     /**

--- a/src/OpenApi/Metadata/ErrorCatalogueReader.php
+++ b/src/OpenApi/Metadata/ErrorCatalogueReader.php
@@ -7,7 +7,6 @@ namespace SineMacula\ApiToolkit\OpenApi\Metadata;
 use Illuminate\Support\Facades\Lang;
 use SineMacula\ApiToolkit\Enums\ErrorCode;
 use SineMacula\ApiToolkit\Exceptions\ApiException;
-use SineMacula\ApiToolkit\Exceptions\TokenMismatchException;
 use SineMacula\ApiToolkit\OpenApi\Exceptions\MetadataReadException;
 
 /**
@@ -132,16 +131,7 @@ final class ErrorCatalogueReader
             return 500;
         }
 
-        // TokenMismatchException overrides getHttpStatusCode() to return 419
-        // directly (no HTTP_STATUS constant) — call the static method.
-        if ($exceptionClass === TokenMismatchException::class || !defined($exceptionClass . '::HTTP_STATUS')) {
-            return $exceptionClass::getHttpStatusCode();
-        }
-
-        /** @var \SineMacula\Http\Enums\HttpStatus $statusConstant */
-        $statusConstant = constant($exceptionClass . '::HTTP_STATUS');
-
-        return $statusConstant->getCode();
+        return $exceptionClass::getHttpStatusCode();
     }
 
     /**

--- a/tests/Integration/ExceptionRenderingTest.php
+++ b/tests/Integration/ExceptionRenderingTest.php
@@ -12,6 +12,8 @@ use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Facades\Route;
 use Monolog\Handler\NullHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Enums\ErrorCode;
+use SineMacula\ApiToolkit\Exceptions\ApiException;
 use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
 use SineMacula\ApiToolkit\Exceptions\ConflictException;
 use Tests\TestCase;
@@ -77,6 +79,40 @@ final class ExceptionRenderingTest extends TestCase
 
         Route::get('/api/token-mismatch', static function (): never {
             throw new TokenMismatchException('CSRF token mismatch.');
+        });
+
+        // Mirrors an exception like the dedicated 419 mismatch: a non-standard
+        // status with no HTTP status enum case (so getStatus() is null) and a
+        // namespace that registers no title translation, exercising the
+        // generic-title fallback during rendering.
+        Route::get('/api/missing-title', static function (): never {
+            throw new class extends ApiException {
+                /** The internal error code for the test exception. */
+                public const \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface CODE = ErrorCode::TOKEN_MISMATCH;
+
+                /**
+                 * Return a non-standard status code with no HTTP status enum
+                 * case.
+                 *
+                 * @return int
+                 */
+                #[\Override]
+                public static function getHttpStatusCode(): int
+                {
+                    return 419;
+                }
+
+                /**
+                 * Resolve from a namespace with no registered translations.
+                 *
+                 * @return string
+                 */
+                #[\Override]
+                protected function getNamespace(): string
+                {
+                    return 'missing-title-namespace';
+                }
+            };
         });
 
         Route::get('/api/unhandled', static function (): never {
@@ -167,6 +203,22 @@ final class ExceptionRenderingTest extends TestCase
         $response->assertStatus(419);
         $response->assertJsonPath('error.status', 419);
         $response->assertJsonPath('error.code', 10105);
+    }
+
+    /**
+     * Test that an exception whose title translation is absent still renders,
+     * carrying its status code and a generic fallback title rather than
+     * throwing while deriving the title.
+     *
+     * @return void
+     */
+    public function testExceptionWithMissingTitleTranslationStillRenders(): void
+    {
+        $response = $this->getJson('/api/missing-title');
+
+        $response->assertStatus(419);
+        $response->assertJsonPath('error.status', 419);
+        $response->assertJsonPath('error.title', 'Unknown Error');
     }
 
     /**

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -345,9 +345,9 @@ final class ApiExceptionTest extends TestCase
             /**
              * Expose the inherited namespace for assertion.
              *
-             * @return string|null
+             * @return string
              */
-            public function exposedNamespace(): ?string
+            public function exposedNamespace(): string
             {
                 return $this->getNamespace();
             }


### PR DESCRIPTION
Part of the v2 deep-review hardening. Correctness fix + dependent cleanup.

- **Base invariant restored (`ApiException`).** The renderer could throw a `LogicException` when an exception's status had no matching title translation - the `TokenMismatchException` `419` case (no http-primitives enum case). `getStatus()`/`getHttpStatus()` now degrade to `null` instead of assuming a valid enum case, and `getDefaultTitle()` falls back to a generic title while preserving the enum-name-derived title for every status-bearing exception. `getHttpStatusCode()` keeps its declared-status invariant. New render test (`testExceptionWithMissingTitleTranslationStillRenders`) proves a missing-title exception renders with the right status, a generic title, and no `LogicException`.
- **`ErrorCatalogueReader::resolveHttpStatus()` collapsed** (depends on the above) - now a null-check plus `getHttpStatusCode()`, dropping the redundant `TokenMismatchException` class-identity special-case, its `constant()` read, and the now-unused import.
- **`ApiException::getNamespace()`** tightened `?string` -> `string` (never null in practice).

The load-bearing `mapGenericHttpException` 419 remap in `ApiExceptionHandler` is untouched; all normal-path statuses and titles are byte-identical (existing `ConcreteExceptionsTest`/`ErrorCatalogueReaderTest`/`ExceptionRenderingTest`/`HttpExceptionTest` pass unmodified).

`composer check --all --no-cache` clean, `composer test` green (1982, +1 render test), `composer smells` clean.