### PR TITLE
refactor: drop the dead aliased-scalar safety-set parameter

### DIFF
--- a/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
+++ b/src/Repositories/Criteria/Concerns/ColumnProjectionApplier.php
@@ -132,11 +132,7 @@ final class ColumnProjectionApplier
      */
     private function deriveSafetySet(Builder $query, array $relationKeys, array $order): array
     {
-        // Aliased scalars are omitted for this iteration: the resolved field
-        // set uses canonical schema keys, and the safety set is additive, so
-        // the narrower already unions every needed column from the
-        // field-column map.
-        return $this->safetySetDeriver->derive($query->getModel(), $relationKeys, [], $this->orderColumns($order));
+        return $this->safetySetDeriver->derive($query->getModel(), $relationKeys, $this->orderColumns($order));
     }
 
     /**

--- a/src/Schema/SafetySetDeriver.php
+++ b/src/Schema/SafetySetDeriver.php
@@ -12,8 +12,8 @@ use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
  * retain.
  *
  * Composes, at runtime, the union of primary key, soft-delete column, relation
- * parent-side keys, aliased-scalar columns, order columns, and append sources,
- * then intersects against the model's real table columns.
+ * parent-side keys, order columns, and append sources, then intersects against
+ * the model's real table columns.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -36,11 +36,10 @@ final class SafetySetDeriver
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array<int, string>  $eagerLoadedRelations
-     * @param  array<int, string>  $aliasedScalarColumns
      * @param  array<int, string>  $orderColumns
      * @return array<int, string>
      */
-    public function derive(Model $model, array $eagerLoadedRelations, array $aliasedScalarColumns, array $orderColumns): array
+    public function derive(Model $model, array $eagerLoadedRelations, array $orderColumns): array
     {
         $columns = [$model->getKeyName()];
 
@@ -51,7 +50,6 @@ final class SafetySetDeriver
         }
 
         $columns = array_merge($columns, $this->relationParentKeys($model, $eagerLoadedRelations));
-        $columns = array_merge($columns, $aliasedScalarColumns);
         $columns = array_merge($columns, $orderColumns);
         $columns = array_merge($columns, $model->getAppends());
 

--- a/tests/Fixtures/Resources/AliasedScalarUserResource.php
+++ b/tests/Fixtures/Resources/AliasedScalarUserResource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+
+/**
+ * Fixture user resource exposing an aliased scalar field.
+ *
+ * The scalar's canonical name ('email_address') differs from the key it is
+ * exposed under ('email'). The exposed key is the single source of truth: it is
+ * both the attribute the serializer reads from the model and the column the
+ * narrower selects, so a narrowed SELECT can never drop a column the renderer
+ * needs.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class AliasedScalarUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'aliased_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name'),
+            Field::scalar('email_address', 'email'),
+        );
+    }
+}

--- a/tests/Integration/ColumnNarrowingIntegrationTest.php
+++ b/tests/Integration/ColumnNarrowingIntegrationTest.php
@@ -20,6 +20,7 @@ use Tests\Fixtures\Models\Article;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\AliasedScalarUserResource;
 use Tests\Fixtures\Resources\ArticleResource;
 use Tests\Fixtures\Resources\UserResource;
 use Tests\TestCase;
@@ -294,6 +295,86 @@ final class ColumnNarrowingIntegrationTest extends TestCase
         $second = FieldColumnMapper::for(ArticleResource::class);
 
         self::assertSame($first, $second);
+    }
+
+    /**
+     * With the flag on, an aliased scalar narrows to the key it is exposed
+     * under - the same key the serializer reads from the model - so the real
+     * column survives and the response is byte-identical to the flag-off
+     * baseline. The canonical source name never reaches the narrowed SELECT.
+     *
+     * @return void
+     */
+    public function testAliasedScalarSurvivesNarrowing(): void
+    {
+        $off = $this->serialiseAliasedUsers('id,name,email');
+
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $columns = $this->captureAliasedUserColumns('id,name,email');
+
+        self::assertNotContains('*', $columns);
+        self::assertContains('email', $columns);
+        self::assertNotContains('email_address', $columns);
+        self::assertSame($off, $this->serialiseAliasedUsers('id,name,email'));
+        self::assertStringContainsString('alice@example.com', $this->serialiseAliasedUsers('id,name,email'));
+    }
+
+    /**
+     * Serialise the seeded users through the aliased-scalar resource for the
+     * given field set.
+     *
+     * @param  string  $fields
+     * @return string
+     */
+    private function serialiseAliasedUsers(string $fields): string
+    {
+        $this->parseAliasedUserQuery($fields);
+
+        $users = $this->applyAliasedUserCriteria()->get();
+
+        return $this->encode(AliasedScalarUserResource::collection($users)->resolve(Request::create(self::TEST_URL)));
+    }
+
+    /**
+     * Capture the narrowed base-table column names set on the aliased-scalar
+     * user query.
+     *
+     * @param  string  $fields
+     * @return array<int, string>
+     */
+    private function captureAliasedUserColumns(string $fields): array
+    {
+        $this->parseAliasedUserQuery($fields);
+
+        return $this->normaliseColumns($this->applyAliasedUserCriteria()->getQuery()->columns);
+    }
+
+    /**
+     * Parse an aliased-scalar user request for the given field set.
+     *
+     * @param  string  $fields
+     * @return void
+     */
+    private function parseAliasedUserQuery(string $fields): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields' => ['aliased_users' => $fields],
+        ]);
+
+        ApiQuery::parse($request);
+    }
+
+    /**
+     * Apply the criteria chain to a user query bound to the aliased-scalar
+     * resource.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User>
+     */
+    private function applyAliasedUserCriteria(): Builder
+    {
+        /** @var \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User> */
+        return $this->makeCriteria()->usingResource(AliasedScalarUserResource::class)->apply(new User);
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/SafetySetDeriverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/SafetySetDeriverTest.php
@@ -55,7 +55,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('getDeletedAtColumn')->willReturn(null);
         $this->introspector->method('getColumns')->willReturn(['uuid', 'name']);
 
-        $columns = $this->deriver->derive($model, [], [], []);
+        $columns = $this->deriver->derive($model, [], []);
 
         self::assertContains('uuid', $columns);
         self::assertNotContains('id', $columns);
@@ -74,7 +74,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('getDeletedAtColumn')->willReturn('deleted_at');
         $this->introspector->method('getColumns')->willReturn(['id', 'deleted_at', 'name']);
 
-        $columns = $this->deriver->derive($model, [], [], []);
+        $columns = $this->deriver->derive($model, [], []);
 
         self::assertContains('deleted_at', $columns);
     }
@@ -91,7 +91,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('getDeletedAtColumn')->willReturn(null);
         $this->introspector->method('getColumns')->willReturn(['id', 'name']);
 
-        $columns = $this->deriver->derive($model, [], [], []);
+        $columns = $this->deriver->derive($model, [], []);
 
         self::assertNotContains('deleted_at', $columns);
     }
@@ -112,7 +112,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('parentKeysFor')->willReturn(['taggable_type', 'taggable_id']);
         $this->introspector->method('getColumns')->willReturn(['id', 'taggable_type', 'taggable_id', 'name']);
 
-        $columns = $this->deriver->derive($model, ['taggable'], [], []);
+        $columns = $this->deriver->derive($model, ['taggable'], []);
 
         self::assertContains('taggable_type', $columns);
         self::assertContains('taggable_id', $columns);
@@ -132,28 +132,25 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('resolveRelation')->willReturn(null);
         $this->introspector->method('getColumns')->willReturn(['id', 'name']);
 
-        $columns = $this->deriver->derive($model, ['nonexistent'], [], []);
+        $columns = $this->deriver->derive($model, ['nonexistent'], []);
 
         self::assertSame(['id'], $columns);
     }
 
     /**
-     * Test that aliased-scalar columns and order columns that are real columns
-     * appear in the result.
+     * Test that order columns that are real columns appear in the result.
      *
      * @return void
      */
-    public function testUnionsAliasedScalarAndOrderColumns(): void
+    public function testUnionsOrderColumns(): void
     {
         $model = $this->makeModel('id');
 
         $this->introspector->method('getDeletedAtColumn')->willReturn(null);
-        $this->introspector->method('getColumns')->willReturn(['id', 'first_name', 'last_name', 'created_at']);
+        $this->introspector->method('getColumns')->willReturn(['id', 'name', 'created_at']);
 
-        $columns = $this->deriver->derive($model, [], ['first_name', 'last_name'], ['created_at']);
+        $columns = $this->deriver->derive($model, [], ['created_at']);
 
-        self::assertContains('first_name', $columns);
-        self::assertContains('last_name', $columns);
         self::assertContains('created_at', $columns);
     }
 
@@ -170,9 +167,8 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('getDeletedAtColumn')->willReturn(null);
         $this->introspector->method('getColumns')->willReturn(['id', 'name']);
 
-        $columns = $this->deriver->derive($model, [], ['computed_alias'], ['virtual_order']);
+        $columns = $this->deriver->derive($model, [], ['virtual_order']);
 
-        self::assertNotContains('computed_alias', $columns);
         self::assertNotContains('virtual_order', $columns);
     }
 
@@ -189,7 +185,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('getDeletedAtColumn')->willReturn(null);
         $this->introspector->method('getColumns')->willReturn(['id', 'status']);
 
-        $columns = $this->deriver->derive($model, [], [], []);
+        $columns = $this->deriver->derive($model, [], []);
 
         self::assertContains('status', $columns);
         self::assertNotContains('virtual_flag', $columns);
@@ -213,7 +209,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('parentKeysFor')->willReturn(['author_id']);
         $this->introspector->method('getColumns')->willReturn(['id', 'author_id', 'name']);
 
-        $columns = $this->deriver->derive($model, ['missing', 'author'], [], []);
+        $columns = $this->deriver->derive($model, ['missing', 'author'], []);
 
         self::assertContains('author_id', $columns);
     }
@@ -243,7 +239,7 @@ final class SafetySetDeriverTest extends TestCase
         );
         $this->introspector->method('getColumns')->willReturn(['id', 'author_id', 'category_id', 'name']);
 
-        $columns = $this->deriver->derive($model, ['author', 'category'], [], []);
+        $columns = $this->deriver->derive($model, ['author', 'category'], []);
 
         self::assertContains('author_id', $columns);
         self::assertContains('category_id', $columns);
@@ -262,7 +258,7 @@ final class SafetySetDeriverTest extends TestCase
         $this->introspector->method('getDeletedAtColumn')->willReturn(null);
         $this->introspector->method('getColumns')->willReturn(['id', 'name']);
 
-        $columns = $this->deriver->derive($model, [], [], ['id', 'ghost', 'name']);
+        $columns = $this->deriver->derive($model, [], ['id', 'ghost', 'name']);
 
         self::assertSame(['id', 'name'], $columns);
     }


### PR DESCRIPTION
Part of the v2 deep-review hardening (decision [21]). Closes out a deferred, permanently-`[]` parameter.

`SafetySetDeriver::derive()` carried an `$aliasedScalarColumns` parameter that its only caller always passed as `[]` behind a "for this iteration" deferral comment - meant to backstop a feared alias-narrowing bug (an aliased scalar whose real column gets narrowed out of the SELECT).

**Determined empirically that the bug cannot occur.** A new end-to-end SQLite test (`Field::scalar('email_address', 'email')`, `narrow_columns` on, requesting the field) shows a plain scalar is keyed in the compiled schema by its **exposed key**, and that same key drives both the read (`ValueResolver` reads `$model->{key}`) and the narrowing (`FieldColumnMapper` returns `[key]`). So the narrowed `SELECT` always retains exactly the column the renderer reads - there's no divergence to backstop. Narrowed columns came back `['id','name','email']` (never `email_address`), response byte-identical to the flag-off baseline.

So the parameter is genuinely dead: removed it, its docblock, the deferral comment, and the two tests that exercised it; added a regression test pinning that aliased scalars survive narrowing. `derive()` is now `derive(Model, array $eagerLoadedRelations, array $orderColumns)`.

`composer check --all --no-cache` clean, `composer test` green (1982), `composer smells` clean.