### PR TITLE
docs: document the input redaction seam and result failure-output affordance

### DIFF
--- a/src/Services/Contracts/ServiceInput.php
+++ b/src/Services/Contracts/ServiceInput.php
@@ -20,6 +20,10 @@ interface ServiceInput
     /**
      * Return the input as an associative array.
      *
+     * This snapshot is carried on the service lifecycle events as inputSummary
+     * and reaches event listeners verbatim. Override this method to scrub
+     * sensitive keys before they are exposed to those listeners.
+     *
      * @return array<string, mixed>
      */
     public function toArray(): array;

--- a/src/Services/Events/ServiceEvent.php
+++ b/src/Services/Events/ServiceEvent.php
@@ -14,6 +14,10 @@ use SineMacula\ApiToolkit\Services\ServiceResult;
  * metadata. Concrete subclasses (ServiceCompleted, ServiceFailed) distinguish
  * the success and failure cases so consumers can subscribe to each.
  *
+ * The inputSummary is produced by the input's toArray() and flows verbatim
+ * to every listener (audit, telemetry); it is not redacted here. Override
+ * the input's toArray() to scrub sensitive keys before they reach listeners.
+ *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
@@ -48,7 +52,7 @@ abstract readonly class ServiceEvent
         /** Correlation identifier for request tracing */
         public string $correlationId,
 
-        /** Snapshot of the input fields passed to the service */
+        /** Input snapshot; scrub sensitive keys via the input's toArray() */
         public array $inputSummary = [],
     ) {}
 }

--- a/src/Services/Input/InputData.php
+++ b/src/Services/Input/InputData.php
@@ -72,6 +72,10 @@ abstract class InputData implements ServiceInput
      * name-to-value map. Concrete subclasses need not implement toArray()
      * unless they require custom serialisation.
      *
+     * The returned map is carried on the service lifecycle events as
+     * inputSummary and reaches event listeners verbatim, so override this
+     * method to scrub sensitive keys before they are exposed.
+     *
      * @return array<string, mixed>
      */
     #[\Override]

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -189,7 +189,8 @@ abstract class Service implements LockKeyProvider
             'transactional'       => $this->transactional,
             'transactionAttempts' => $this->transactionAttempts,
             'lockable'            => $this->lockable,
-            'inputSummary'        => $this->input->toArray(),
+            // Flows verbatim to lifecycle-event listeners; scrub via toArray()
+            'inputSummary' => $this->input->toArray(),
         ];
     }
 

--- a/src/Services/ServiceResult.php
+++ b/src/Services/ServiceResult.php
@@ -60,6 +60,12 @@ final readonly class ServiceResult
     /**
      * Create a failed service result.
      *
+     * The optional $output lets a caller attach partial or diagnostic output to
+     * a failed result. The package never populates it on its own failures; it
+     * exists purely for callers that construct a failure directly. Note that
+     * outputOr() still returns its default for a failed result, so any output
+     * attached here is reachable only via the output property or output().
+     *
      * @param  \Throwable|null  $exception
      * @param  mixed  $output
      * @return self<mixed>
@@ -102,9 +108,9 @@ final readonly class ServiceResult
     /**
      * Return the output when succeeded, or the given default otherwise.
      *
-     * A failed result always returns the default, even when a non-null output
-     * was captured alongside the failure. This lets the caller distinguish "no
-     * output" from "failed" without checking the status.
+     * A failed result intentionally returns the default, even when output was
+     * attached to the failure via failure(). This lets the caller distinguish
+     * "no output" from "failed" without checking the status.
      *
      * @param  mixed  $default
      * @return mixed


### PR DESCRIPTION
Part of the v2 deep-review hardening (decisions [17] + [19]). Documentation-only - no behaviour, signatures, or assertions changed.

- **[17] Input redaction seam.** A service's input is carried into lifecycle events as `inputSummary` (via `ServiceInput::toArray()`) and reaches every listener verbatim - audit/telemetry included. The docblocks now name `toArray()` as the override point to scrub sensitive keys before they leave the process (noted on `ServiceEvent`, `Service::serviceHooks()`, `ServiceInput::toArray()`, `InputData::toArray()`). No `sensitiveKeys()` or redaction behaviour added - that remains a separate decision if you want redact-by-default.
- **[19] `ServiceResult::failure()` `$output`.** Documents that the optional `$output` lets a caller attach partial/diagnostic output (the package never populates it on its own failures), and that `outputOr()` intentionally returns its default on a failed result, so attached output is reachable only via `output`/`output()`. Parameter and behaviour unchanged.

`composer check --all --no-cache` clean, `composer test` green (1981).