### PR TITLE
refactor!: minimise FilterContext to its only consumed dimension

### DIFF
--- a/src/Repositories/Criteria/Concerns/FilterApplier.php
+++ b/src/Repositories/Criteria/Concerns/FilterApplier.php
@@ -201,7 +201,7 @@ final class FilterApplier
     {
         $method = ($context->getLogicalOperator() === '$and' && $operator === '$or')
             ? 'where' : $this->logicalOperatorMap[$operator];
-        $nested = FilterContext::nested($operator, $context);
+        $nested = FilterContext::nested($operator);
 
         $callback = function (Builder $query) use ($value, $nested): void {
             foreach ($value as $subKey => $subValue) {
@@ -234,11 +234,10 @@ final class FilterApplier
      */
     private function applyRelationFilter(Builder $query, string $relation, array $filters, FilterContext $context): void
     {
-        $method          = ($context->getLogicalOperator() === '$or') ? 'orWhereHas' : 'whereHas';
-        $relationContext = FilterContext::forRelation($context);
+        $method = ($context->getLogicalOperator() === '$or') ? 'orWhereHas' : 'whereHas';
 
-        $this->applyRelationalMethod($query, $method, $relation, function (Builder $query) use ($filters, $relationContext): void {
-            $this->processRelationFilters($query, $filters, $relationContext);
+        $this->applyRelationalMethod($query, $method, $relation, function (Builder $query) use ($filters, $context): void {
+            $this->processRelationFilters($query, $filters, $context);
         });
     }
 
@@ -257,9 +256,9 @@ final class FilterApplier
             /** @var array<string, mixed> $orFilters */
             $orFilters = is_array($filters['$or']) ? $filters['$or'] : [];
 
-            $query->where(function (Builder $nested) use ($orFilters, $context): void {
+            $query->where(function (Builder $nested) use ($orFilters): void {
                 foreach ($orFilters as $key => $value) {
-                    $this->applyFilters($nested, $value, $key, FilterContext::nested('$or', $context));
+                    $this->applyFilters($nested, $value, $key, FilterContext::nested('$or'));
                 }
             });
         } else {

--- a/src/Repositories/Criteria/Concerns/FilterContext.php
+++ b/src/Repositories/Criteria/Concerns/FilterContext.php
@@ -7,9 +7,8 @@ namespace SineMacula\ApiToolkit\Repositories\Criteria\Concerns;
 /**
  * Immutable value object for filter dispatch state.
  *
- * Captures the logical operator, relation scope flag, and nesting depth at each
- * level of the recursive filter dispatch. Each named constructor returns a new
- * instance, leaving the parent unmodified.
+ * Captures the logical operator in effect at each level of the recursive filter
+ * dispatch. Each named constructor returns a new immutable instance.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -20,20 +19,12 @@ final class FilterContext
      * Constructor.
      *
      * @param  string|null  $logicalOperator
-     * @param  bool  $inRelation
-     * @param  int  $depth
      * @return void
      */
     private function __construct(
 
         /** The current logical operator ('$and', '$or', or null) */
         private readonly ?string $logicalOperator,
-
-        /** Whether the current context is inside a relation scope */
-        private readonly bool $inRelation,
-
-        /** The nesting depth (0 = top level) */
-        private readonly int $depth,
     ) {}
 
     /**
@@ -43,30 +34,18 @@ final class FilterContext
      */
     public static function root(): self
     {
-        return new self(null, false, 0);
+        return new self(null);
     }
 
     /**
      * Create a context for a nested logical group.
      *
      * @param  string  $logicalOperator
-     * @param  self  $parent
      * @return self
      */
-    public static function nested(string $logicalOperator, self $parent): self
+    public static function nested(string $logicalOperator): self
     {
-        return new self($logicalOperator, $parent->inRelation, $parent->depth + 1);
-    }
-
-    /**
-     * Create a context for entering a relation scope.
-     *
-     * @param  self  $parent
-     * @return self
-     */
-    public static function forRelation(self $parent): self
-    {
-        return new self($parent->logicalOperator, true, $parent->depth);
+        return new self($logicalOperator);
     }
 
     /**
@@ -77,25 +56,5 @@ final class FilterContext
     public function getLogicalOperator(): ?string
     {
         return $this->logicalOperator;
-    }
-
-    /**
-     * Return whether inside a relation scope.
-     *
-     * @return bool
-     */
-    public function isInRelation(): bool
-    {
-        return $this->inRelation;
-    }
-
-    /**
-     * Return the nesting depth (0 = top level).
-     *
-     * @return int
-     */
-    public function getDepth(): int
-    {
-        return $this->depth;
     }
 }

--- a/tests/Unit/Repositories/Criteria/Concerns/FilterContextTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/FilterContextTest.php
@@ -20,144 +20,24 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterContext;
 final class FilterContextTest extends TestCase
 {
     /**
-     * Test that root returns null operator, not in relation, and depth zero.
+     * Test that root returns a null logical operator.
      *
      * @return void
      */
-    public function testRootReturnsNullOperatorNotInRelationDepthZero(): void
+    public function testRootReturnsNullOperator(): void
     {
-        $context = FilterContext::root();
-
-        self::assertNull($context->getLogicalOperator());
-        self::assertFalse($context->isInRelation());
-        self::assertSame(0, $context->getDepth());
+        self::assertNull(FilterContext::root()->getLogicalOperator());
     }
 
     /**
-     * Test that nested increments depth and sets the operator.
+     * Test that nested sets the logical operator.
      *
      * @return void
      */
-    public function testNestedIncrementsDepthAndSetsOperator(): void
+    public function testNestedSetsOperator(): void
     {
-        $root   = FilterContext::root();
-        $nested = FilterContext::nested('$and', $root);
+        $nested = FilterContext::nested('$and');
 
         self::assertSame('$and', $nested->getLogicalOperator());
-        self::assertSame(1, $nested->getDepth());
-    }
-
-    /**
-     * Test that nested inherits the relation flag from its parent.
-     *
-     * @return void
-     */
-    public function testNestedInheritsRelationFlagFromParent(): void
-    {
-        $root     = FilterContext::root();
-        $relation = FilterContext::forRelation($root);
-        $nested   = FilterContext::nested('$or', $relation);
-
-        self::assertTrue($nested->isInRelation());
-    }
-
-    /**
-     * Test that forRelation sets inRelation to true.
-     *
-     * @return void
-     */
-    public function testForRelationSetsInRelationTrue(): void
-    {
-        $root     = FilterContext::root();
-        $relation = FilterContext::forRelation($root);
-
-        self::assertTrue($relation->isInRelation());
-        self::assertSame($root->getDepth(), $relation->getDepth());
-    }
-
-    /**
-     * Test that forRelation inherits the operator from its parent.
-     *
-     * @return void
-     */
-    public function testForRelationInheritsOperatorFromParent(): void
-    {
-        $root     = FilterContext::root();
-        $nested   = FilterContext::nested('$or', $root);
-        $relation = FilterContext::forRelation($nested);
-
-        self::assertSame('$or', $relation->getLogicalOperator());
-    }
-
-    /**
-     * Test that forRelation does not increment depth.
-     *
-     * @return void
-     */
-    public function testForRelationDoesNotIncrementDepth(): void
-    {
-        $root     = FilterContext::root();
-        $relation = FilterContext::forRelation($root);
-
-        self::assertSame(0, $relation->getDepth());
-    }
-
-    /**
-     * Test that chaining nested calls produces the correct depth.
-     *
-     * @return void
-     */
-    public function testNestedChainProducesCorrectDepth(): void
-    {
-        $root   = FilterContext::root();
-        $first  = FilterContext::nested('$and', $root);
-        $second = FilterContext::nested('$or', $first);
-
-        self::assertSame(2, $second->getDepth());
-    }
-
-    /**
-     * Test that the parent is unchanged after calling nested.
-     *
-     * @return void
-     */
-    public function testImmutabilityParentUnchangedAfterNested(): void
-    {
-        $root = FilterContext::root();
-
-        FilterContext::nested('$and', $root);
-
-        self::assertNull($root->getLogicalOperator());
-        self::assertSame(0, $root->getDepth());
-    }
-
-    /**
-     * Test that the parent is unchanged after calling forRelation.
-     *
-     * @return void
-     */
-    public function testImmutabilityParentUnchangedAfterForRelation(): void
-    {
-        $root = FilterContext::root();
-
-        FilterContext::forRelation($root);
-
-        self::assertFalse($root->isInRelation());
-    }
-
-    /**
-     * Test that nested then forRelation produces the correct compound state.
-     *
-     * @return void
-     */
-    public function testNestedThenForRelationCompoundState(): void
-    {
-        $root     = FilterContext::root();
-        $nested   = FilterContext::nested('$and', $root);
-        $relation = FilterContext::forRelation($nested);
-
-        self::assertSame('$and', $relation->getLogicalOperator());
-        self::assertTrue($relation->isInRelation());
-        self::assertSame(1, $relation->getDepth());
     }
 }

--- a/tests/Unit/Repositories/Criteria/Operators/EqualOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/EqualOperatorTest.php
@@ -52,7 +52,7 @@ final class EqualOperatorTest extends TestCase
     {
         $operator = new EqualOperator;
         $query    = (new User)->newQuery();
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'name', 'Bob', $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/GreaterThanOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/GreaterThanOperatorTest.php
@@ -52,7 +52,7 @@ final class GreaterThanOperatorTest extends TestCase
     {
         $operator = new GreaterThanOperator;
         $query    = (new User)->newQuery();
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'id', 5, $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/GreaterThanOrEqualOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/GreaterThanOrEqualOperatorTest.php
@@ -52,7 +52,7 @@ final class GreaterThanOrEqualOperatorTest extends TestCase
     {
         $query    = (new User)->newQuery();
         $operator = new GreaterThanOrEqualOperator;
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'age', 18, $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/LessThanOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/LessThanOperatorTest.php
@@ -52,7 +52,7 @@ final class LessThanOperatorTest extends TestCase
     {
         $query    = (new User)->newQuery();
         $operator = new LessThanOperator;
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'age', 30, $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/LessThanOrEqualOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/LessThanOrEqualOperatorTest.php
@@ -52,7 +52,7 @@ final class LessThanOrEqualOperatorTest extends TestCase
     {
         $query    = (new User)->newQuery();
         $operator = new LessThanOrEqualOperator;
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'age', 25, $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/LikeOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/LikeOperatorTest.php
@@ -52,7 +52,7 @@ final class LikeOperatorTest extends TestCase
     {
         $query    = (new User)->newQuery();
         $operator = new LikeOperator;
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'name', 'Ali', $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/NotEqualOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/NotEqualOperatorTest.php
@@ -52,7 +52,7 @@ final class NotEqualOperatorTest extends TestCase
     {
         $operator = new NotEqualOperator;
         $query    = (new User)->newQuery();
-        $context  = FilterContext::nested('$or', FilterContext::root());
+        $context  = FilterContext::nested('$or');
 
         $operator->apply($query, 'status', 'banned', $context);
 

--- a/tests/Unit/Repositories/Criteria/Operators/NotNullOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/NotNullOperatorTest.php
@@ -63,7 +63,7 @@ final class NotNullOperatorTest extends TestCase
     {
         $query = (new User)->newQuery();
 
-        $this->operator->apply($query, 'name', true, FilterContext::nested('$or', FilterContext::root()));
+        $this->operator->apply($query, 'name', true, FilterContext::nested('$or'));
 
         $wheres = $query->getQuery()->wheres;
 

--- a/tests/Unit/Repositories/Criteria/Operators/NullOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/NullOperatorTest.php
@@ -63,7 +63,7 @@ final class NullOperatorTest extends TestCase
     {
         $query = (new User)->newQuery();
 
-        $this->operator->apply($query, 'name', true, FilterContext::nested('$or', FilterContext::root()));
+        $this->operator->apply($query, 'name', true, FilterContext::nested('$or'));
 
         $wheres = $query->getQuery()->wheres;
 


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [8]). **Breaking** (narrows the custom-operator extension surface) - no known consumer.

`FilterContext` is passed to custom filter operators, but only `getLogicalOperator()` was ever read. `inRelation`, `depth`, `isInRelation()`, `getDepth()` had **zero** production readers, and `forRelation()` was a behavioural no-op (it only flipped the never-read `inRelation`). Confirmed unused downstream: greps of `sinemacula/laravel-repositories` and `sinemacula/laravel-resource-exporter` return **no** references to any of these.

Removed the dead dimensions/accessors and the no-op `forRelation()`; the call site now passes the existing context directly, and `nested()` drops its dead depth bookkeeping and its now-vestigial `$parent` argument (it only needs the logical operator). 13 `nested(...)` call sites updated to the new signature - **construction only; every filter/sort SQL assertion is byte-for-byte unchanged**.

`composer check --all --no-cache` clean, `composer test` green (1973), `composer smells` clean.