### PR TITLE
feat: log the field that forces column-narrowing to fall back

### DIFF
--- a/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
+++ b/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
@@ -6,6 +6,7 @@ namespace SineMacula\ApiToolkit\Repositories\Criteria\Concerns;
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
@@ -20,7 +21,9 @@ use SineMacula\ApiToolkit\Schema\SafetySetDeriver;
  * safety set, asks the narrower for a decision, and applies a single `select()`
  * only when every resolved field is provably column-mapped. On every other path
  * the builder's columns are left untouched so the downstream default `'*'`
- * selection flows through unchanged.
+ * selection flows through unchanged. When an unmapped field forces that
+ * fall-back, the offending field key is recorded at debug level so the silent
+ * widening is diagnosable.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -69,6 +72,14 @@ final class ColumnProjectionApplier
 
         if ($decision->shouldNarrow()) {
             $query->getQuery()->select($decision->columns());
+        } elseif ($decision->reason() !== null) {
+            // Surface the silent fall-back so a developer can see which field
+            // forced a full select; debug level keeps it quiet in production.
+            Log::debug('Column narrowing fell back to a full select', [
+                'model'    => $query->getModel()::class,
+                'resource' => $resourceClass,
+                'field'    => $decision->reason(),
+            ]);
         }
 
         return $query;

--- a/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Repositories\Criteria\Concerns;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
@@ -169,6 +170,33 @@ final class ColumnProjectionApplierTest extends TestCase
         $result = $this->makeApplier()->apply($query, $provider, UserResource::class, []);
 
         self::assertNull($result->getQuery()->columns);
+    }
+
+    /**
+     * Test that a fall-back forced by an unmapped field is recorded at debug
+     * level carrying the offending field key and query context.
+     *
+     * @return void
+     */
+    public function testFallbackLogsOffendingFieldAtDebugLevel(): void
+    {
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $this->parseRequest(new Request);
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(['id', 'full_label']);
+        $provider->method('eagerLoadMapFor')->willReturn([]);
+
+        Log::shouldReceive('debug')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Column narrowing fell back to a full select'
+                    && $context['model']                                      === User::class
+                    && $context['resource']                                   === UserResource::class
+                    && $context['field']                                      === 'full_label');
+
+        $this->makeApplier()->apply((new User)->newQuery(), $provider, UserResource::class, []);
     }
 
     /**


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [22]). Wires up an existing-but-unconsumed diagnostic.

Column narrowing already recorded the offending field key on its fallback decision (`NarrowingDecision::reason()`, "for dev-time diagnostics"), but nothing surfaced it - so when narrowing silently fell back to a full `SELECT`, a developer had no way to see which field caused it. `ColumnProjectionApplier` now emits a **debug-level** log (model, resource, offending field key) on a fallback decision, so `reason()` earns its keep.

Debug-only and silent in normal operation; the narrowing logic and produced SQL are unchanged; only the field key is logged (nothing sensitive). New test asserts the debug log fires once carrying the offending field.

(The review's note about a stale `src/Schema/ColumnProjectionApplier` path had no target - every reference already uses the correct `Repositories/Criteria/Concerns/` path.)

`composer check --all --no-cache` clean, `composer test` green (1982, +1 test), `composer smells` clean.