### PR TITLE
docs: document guest throttle keying and the TrustProxies caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,19 @@ scoped independently in `api-toolkit.middleware`:
 All four middleware accept `'scope': 'global'` (default, pushed to the global stack) or `'scope': 'api'`
 (appended to the `api` middleware group only).
 
+**Request throttling and rate-limit keying** - each request is keyed by method, host, path, and caller
+identity. Authenticated requests are keyed by the user identifier; guests are keyed by their client IP
+(`$request->ip()`), matching Laravel's stock `ThrottleRequests`. Guests are deliberately not pooled into a
+single shared bucket, which would let one anonymous caller exhaust the rate limit for every other guest.
+
+Behind a shared-IP proxy, load balancer, CDN, or NAT, per-IP guest keying can over-throttle many distinct
+callers that share one egress IP. Configure Laravel's `TrustProxies` middleware so that `$request->ip()`
+resolves the real client IP rather than the proxy's.
+
+To key guests by an application-specific identifier (for example an API key) instead of their IP, set
+`api-toolkit.middleware.throttle.class` to your own middleware that uses the `ThrottleRequestsTrait` and
+overrides `resolveRequestSignature()`. That config option is the supported customisation point.
+
 ---
 
 ### Schema Introspection and OpenAPI Export

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -435,7 +435,10 @@ return [
     |   - `enabled`: true to override the alias (default), false to skip.
     |   - `class`: A fully-qualified class name to use as the throttle
     |              middleware instead of the toolkit's default. Set to null
-    |              (default) for automatic detection.
+    |              (default) for automatic detection. Use this to key guests
+    |              by an app-specific identifier instead of their client IP:
+    |              point it at a class that uses ThrottleRequestsTrait and
+    |              overrides resolveRequestSignature().
     |
     */
 


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [40]). Documentation-only - the behaviour is correct and unchanged.

Throttle keys fold the authenticated user identifier, or the **client IP for guests**, matching Laravel's stock `ThrottleRequests` (guests aren't pooled into one shared bucket - that would let a single anonymous caller throttle everyone). Documented in the README middleware section + a config-comment pointer:

- **Keying:** authenticated by user id, guests by `$request->ip()`.
- **Deployment caveat:** behind a shared-IP proxy / load balancer / CDN / NAT, per-IP guest keying can over-throttle many users on one egress IP - operators should configure Laravel's `TrustProxies` so `$request->ip()` resolves the real client.
- **Customisation:** point the `throttle.class` config at a middleware that uses `ThrottleRequestsTrait` and overrides `resolveRequestSignature()` (the supported customisation point).

`composer check --all --no-cache` clean (markdownlint passes), `composer test` green (1981, unaffected).