### PR TITLE
refactor!: rename the transaction and lock stages to Services\Pipeline

### DIFF
--- a/src/Services/Pipeline/LockStage.php
+++ b/src/Services/Pipeline/LockStage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace SineMacula\ApiToolkit\Services\Concerns;
+namespace SineMacula\ApiToolkit\Services\Pipeline;
 
 use SineMacula\ApiToolkit\Services\Service;
 
@@ -16,7 +16,7 @@ use SineMacula\ApiToolkit\Services\Service;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class LockConcern
+final class LockStage
 {
     /**
      * Acquire the service's cache lock, run $next, release in finally.

--- a/src/Services/Pipeline/TransactionStage.php
+++ b/src/Services/Pipeline/TransactionStage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace SineMacula\ApiToolkit\Services\Concerns;
+namespace SineMacula\ApiToolkit\Services\Pipeline;
 
 use Illuminate\Support\Facades\DB;
 
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\DB;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class TransactionConcern
+final class TransactionStage
 {
     /**
      * Wrap $next in DB::transaction with $attempts retries.

--- a/src/Services/ServiceRunner.php
+++ b/src/Services/ServiceRunner.php
@@ -7,11 +7,11 @@ namespace SineMacula\ApiToolkit\Services;
 use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Exceptions\LockOperationException;
 use SineMacula\ApiToolkit\Services\Actors\SystemActor;
-use SineMacula\ApiToolkit\Services\Concerns\LockConcern;
-use SineMacula\ApiToolkit\Services\Concerns\TransactionConcern;
 use SineMacula\ApiToolkit\Services\Contracts\ServiceConcern;
 use SineMacula\ApiToolkit\Services\Events\ServiceCompleted;
 use SineMacula\ApiToolkit\Services\Events\ServiceFailed;
+use SineMacula\ApiToolkit\Services\Pipeline\LockStage;
+use SineMacula\ApiToolkit\Services\Pipeline\TransactionStage;
 
 /**
  * Fixed lifecycle orchestrator for service actions.
@@ -164,7 +164,7 @@ final class ServiceRunner
      */
     private function wrapTransaction(\Closure $core, int $attempts): \Closure
     {
-        $class = TransactionConcern::class;
+        $class = TransactionStage::class;
 
         return fn (): mixed => app($class)->wrap($core, $attempts);
     }
@@ -195,7 +195,7 @@ final class ServiceRunner
      */
     private function wrapLock(Service $service, \Closure $core): \Closure
     {
-        $class = LockConcern::class;
+        $class = LockStage::class;
 
         return fn (): mixed => app($class)->wrap($service, $core);
     }

--- a/tests/Unit/Services/Pipeline/LockStageTest.php
+++ b/tests/Unit/Services/Pipeline/LockStageTest.php
@@ -2,26 +2,26 @@
 
 declare(strict_types = 1);
 
-namespace Tests\Unit\Services\Concerns;
+namespace Tests\Unit\Services\Pipeline;
 
 use Illuminate\Contracts\Cache\Lock;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Exceptions\LockUnavailableException;
-use SineMacula\ApiToolkit\Services\Concerns\LockConcern;
 use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Pipeline\LockStage;
 use SineMacula\ApiToolkit\Services\Service;
 use Tests\TestCase;
 
 /**
- * Tests for the LockConcern class.
+ * Tests for the LockStage class.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  *
  * @internal
  */
-#[CoversClass(LockConcern::class)]
-final class LockConcernTest extends TestCase
+#[CoversClass(LockStage::class)]
+final class LockStageTest extends TestCase
 {
     /**
      * Test that wrap acquires the lock before $next, releases after, and
@@ -34,7 +34,7 @@ final class LockConcernTest extends TestCase
         $callOrder = [];
 
         $service = $this->createLockableService($callOrder);
-        $concern = new LockConcern;
+        $concern = new LockStage;
 
         $result = $concern->wrap($service, function () use (&$callOrder): string {
             $callOrder[] = 'next';
@@ -57,7 +57,7 @@ final class LockConcernTest extends TestCase
         $callOrder = [];
 
         $service = $this->createLockableService($callOrder);
-        $concern = new LockConcern;
+        $concern = new LockStage;
 
         try {
 
@@ -105,7 +105,7 @@ final class LockConcernTest extends TestCase
             }
         };
 
-        $concern = new LockConcern;
+        $concern = new LockStage;
 
         $this->expectException(LockUnavailableException::class);
 

--- a/tests/Unit/Services/Pipeline/TransactionStageTest.php
+++ b/tests/Unit/Services/Pipeline/TransactionStageTest.php
@@ -2,23 +2,23 @@
 
 declare(strict_types = 1);
 
-namespace Tests\Unit\Services\Concerns;
+namespace Tests\Unit\Services\Pipeline;
 
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversClass;
-use SineMacula\ApiToolkit\Services\Concerns\TransactionConcern;
+use SineMacula\ApiToolkit\Services\Pipeline\TransactionStage;
 use Tests\TestCase;
 
 /**
- * Tests for the TransactionConcern class.
+ * Tests for the TransactionStage class.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  *
  * @internal
  */
-#[CoversClass(TransactionConcern::class)]
-final class TransactionConcernTest extends TestCase
+#[CoversClass(TransactionStage::class)]
+final class TransactionStageTest extends TestCase
 {
     /**
      * Test that wrap returns $next's value when the transaction commits.
@@ -31,7 +31,7 @@ final class TransactionConcernTest extends TestCase
             ->once()
             ->andReturnUsing(fn (\Closure $callback): mixed => $callback());
 
-        $concern = new TransactionConcern;
+        $concern = new TransactionStage;
 
         $result = $concern->wrap(fn (): string => 'committed', 1);
 
@@ -51,7 +51,7 @@ final class TransactionConcernTest extends TestCase
             ->once()
             ->andReturnUsing(fn (\Closure $callback): mixed => $callback());
 
-        $concern = new TransactionConcern;
+        $concern = new TransactionStage;
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('rollback');
@@ -71,7 +71,7 @@ final class TransactionConcernTest extends TestCase
             ->withArgs(fn (\Closure $callback, int $attempts): bool => $attempts === 5)
             ->andReturnUsing(fn (\Closure $callback): mixed => $callback());
 
-        $concern = new TransactionConcern;
+        $concern = new TransactionStage;
 
         $concern->wrap(fn (): bool => true, 5);
     }


### PR DESCRIPTION
Part of the v2 deep-review hardening (namespace restructure, finding [14]). **Breaking** (internal classes; v2 unreleased). First of two namespace PRs ([15] relocates schema introspection/validation separately).

The internal transaction and lock pipeline stages lived in `Services\Concerns` named `TransactionConcern`/`LockConcern` - reading as implementations of the user-facing `ServiceConcern` contract, which they are **not** (bespoke `wrap()` signature, fixed lock-then-transaction ordering enforced by `ServiceRunner`, not `ServiceConcern` implementers). They move to `SineMacula\ApiToolkit\Services\Pipeline` as `TransactionStage` / `LockStage`.

Method bodies, the `wrap()` signatures, and the lock-then-transaction ordering are **byte-for-byte unchanged** - only class names, namespace, and paths change. `ServiceRunner` and the tests are updated; the empty `Services\Concerns` directory is removed. Post-move grep for the old names/namespace returns nothing.

**Merge note:** UPGRADE.md still contains a stale `concerns() => [LockConcern::class, ...]` example, but that is the fabricated-API block #303 deletes in its rewrite - so this PR deliberately doesn't touch UPGRADE.md (no conflict; merge alongside #303).

`composer check --all --no-cache` clean (PHPStan confirms no missed reference), `composer test` green (1981), `composer smells` clean.