### PR TITLE
refactor!: remove the orphaned export-detection capabilities (expectsStream + expectsPdf)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -530,8 +530,8 @@ posture leaks fewer sensitive columns out of the box.
 
 ### Removed: Request macros in favour of RequestCapabilities
 
-The request macros the toolkit used to register - `includeTrashed()`, `onlyTrashed()`, `expectsPdf()`,
-and `expectsStream()` - have been removed. Resolve these capabilities through the typed
+The request macros the toolkit used to register - `includeTrashed()`, `onlyTrashed()`, and
+`expectsPdf()` - have been removed. Resolve these capabilities through the typed
 `RequestCapabilities` value object instead. The export-detection macros (`expectsExport()`,
 `expectsCsv()`, and `expectsXml()`) have been removed outright: content-negotiated exports now live in the
 `sinemacula/laravel-resource-exporter` package, not in the toolkit.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -530,15 +530,15 @@ posture leaks fewer sensitive columns out of the box.
 
 ### Removed: Request macros in favour of RequestCapabilities
 
-The request macros the toolkit used to register - `includeTrashed()`, `onlyTrashed()`, and
-`expectsPdf()` - have been removed. Resolve these capabilities through the typed
+The request macros the toolkit used to register - `includeTrashed()` and `onlyTrashed()` - have
+been removed. Resolve these capabilities through the typed
 `RequestCapabilities` value object instead. The export-detection macros (`expectsExport()`,
 `expectsCsv()`, and `expectsXml()`) have been removed outright: content-negotiated exports now live in the
 `sinemacula/laravel-resource-exporter` package, not in the toolkit.
 
 **Before:**
 
-    if ($request->expectsPdf()) {
+    if ($request->includeTrashed()) {
         // ...
     }
 
@@ -548,7 +548,7 @@ The request macros the toolkit used to register - `includeTrashed()`, `onlyTrash
 
     $capabilities = RequestCapabilities::fromRequest($request);
 
-    if ($capabilities->expectsPdf()) {
+    if ($capabilities->includeTrashed()) {
         // ...
     }
 

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -412,7 +412,7 @@ return [
     |
     | `detect_capabilities`: Controls the registration of the
     | DetectsCapabilities middleware, which resolves the typed request
-    | capabilities (trashed visibility, PDF and SSE stream negotiation)
+    | capabilities (trashed visibility and PDF negotiation)
     | once per request. Capabilities resolve lazily on first access even
     | when disabled; the middleware simply precomputes them.
     |   - `enabled`: true to register (default), false to skip entirely.

--- a/src/Http/RequestCapabilities.php
+++ b/src/Http/RequestCapabilities.php
@@ -5,13 +5,11 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Http;
 
 use Illuminate\Http\Request;
-use SineMacula\Http\Enums\HttpHeader;
-use SineMacula\Http\Enums\MediaType;
 
 /**
  * Request capabilities value object.
  *
- * Encapsulates the 3 boolean capability checks resolved from the current
+ * Encapsulates the 2 boolean capability checks resolved from the current
  * request. Immutable once created.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
@@ -27,7 +25,6 @@ final class RequestCapabilities
      *
      * @param  bool  $includeTrashed
      * @param  bool  $onlyTrashed
-     * @param  bool  $expectsPdf
      */
     private function __construct(
 
@@ -36,9 +33,6 @@ final class RequestCapabilities
 
         /** Whether the request returns only soft-deleted records. */
         private readonly bool $onlyTrashed,
-
-        /** Whether the request expects a PDF response. */
-        private readonly bool $expectsPdf,
     ) {}
 
     /**
@@ -77,16 +71,9 @@ final class RequestCapabilities
         $includeTrashed = $request->input('include_trashed', false) === 'true';
         $onlyTrashed    = $request->input('only_trashed', false)    === 'true';
 
-        /** @var string $acceptRaw */
-        $acceptRaw    = $request->header(HttpHeader::ACCEPT->getName(), '');
-        $acceptHeader = strtolower($acceptRaw);
-
-        $expectsPdf = $acceptHeader === MediaType::APPLICATION_PDF->getMimeType();
-
         return new self(
             $includeTrashed,
             $onlyTrashed,
-            $expectsPdf,
         );
     }
 
@@ -124,15 +111,5 @@ final class RequestCapabilities
     public function onlyTrashed(): bool
     {
         return $this->onlyTrashed;
-    }
-
-    /**
-     * Whether the request expects a PDF response.
-     *
-     * @return bool
-     */
-    public function expectsPdf(): bool
-    {
-        return $this->expectsPdf;
     }
 }

--- a/src/Http/RequestCapabilities.php
+++ b/src/Http/RequestCapabilities.php
@@ -11,7 +11,7 @@ use SineMacula\Http\Enums\MediaType;
 /**
  * Request capabilities value object.
  *
- * Encapsulates the 4 boolean capability checks resolved from the current
+ * Encapsulates the 3 boolean capability checks resolved from the current
  * request. Immutable once created.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
@@ -28,7 +28,6 @@ final class RequestCapabilities
      * @param  bool  $includeTrashed
      * @param  bool  $onlyTrashed
      * @param  bool  $expectsPdf
-     * @param  bool  $expectsStream
      */
     private function __construct(
 
@@ -40,9 +39,6 @@ final class RequestCapabilities
 
         /** Whether the request expects a PDF response. */
         private readonly bool $expectsPdf,
-
-        /** Whether the request expects a streamed response. */
-        private readonly bool $expectsStream,
     ) {}
 
     /**
@@ -85,14 +81,12 @@ final class RequestCapabilities
         $acceptRaw    = $request->header(HttpHeader::ACCEPT->getName(), '');
         $acceptHeader = strtolower($acceptRaw);
 
-        $expectsPdf    = $acceptHeader === MediaType::APPLICATION_PDF->getMimeType();
-        $expectsStream = $acceptHeader === MediaType::TEXT_EVENT_STREAM->getMimeType();
+        $expectsPdf = $acceptHeader === MediaType::APPLICATION_PDF->getMimeType();
 
         return new self(
             $includeTrashed,
             $onlyTrashed,
             $expectsPdf,
-            $expectsStream,
         );
     }
 
@@ -140,15 +134,5 @@ final class RequestCapabilities
     public function expectsPdf(): bool
     {
         return $this->expectsPdf;
-    }
-
-    /**
-     * Whether the request expects a streamed response.
-     *
-     * @return bool
-     */
-    public function expectsStream(): bool
-    {
-        return $this->expectsStream;
     }
 }

--- a/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
+++ b/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
@@ -81,7 +81,6 @@ final class DetectsCapabilitiesTest extends TestCase
             static::assertTrue($capabilities->includeTrashed());
             static::assertFalse($capabilities->onlyTrashed());
             static::assertFalse($capabilities->expectsPdf());
-            static::assertFalse($capabilities->expectsStream());
 
             return new Response;
         });

--- a/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
+++ b/tests/Unit/Http/Middleware/DetectsCapabilitiesTest.php
@@ -80,7 +80,6 @@ final class DetectsCapabilitiesTest extends TestCase
 
             static::assertTrue($capabilities->includeTrashed());
             static::assertFalse($capabilities->onlyTrashed());
-            static::assertFalse($capabilities->expectsPdf());
 
             return new Response;
         });

--- a/tests/Unit/Http/RequestCapabilitiesTest.php
+++ b/tests/Unit/Http/RequestCapabilitiesTest.php
@@ -56,7 +56,6 @@ final class RequestCapabilitiesTest extends TestCase
         self::assertFalse($capabilities->includeTrashed());
         self::assertFalse($capabilities->onlyTrashed());
         self::assertFalse($capabilities->expectsPdf());
-        self::assertFalse($capabilities->expectsStream());
     }
 
     /**
@@ -119,21 +118,6 @@ final class RequestCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that resolve detects stream via Accept header.
-     *
-     * @return void
-     */
-    public function testResolveDetectsExpectsStream(): void
-    {
-        $request = Request::create(self::TEST_URL);
-        $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::TEXT_EVENT_STREAM->getMimeType());
-
-        $capabilities = RequestCapabilities::resolve($request);
-
-        self::assertTrue($capabilities->expectsStream());
-    }
-
-    /**
      * Test that storeOnRequest sets the attribute on the request.
      *
      * @return void
@@ -152,7 +136,7 @@ final class RequestCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that all 4 accessor methods return the correct corresponding values.
+     * Test that all 3 accessor methods return the correct corresponding values.
      *
      * @return void
      */
@@ -162,13 +146,11 @@ final class RequestCapabilitiesTest extends TestCase
             includeTrashed: true,
             onlyTrashed: true,
             expectsPdf: true,
-            expectsStream: true,
         );
 
         self::assertTrue($capabilities->includeTrashed());
         self::assertTrue($capabilities->onlyTrashed());
         self::assertTrue($capabilities->expectsPdf());
-        self::assertTrue($capabilities->expectsStream());
     }
 
     /**
@@ -177,10 +159,9 @@ final class RequestCapabilitiesTest extends TestCase
      * @param  bool  $includeTrashed
      * @param  bool  $onlyTrashed
      * @param  bool  $expectsPdf
-     * @param  bool  $expectsStream
      * @return \SineMacula\ApiToolkit\Http\RequestCapabilities
      */
-    private function createCapabilities(bool $includeTrashed = false, bool $onlyTrashed = false, bool $expectsPdf = false, bool $expectsStream = false): RequestCapabilities
+    private function createCapabilities(bool $includeTrashed = false, bool $onlyTrashed = false, bool $expectsPdf = false): RequestCapabilities
     {
 
         $reflection  = new \ReflectionClass(RequestCapabilities::class);
@@ -197,7 +178,6 @@ final class RequestCapabilitiesTest extends TestCase
             $includeTrashed,
             $onlyTrashed,
             $expectsPdf,
-            $expectsStream,
         );
 
         return $instance;

--- a/tests/Unit/Http/RequestCapabilitiesTest.php
+++ b/tests/Unit/Http/RequestCapabilitiesTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\Http;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Http\RequestCapabilities;
-use SineMacula\Http\Enums\HttpHeader;
-use SineMacula\Http\Enums\MediaType;
 use Tests\TestCase;
 
 /**
@@ -55,7 +53,6 @@ final class RequestCapabilitiesTest extends TestCase
 
         self::assertFalse($capabilities->includeTrashed());
         self::assertFalse($capabilities->onlyTrashed());
-        self::assertFalse($capabilities->expectsPdf());
     }
 
     /**
@@ -103,21 +100,6 @@ final class RequestCapabilitiesTest extends TestCase
     }
 
     /**
-     * Test that resolve detects PDF via Accept header.
-     *
-     * @return void
-     */
-    public function testResolveDetectsExpectsPdf(): void
-    {
-        $request = Request::create(self::TEST_URL);
-        $request->headers->set(HttpHeader::ACCEPT->getName(), MediaType::APPLICATION_PDF->getMimeType());
-
-        $capabilities = RequestCapabilities::resolve($request);
-
-        self::assertTrue($capabilities->expectsPdf());
-    }
-
-    /**
      * Test that storeOnRequest sets the attribute on the request.
      *
      * @return void
@@ -125,18 +107,18 @@ final class RequestCapabilitiesTest extends TestCase
     public function testStoreOnRequestSetsAttribute(): void
     {
         $request      = Request::create(self::TEST_URL);
-        $capabilities = $this->createCapabilities(expectsPdf: true);
+        $capabilities = $this->createCapabilities(includeTrashed: true);
 
         RequestCapabilities::storeOnRequest($request, $capabilities);
 
         $stored = $request->attributes->get(RequestCapabilities::class);
 
         self::assertInstanceOf(RequestCapabilities::class, $stored);
-        self::assertTrue($stored->expectsPdf());
+        self::assertTrue($stored->includeTrashed());
     }
 
     /**
-     * Test that all 3 accessor methods return the correct corresponding values.
+     * Test that all 2 accessor methods return the correct corresponding values.
      *
      * @return void
      */
@@ -145,12 +127,10 @@ final class RequestCapabilitiesTest extends TestCase
         $capabilities = $this->createCapabilities(
             includeTrashed: true,
             onlyTrashed: true,
-            expectsPdf: true,
         );
 
         self::assertTrue($capabilities->includeTrashed());
         self::assertTrue($capabilities->onlyTrashed());
-        self::assertTrue($capabilities->expectsPdf());
     }
 
     /**
@@ -158,10 +138,9 @@ final class RequestCapabilitiesTest extends TestCase
      *
      * @param  bool  $includeTrashed
      * @param  bool  $onlyTrashed
-     * @param  bool  $expectsPdf
      * @return \SineMacula\ApiToolkit\Http\RequestCapabilities
      */
-    private function createCapabilities(bool $includeTrashed = false, bool $onlyTrashed = false, bool $expectsPdf = false): RequestCapabilities
+    private function createCapabilities(bool $includeTrashed = false, bool $onlyTrashed = false): RequestCapabilities
     {
 
         $reflection  = new \ReflectionClass(RequestCapabilities::class);
@@ -177,7 +156,6 @@ final class RequestCapabilitiesTest extends TestCase
             $instance,
             $includeTrashed,
             $onlyTrashed,
-            $expectsPdf,
         );
 
         return $instance;


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [4], both halves). **Breaking.** **Stacked on #303** (base `docs/upgrade-services-accuracy`) - merge #303 first and this auto-retargets to `2.x`.

When content-negotiated export and SSE were extracted to standalone packages, their detection accessors were left behind on `RequestCapabilities`. Neither is used by anything in the toolkit:

- **`expectsStream()`** detected `text/event-stream`; SSE now lives in `sinemacula/laravel-sse`.
- **`expectsPdf()`** detected `application/pdf`; the toolkit has never handled PDF (the exporter's formats are CSV/TSV/XLSX/XML/JSON/NDJSON, and nothing generates PDF).

Both are removed. With the last Accept-header detection gone, `RequestCapabilities` is now a pure trashed-visibility surface (`includeTrashed()` / `onlyTrashed()`). Tests, the `detect_capabilities` config comment, and the `UPGRADE.md` capability list are updated to match.

`composer check --all --no-cache` clean, `composer test` green (1979), `composer smells` clean.