### PR TITLE
refactor!: make the ThrottleRequests middleware final

### DIFF
--- a/src/Http/Middleware/ThrottleRequests.php
+++ b/src/Http/Middleware/ThrottleRequests.php
@@ -12,10 +12,8 @@ use SineMacula\ApiToolkit\Http\Middleware\Concerns\ThrottleRequestsTrait;
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
- *
- * @inheritable
  */
-class ThrottleRequests extends BaseThrottleRequests
+final class ThrottleRequests extends BaseThrottleRequests
 {
     use ThrottleRequestsTrait;
 }

--- a/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
+++ b/tests/Unit/Http/Middleware/Traits/ThrottleRequestsTraitTest.php
@@ -8,12 +8,12 @@ use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests as BaseThrottleRequests;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 use SineMacula\ApiToolkit\Exceptions\RequestSignatureException;
 use SineMacula\ApiToolkit\Http\Middleware\Concerns\ThrottleRequestsTrait;
-use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequests;
 use SineMacula\Http\Enums\HttpMethod;
 
 /**
@@ -170,7 +170,9 @@ final class ThrottleRequestsTraitTest extends TestCase
         $cache   = self::createStub(Repository::class);
         $limiter = new RateLimiter($cache);
 
-        $middleware = new class ($limiter) extends ThrottleRequests {
+        $middleware = new class ($limiter) extends BaseThrottleRequests {
+            use ThrottleRequestsTrait;
+
             /**
              * @param  \Illuminate\Http\Request  $request
              * @return string


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [6]). **Breaking** (removes a subclassing extension point).

`ThrottleRequestsWithRedis` was already `final`, but `ThrottleRequests` carried an `@inheritable` escape hatch - an unwarranted asymmetry. The supported customisation point is the `throttle.class` config override (a consumer points config at their own middleware class), **not** subclassing the toolkit's middleware, and nothing in `src/` extends it. `ThrottleRequests` is now `final` to match, restoring the final-by-default posture.

The one test that subclassed it to exercise `ThrottleRequestsTrait` now composes the trait onto Laravel's own base `ThrottleRequests` (not the toolkit's final class), preserving its intent and assertion. The `throttle.class` config-override path is untouched (`MiddlewareConfigCustomThrottleTest` still passes unmodified).

`composer check --all --no-cache` clean, `composer test` green (1981), `composer smells` clean.