### PR TITLE
docs: document the WritePool auto-flush observability hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ dropping them. The `'throw'` strategy raises a `WritePoolFlushException` for cal
 site. The `'log'` strategy is best-effort only - use it solely for genuinely disposable writes such as
 telemetry.
 
+The `WritePool` is a scoped singleton, so after a deferred write you can call
+`app(WritePool::class)->lastAutoFlushResult()` to observe the outcome of the most recent automatic flush
+(`null` if none has occurred). Under the non-throwing `'collect'` and `'log'` strategies this accessor is the
+only in-process signal that an auto-flush failed.
+
 ---
 
 ### Filter-Operator Registry

--- a/src/Repositories/Concerns/WritePool.php
+++ b/src/Repositories/Concerns/WritePool.php
@@ -21,7 +21,7 @@ final class WritePool
     /** @var array<string, list<array<string, mixed>>> Records buffered by table name. */
     private array $buffer = [];
 
-    /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult|null The result from the most recent auto-flush. */
+    /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult|null The retained outcome of the most recent auto-flush; persists until the next auto-flush overwrites it. */
     private ?WritePoolFlushResult $lastAutoFlushResult = null;
 
     /**
@@ -69,6 +69,8 @@ final class WritePool
             return;
         }
 
+        // Retain the outcome so lastAutoFlushResult() can surface a
+        // non-throwing collect/log auto-flush failure.
         $this->lastAutoFlushResult = $this->flush();
     }
 
@@ -94,8 +96,16 @@ final class WritePool
     }
 
     /**
-     * Return the result from the most recent auto-flush triggered by add(), or
+     * Return the outcome of the most recent auto-flush triggered by add(), or
      * null if no auto-flush has occurred.
+     *
+     * This is a supported observability hook. Under the non-throwing collect
+     * and log strategies an auto-flush that fails inside add() returns without
+     * raising, so this accessor is the only in-process signal that an
+     * auto-flush failed. Because the pool is a scoped singleton it is reachable
+     * after a deferred write via app(WritePool::class)->lastAutoFlushResult(),
+     * which resolves the same instance the Deferrable trait and the boundary
+     * flush subscriber use.
      *
      * @return \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult|null
      */


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [12]). Documentation-only - no behaviour change.

`WritePool::lastAutoFlushResult()` is a supported but undocumented observability hook. Under the non-throwing `collect`/`log` auto-flush strategies a failed auto-flush returns without raising, so this accessor is the **only in-process signal** of that failure; and because `WritePool` is a scoped singleton, an app can read it after a deferred write via `app(WritePool::class)->lastAutoFlushResult()` (the same instance `Deferrable` and the boundary-flush subscriber use).

Verified against the code and documented on the accessor, the property, the `add()` assignment site, and the Deferrable section of the README. (Kept as a documented hook per the review; the alternative of surfacing it through `Deferrable` directly remains a possible future enhancement.)

`composer check --all --no-cache` clean, `composer test` green (1981, unaffected).