### PR TITLE
refactor: compose the error-envelope $ref from its name constant

### DIFF
--- a/src/OpenApi/Builder/ErrorResponseBuilder.php
+++ b/src/OpenApi/Builder/ErrorResponseBuilder.php
@@ -28,7 +28,7 @@ final class ErrorResponseBuilder
     private const string RESPONSE_NAME_PREFIX = 'ErrorResponse';
 
     /** The reference to the shared error-envelope schema */
-    private const string ENVELOPE_SCHEMA_REF = '#/components/schemas/ErrorEnvelope';
+    private const string ENVELOPE_SCHEMA_REF = '#/components/schemas/' . self::ENVELOPE_SCHEMA_NAME;
 
     /**
      * Constructor.


### PR DESCRIPTION
Part of the v2 deep-review hardening (non-breaking, value-preserving).

`ErrorResponseBuilder::ENVELOPE_SCHEMA_REF` was a hard-coded `'#/components/schemas/ErrorEnvelope'` literal that duplicated the component name already held in `ENVELOPE_SCHEMA_NAME`. It is now composed as `'#/components/schemas/' . self::ENVELOPE_SCHEMA_NAME`, so the name lives in one place. Compile-time value unchanged, so the literal-asserting tests stay green.

Deliberately left alone: the cross-class prefix duplication in `ResourceSchemaBuilder` (only two call sites, and the classes cannot reference each other's private const - not worth a shared/public constant).

`composer check --all --no-cache` clean, `composer test` green (1981), `composer smells` clean.