### PR TITLE
fix: stop documenting uncast json/jsonb columns as OpenAPI arrays

### DIFF
--- a/src/OpenApi/Resolution/ColumnTypeMapper.php
+++ b/src/OpenApi/Resolution/ColumnTypeMapper.php
@@ -143,8 +143,12 @@ final class ColumnTypeMapper
     }
 
     /**
-     * Resolve JSON and binary column types, or null when the type is not a
-     * structured or binary value.
+     * Resolve binary column types, or null when the type is not a binary value.
+     *
+     * An uncast json/jsonb column is deliberately left unresolved: it can hold
+     * an object, scalar or string, and absent a cast Eloquent returns the raw
+     * JSON string, so any concrete type here would be a confident-but-wrong
+     * guess. It falls through to an undocumented schema instead.
      *
      * @param  string  $typeName
      * @return array{type: string, format?: string}|null
@@ -152,7 +156,6 @@ final class ColumnTypeMapper
     private function resolveStructuredType(string $typeName): ?array
     {
         return match ($typeName) {
-            'json', 'jsonb' => ['type' => 'array'],
             'binary', 'blob', 'bytea' => ['type' => 'string', 'format' => 'byte'],
             default => null,
         };

--- a/tests/Unit/OpenApi/Resolution/ColumnTypeMapperTest.php
+++ b/tests/Unit/OpenApi/Resolution/ColumnTypeMapperTest.php
@@ -62,8 +62,6 @@ final class ColumnTypeMapperTest extends TestCase
         yield 'timestamptz format' => ['timestamptz', 'string', 'date-time'];
         yield 'time format' => ['time', 'string', 'time'];
         yield 'timetz format' => ['timetz', 'string', 'time'];
-        yield 'json array' => ['json', 'array', null];
-        yield 'jsonb array' => ['jsonb', 'array', null];
         yield 'binary byte' => ['binary', 'string', 'byte'];
         yield 'blob byte' => ['blob', 'string', 'byte'];
         yield 'bytea byte' => ['bytea', 'string', 'byte'];
@@ -124,15 +122,31 @@ final class ColumnTypeMapperTest extends TestCase
     }
 
     /**
-     * Test that an unknown type name with no cast resolves to a flagged
-     * undocumented schema rather than guessing a concrete type.
+     * Provide each type name that, absent a cast, the mapper cannot confidently
+     * describe and so resolves to an undocumented schema.
      *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function undocumentedTypeNameProvider(): iterable
+    {
+        yield 'unknown point' => ['point'];
+        yield 'json' => ['json'];
+        yield 'jsonb' => ['jsonb'];
+    }
+
+    /**
+     * Test that a type name the mapper cannot confidently describe, with no
+     * cast, resolves to a flagged undocumented schema rather than guessing a
+     * concrete type.
+     *
+     * @param  string  $typeName
      * @return void
      */
-    public function testUnknownTypeNameResolvesToUndocumented(): void
+    #[DataProvider('undocumentedTypeNameProvider')]
+    public function testUndocumentedTypeNameResolvesToUndocumented(string $typeName): void
     {
         $mapper = new ColumnTypeMapper;
-        $column = new ColumnDefinition(name: 'geometry', typeName: 'point', nullable: false);
+        $column = new ColumnDefinition(name: 'column', typeName: $typeName, nullable: false);
 
         $schema = $mapper->map($column);
 


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [30]). Non-breaking code; changes published OpenAPI output for one case.

An **uncast** `json`/`jsonb` column was mapped to OpenAPI `type: array` - a confident-but-wrong shape. Such a column can hold an object/scalar/string, and without a cast Eloquent returns the raw JSON string anyway. It also contradicted `ColumnTypeMapper`'s own contract ("never guesses a confident-but-wrong concrete type") and its conservative precedent (uncast `tinyint`→integer; unknown types→`undocumented()`).

The `'json'/'jsonb' => ['type' => 'array']` arm in `resolveStructuredType()` is removed, so an uncast json/jsonb column now falls through to `undocumented()`. **Cast-driven arms are untouched** - a column with an array/object/`AsArrayObject` cast still maps to `array`/`object`; the binary `byte`-format arm is unchanged. Test rows for uncast json/jsonb now assert `undocumented` alongside the existing unknown-type case.

`composer check --all --no-cache` clean, `composer test` green (1981), `composer smells` clean.