### PR TITLE
fix: honour field guards and transformers in tabular exports

### DIFF
--- a/src/Exceptions/PerItemGuardedFieldException.php
+++ b/src/Exceptions/PerItemGuardedFieldException.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Exceptions;
+
+/**
+ * Thrown when a field whose guard depends on the row is derived into a tabular
+ * export schema.
+ *
+ * A tabular export includes or omits whole columns, never individual cells, so
+ * a guard that inspects the row cannot be honoured: every row would share the
+ * same column, and a value the guard meant to hide for some rows would leak.
+ * The trait refuses such a field at schema-build time rather than expose it.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class PerItemGuardedFieldException extends \RuntimeException
+{
+    /**
+     * Create the exception for the given field and resource type.
+     *
+     * @param  string  $field
+     * @param  string  $resourceType
+     * @return self
+     */
+    public static function forField(string $field, string $resourceType): self
+    {
+        return new self(sprintf(
+            'The "%s" field on the "%s" resource carries a guard that depends on the row, '
+            . 'so it cannot be exported to a tabular format. A tabular export includes or '
+            . 'omits whole columns rather than individual cells, so a per-row guard cannot '
+            . 'be honoured without leaking the values it is meant to hide. Exclude the field '
+            . 'from the export, or override tabular() and gate the column with the exporter\'s '
+            . '->visible().',
+            $field,
+            $resourceType,
+        ));
+    }
+}

--- a/src/Http/Resources/Concerns/DerivesTabularSchema.php
+++ b/src/Http/Resources/Concerns/DerivesTabularSchema.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace SineMacula\ApiToolkit\Http\Resources\Concerns;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
@@ -19,16 +21,19 @@ use SineMacula\Exporter\Schema\TabularSchema;
  * subclasses that also implement
  * {@see \SineMacula\Exporter\Contracts\ProvidesTabularExport}. When mixed in,
  * the `tabular()` method is satisfied for free: it compiles the resource schema
- * and maps each non-relation field to a typed Column. Accessor and computed
- * fields are resolved through a fresh resource instance, and plain scalar
- * fields fall through to the default raw-attribute read via `data_get`. The
- * resource's per-field guards and transformers are NOT applied to exported
- * values: a guarded or transformed field still emits its underlying attribute
- * or accessor result. Use the exporter's `->visible()` gate to keep a column
- * out of an export; a schema-declared guard does not.
+ * and maps each non-relation field to a typed Column, resolving each cell
+ * through a fresh resource so the field's compute, accessor, and transformers
+ * are honoured exactly as the JSON response applies them.
  *
- * The schema returned is request-aware so column visibility and field
- * selection can be narrowed by the active API query.
+ * Field guards are honoured at the column level. A guard that depends only on
+ * the request maps to the exporter's column-visibility gate, so the whole
+ * column is omitted when the guard hides the field. A guard that inspects the
+ * row cannot be honoured by a flat tabular schema - the exporter drops whole
+ * columns, not individual cells - so such a field is refused at build time to
+ * avoid leaking the values the guard is meant to hide.
+ *
+ * The schema returned is request-aware so column visibility and field selection
+ * can be narrowed by the active API query.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -48,6 +53,8 @@ trait DerivesTabularSchema
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \SineMacula\Exporter\Schema\TabularSchema
+     *
+     * @throws \SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException
      */
     public function tabular(Request $request): TabularSchema
     {
@@ -69,7 +76,7 @@ trait DerivesTabularSchema
                 continue;
             }
 
-            $columns[] = $this->buildTabularColumn($key, $definition, $resourceClass);
+            $columns[] = $this->buildTabularColumn($key, $definition, $resourceClass, $request);
         }
 
         return new DerivedTabularSchema($request, $columns);
@@ -78,60 +85,187 @@ trait DerivesTabularSchema
     /**
      * Build a single tabular column for the given field definition.
      *
-     * Routes accessor and computed fields through a fresh resource instance so
-     * the field's own compute or accessor closure runs, and plain scalar fields
-     * use the default raw-attribute read via data_get on the underlying model.
-     * The resource's per-field guards and transformers are NOT applied here, so
-     * the column emits the raw resolved value; use the exporter's `->visible()`
-     * gate to exclude a column from an export.
+     * Resolves the cell value (with transformers) and then applies the field's
+     * guards to the column.
+     *
+     * @param  string  $key
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
+     * @param  class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource>  $resourceClass
+     * @param  \Illuminate\Http\Request  $request
+     * @return \SineMacula\Exporter\Schema\Column
+     *
+     * @throws \SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException
+     */
+    private function buildTabularColumn(string $key, CompiledFieldDefinition $definition, string $resourceClass, Request $request): Column
+    {
+        return $this->applyGuards($key, $definition, $this->baseColumn($key, $definition, $resourceClass), $request);
+    }
+
+    /**
+     * Build the value-resolving column for the field, before guards.
+     *
+     * Fields with a compute, a callable accessor, or transformers resolve
+     * their value through a fresh resource so the JSON value, transformers
+     * included, is mirrored in the cell. Plain scalar and string-accessor
+     * fields without transformers keep the exporter's raw attribute read.
      *
      * @param  string  $key
      * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
      * @param  class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource>  $resourceClass
      * @return \SineMacula\Exporter\Schema\Column
      */
-    private function buildTabularColumn(string $key, CompiledFieldDefinition $definition, string $resourceClass): Column
+    private function baseColumn(string $key, CompiledFieldDefinition $definition, string $resourceClass): Column
     {
+        if ($this->needsResourceResolution($definition)) {
+            return Column::make($key)->resolveUsing($this->resourceValueResolver($key, $definition, $resourceClass));
+        }
+
         if (is_string($definition->accessor)) {
             return Column::make($key)->fromModel($definition->accessor);
         }
 
-        $resolver = $this->columnResolverFor($definition, $resourceClass);
-
-        return $resolver !== null ? Column::make($key)->resolveUsing($resolver) : Column::make($key);
+        return Column::make($key);
     }
 
     /**
-     * Build the closure used to resolve a column value through a resource
-     * instance, or null when no resource-mediated resolution is needed.
-     *
-     * Combines callable compute and callable accessor into one code path since
-     * both are invoked with the resource and request by ValueResolver.
+     * Determine whether the field's value must be resolved through a resource.
      *
      * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
-     * @param  class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource>  $resourceClass
-     * @return \Closure|null
+     * @return bool
      */
-    private function columnResolverFor(CompiledFieldDefinition $definition, string $resourceClass): ?\Closure
+    private function needsResourceResolution(CompiledFieldDefinition $definition): bool
     {
-        // String compute: a named method called on the resource instance.
-        if (is_string($definition->compute)) {
-            $method = $definition->compute;
-            return static function ($item, $request) use ($resourceClass, $method): mixed {
-                $resource = new $resourceClass($item);
-                return method_exists($resource, $method) ? $resource->{$method}($request) : null; // @phpstan-ignore method.dynamicName
-            };
+        return $definition->transformers !== []
+            || $definition->compute      !== null
+            || is_callable($definition->accessor);
+    }
+
+    /**
+     * Build the closure that resolves a cell value through a resource instance.
+     *
+     * Delegates to the same value resolver the JSON response uses, so compute,
+     * accessor, and transformer logic produce identical values. A MissingValue
+     * (an absent attribute or unmet guard) collapses to null so the column's
+     * null/default policy applies.
+     *
+     * @param  string  $key
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
+     * @param  class-string<\SineMacula\ApiToolkit\Http\Resources\ApiResource>  $resourceClass
+     * @return \Closure
+     */
+    private function resourceValueResolver(string $key, CompiledFieldDefinition $definition, string $resourceClass): \Closure
+    {
+        $resolver = new ValueResolver(new GuardEvaluator);
+
+        return static function ($item, $request) use ($resolver, $key, $definition, $resourceClass): mixed {
+            $value = $resolver->resolveFieldValue($key, $definition, new $resourceClass($item), $request);
+
+            return $value instanceof MissingValue ? null : $value;
+        };
+    }
+
+    /**
+     * Apply the field's guards to the column.
+     *
+     * A field with no guards is returned untouched. A guard that inspects
+     * the row cannot gate a flat column, so the field is refused. Guards
+     * that depend only on the request map to the column-visibility gate.
+     *
+     * @param  string  $key
+     * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
+     * @param  \SineMacula\Exporter\Schema\Column  $column
+     * @param  \Illuminate\Http\Request  $request
+     * @return \SineMacula\Exporter\Schema\Column
+     *
+     * @throws \SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException
+     */
+    private function applyGuards(string $key, CompiledFieldDefinition $definition, Column $column, Request $request): Column
+    {
+        $guards = $definition->guards;
+
+        if ($guards === []) {
+            return $column;
         }
 
-        // Callable compute and accessor are both invoked with the resource.
-        if (is_callable($definition->compute)) {
-            $callable = \Closure::fromCallable($definition->compute);
-        } elseif (is_callable($definition->accessor)) {
-            $callable = \Closure::fromCallable($definition->accessor);
-        } else {
-            return null;
+        if ($this->hasPerItemGuard($guards, $request)) {
+            throw PerItemGuardedFieldException::forField($key, static::getResourceType());
         }
 
-        return static fn ($item, $request): mixed => $callable(new $resourceClass($item), $request);
+        return $column->visible(fn (Request $request): bool => $this->passesRequestGuards($guards, $request));
+    }
+
+    /**
+     * Determine whether any guard depends on the row rather than the request.
+     *
+     * Each guard is invoked with a probe in place of the resource. A guard that
+     * touches the probe, or errors when handed it, is treating the row as
+     * load-bearing and is reported as per-item. Failing closed, an
+     * unclassifiable guard is treated as per-item.
+     *
+     * @param  array<int, mixed>  $guards
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    private function hasPerItemGuard(array $guards, Request $request): bool
+    {
+        foreach ($guards as $guard) {
+            if (is_callable($guard) && $this->probeGuard($guard, $request)[0]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Evaluate the request-scoped guards for column visibility.
+     *
+     * Mirrors the JSON guard semantics: a guard suppresses the column only when
+     * it returns exactly false. A guard that touches the row, or errors, hides
+     * the column rather than risk exposing it.
+     *
+     * @param  array<int, mixed>  $guards
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    private function passesRequestGuards(array $guards, Request $request): bool
+    {
+        foreach ($guards as $guard) {
+
+            if (!is_callable($guard)) {
+                continue;
+            }
+
+            [$touchedOrThrew, $result] = $this->probeGuard($guard, $request);
+
+            if ($touchedOrThrew || $result === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Invoke a guard with a probe row and report what it did.
+     *
+     * Returns a two-element tuple: whether the guard touched the probe or
+     * threw, and the value it returned (false when it threw).
+     *
+     * @param  callable  $guard
+     * @param  \Illuminate\Http\Request  $request
+     * @return array{0: bool, 1: mixed}
+     */
+    private function probeGuard(callable $guard, Request $request): array
+    {
+        $probe = new RowGuardProbe;
+
+        try {
+            $result = $guard($probe, $request);
+        } catch (\Throwable) {
+            return [true, false];
+        }
+
+        return [$probe->wasTouched(), $result];
     }
 }

--- a/src/Http/Resources/Concerns/RowGuardProbe.php
+++ b/src/Http/Resources/Concerns/RowGuardProbe.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Http\Resources\Concerns;
+
+/**
+ * Stand-in resource passed to a guard to detect whether it reads the row.
+ *
+ * A guard receives the resource and the request. Per-row data only ever reaches
+ * a guard through the resource argument, so handing the guard this probe in
+ * place of a real resource and recording whether it interacts with the probe
+ * reveals whether the guard depends on the row (per-item) or only on the
+ * request. Every recorded access flips an internal flag and returns a value
+ * that lets the guard keep running, so a chained read is observed before it can
+ * error. Any access the probe does not model (array access, invocation,
+ * counting) throws, which the caller treats as a per-item read by failing
+ * closed.
+ *
+ * @internal
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @implements \IteratorAggregate<int, mixed>
+ */
+final class RowGuardProbe implements \IteratorAggregate, \Stringable
+{
+    /** @var bool Whether the guard interacted with the probe in any way. */
+    private bool $touched = false;
+
+    /**
+     * Record a property read.
+     *
+     * @param  string  $name
+     * @return self
+     */
+    public function __get(string $name): self
+    {
+        $this->touched = true;
+
+        return $this;
+    }
+
+    /**
+     * Record an isset check.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function __isset(string $name): bool
+    {
+        $this->touched = true;
+
+        return true;
+    }
+
+    /**
+     * Record a method call.
+     *
+     * @param  string  $name
+     * @param  array<int, mixed>  $arguments
+     * @return self
+     *
+     * @SuppressWarnings("php:S4144")
+     */
+    public function __call(string $name, array $arguments): self
+    {
+        $this->touched = true;
+
+        return $this;
+    }
+
+    /**
+     * Record a string coercion.
+     *
+     * @return string
+     */
+    #[\Override]
+    public function __toString(): string
+    {
+        $this->touched = true;
+
+        return '';
+    }
+
+    /**
+     * Determine whether the guard interacted with the probe.
+     *
+     * @return bool
+     */
+    public function wasTouched(): bool
+    {
+        return $this->touched;
+    }
+
+    /**
+     * Record an iteration.
+     *
+     * @return \Traversable<int, mixed>
+     */
+    #[\Override]
+    public function getIterator(): \Traversable
+    {
+        $this->touched = true;
+
+        return new \ArrayIterator([]);
+    }
+}

--- a/tests/Fixtures/Resources/GuardedExportResource.php
+++ b/tests/Fixtures/Resources/GuardedExportResource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\Exporter\Contracts\ProvidesTabularExport;
+
+/**
+ * Fixture resource exercising the tabular trait's transformer and
+ * request-scoped guard handling.
+ *
+ * The name field carries a transformer so the export can be checked against the
+ * JSON value. The secret field carries a request-scoped guard so the column can
+ * be proven to drop out of the export when the guard hides the field.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class GuardedExportResource extends ApiResource implements ProvidesTabularExport
+{
+    use DerivesTabularSchema;
+
+    /** @var string */
+    public const string RESOURCE_TYPE = 'guarded_exports';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email', 'secret'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name')->transform(static fn ($resource, $value): string => strtoupper(is_string($value) ? $value : '')),
+            Field::scalar('email'),
+            Field::scalar('secret')->guard(static fn ($resource, $request): bool => $request?->query('show') === 'yes'),
+        );
+    }
+}

--- a/tests/Fixtures/Resources/PerItemGuardedExportResource.php
+++ b/tests/Fixtures/Resources/PerItemGuardedExportResource.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\Exporter\Contracts\ProvidesTabularExport;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture resource whose email field is guarded per-item.
+ *
+ * The guard inspects the row, so the tabular trait cannot honour it on a flat
+ * column and must refuse to derive the schema. Used to prove the dedicated
+ * build-time exception is thrown.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class PerItemGuardedExportResource extends ApiResource implements ProvidesTabularExport
+{
+    use DerivesTabularSchema;
+
+    /** @var string */
+    public const string RESOURCE_TYPE = 'per_item_guarded_exports';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name'),
+            Field::scalar('email')->guard(static function ($resource): bool {
+                $model = $resource->resource;
+
+                return $model instanceof User && $model->status === 'active';
+            }),
+        );
+    }
+}

--- a/tests/Fixtures/Resources/ThrowingGuardExportResource.php
+++ b/tests/Fixtures/Resources/ThrowingGuardExportResource.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use Illuminate\Http\Request;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\Exporter\Contracts\ProvidesTabularExport;
+
+/**
+ * Fixture resource whose secret field carries a guard that errors when it is
+ * evaluated against a probe row.
+ *
+ * A guard that cannot be evaluated without a real row cannot be classified as
+ * request-scoped, so the trait fails closed and refuses to derive the schema.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ThrowingGuardExportResource extends ApiResource implements ProvidesTabularExport
+{
+    use DerivesTabularSchema;
+
+    /** @var string */
+    public const string RESOURCE_TYPE = 'throwing_guard_exports';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'secret'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('secret')->guard(self::erroringGuard(...)),
+        );
+    }
+
+    /**
+     * A guard that cannot run without a real row.
+     *
+     * @param  mixed  $resource
+     * @param  \Illuminate\Http\Request|null  $request
+     * @return never
+     *
+     * @throws \RuntimeException
+     */
+    private static function erroringGuard(mixed $resource, ?Request $request): never
+    {
+        throw new \RuntimeException('guard needs a real row');
+    }
+}

--- a/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
+++ b/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Concerns;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException;
+use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\RowGuardProbe;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\Exporter\Schema\CastRegistry;
+use SineMacula\Exporter\Schema\Column;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\GuardedExportResource;
+use Tests\Fixtures\Resources\PerItemGuardedExportResource;
+use Tests\Fixtures\Resources\ThrowingGuardExportResource;
+use Tests\TestCase;
+
+/**
+ * Tests for the DerivesTabularSchema trait's transformer and guard handling.
+ *
+ * Proves that a transformed field mirrors the JSON value in the export, that a
+ * request-scoped guard drops the whole column when it hides the field, and that
+ * a field guarded per-item is refused at schema-build time.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(PerItemGuardedFieldException::class)]
+#[CoversClass(RowGuardProbe::class)]
+#[CoversTrait(DerivesTabularSchema::class)]
+final class DerivesTabularSchemaTest extends TestCase
+{
+    /**
+     * Set up each test with a clean schema cache.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SchemaCompiler::clearCache();
+    }
+
+    /**
+     * Tear down, clearing the schema compiler cache.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        SchemaCompiler::clearCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a transformed scalar field resolves to the same value the JSON
+     * response emits.
+     *
+     * @return void
+     */
+    public function testTransformedFieldMatchesJsonValue(): void
+    {
+        $user    = new User(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $jsonValue = (new GuardedExportResource($user))->toArray($request)['name'];
+        $cell      = $this->columnFor('name', $request, $user)->toCellValue($user, $request, new CastRegistry);
+
+        self::assertSame('ALICE', $cell->raw);
+        self::assertSame($jsonValue, $cell->raw);
+    }
+
+    /**
+     * Test that a request-scoped guard omits the whole column when it hides the
+     * field for the current request.
+     *
+     * @return void
+     */
+    public function testRequestScopedGuardOmitsColumnWhenHidden(): void
+    {
+        $user    = new User(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $visible = $this->visibleColumnKeys($request, $user);
+
+        self::assertNotContains('secret', $visible);
+        self::assertContains('name', $visible);
+    }
+
+    /**
+     * Test that a request-scoped guard keeps the column when it permits the
+     * field for the current request.
+     *
+     * @return void
+     */
+    public function testRequestScopedGuardKeepsColumnWhenPermitted(): void
+    {
+        $user    = new User(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $request = Request::create('/?show=yes');
+
+        ApiQuery::parse($request);
+
+        self::assertContains('secret', $this->visibleColumnKeys($request, $user));
+    }
+
+    /**
+     * Test that a field guarded per-item is refused at schema-build time with
+     * the dedicated exception naming the field.
+     *
+     * @return void
+     */
+    public function testPerItemGuardedFieldThrows(): void
+    {
+        $user    = new User(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $this->expectException(PerItemGuardedFieldException::class);
+        $this->expectExceptionMessageMatches('/"email".*per_item_guarded_exports/s');
+
+        (new PerItemGuardedExportResource($user))->tabular($request);
+    }
+
+    /**
+     * Test that a guard that errors when handed a probe row is refused rather
+     * than exposed, failing closed.
+     *
+     * @return void
+     */
+    public function testGuardThatErrorsOnProbeRowIsRefused(): void
+    {
+        $user    = new User(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $this->expectException(PerItemGuardedFieldException::class);
+
+        (new ThrowingGuardExportResource($user))->tabular($request);
+    }
+
+    /**
+     * Resolve the column with the given key from the guarded export schema.
+     *
+     * @param  string  $key
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Tests\Fixtures\Models\User  $user
+     * @return \SineMacula\Exporter\Schema\Column
+     */
+    private function columnFor(string $key, Request $request, User $user): Column
+    {
+        foreach ((new GuardedExportResource($user))->tabular($request)->columns() as $column) {
+            if ($column->getKey() === $key) {
+                return $column;
+            }
+        }
+
+        self::fail(sprintf('No column found for key "%s".', $key));
+    }
+
+    /**
+     * Get the keys of the columns visible for the given request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Tests\Fixtures\Models\User  $user
+     * @return array<int, string>
+     */
+    private function visibleColumnKeys(Request $request, User $user): array
+    {
+        $keys = [];
+
+        foreach ((new GuardedExportResource($user))->tabular($request)->columns() as $column) {
+
+            if (!$column->isVisible($request)) {
+                continue;
+            }
+
+            $keys[] = $column->getKey();
+        }
+
+        return $keys;
+    }
+}


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [0]). **Security-sensitive** - closes a data-exposure gap; please review the classification approach.

**The bug:** tabular exports (CSV/XLSX) via `DerivesTabularSchema` emitted values raw - they never ran the schema's field **guards** or **transformers**, so a field hidden/masked in JSON leaked unredacted into an export.

**Transformers:** cells now resolve through `ValueResolver::resolveFieldValue()` (the same path JSON uses), so transformers/compute/accessor produce identical values; `MissingValue`→`null`. Plain scalar fields without transformers keep the fast raw read.

**Guards - the hard part:** guards are invoked as `guard($resource, $request): bool` with **no scope marker**, so static inspection can't distinguish a request-scoped guard from a per-row one. The fix classifies **empirically and fail-closed**:
- At schema-build each guard is run once against a `RowGuardProbe` standing in for the resource.
- A guard that only inspects the **request** (never touches the probe) → mapped to the exporter's `Column::visible()` gate, so the column is omitted when the guard hides the field.
- A guard that **touches the row probe, or errors** → treated as per-item and **refused** at build time with the new `PerItemGuardedFieldException` (naming the field), because a flat tabular schema drops whole columns, not individual cells - silently emitting a per-row-guarded value is exactly the leak being closed.
- Anything unclassifiable **fails closed** (refused), never exposed.

**Known limitation (by design):** classification is empirical and per-request, not declarative. It's complete for per-row dependence delivered through the `$resource` argument (the only per-row channel). A declarative request-scoped-guard variant on the `Field` DSL could replace the probe later if you want finer control.

New: `RowGuardProbe`, `PerItemGuardedFieldException`. Tests cover transformed value == JSON, request-scoped guard omits/keeps the column, per-item guard throws, and probe-error → refused.

`composer check --all --no-cache` clean, `composer test` green (1986, +5 tests), `composer smells` clean.