### PR TITLE
feat: gate nested relation traversal on the declared traversable set [BL-37]

### DIFF
--- a/src/Repositories/Criteria/QuerySurface.php
+++ b/src/Repositories/Criteria/QuerySurface.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\Schema\CompiledSchema;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 
 /**
@@ -27,7 +28,12 @@ use SineMacula\ApiToolkit\Schema\SchemaCompiler;
  * allowlist posture. When no mapped resource exists for a related model the
  * gate fails closed (rejects), matching the root secure-by-default behaviour.
  * Under the blocklist posture the legacy searchable predicate still applies for
- * related models. The relation-traversal gate (permitsRelation) is unchanged.
+ * related models. Relation traversal is gated the same way at every level: the
+ * root relation against the declared traversable set, and each onward relation
+ * against the related resource's declared traversable set, failing closed when
+ * the related model has no mapped resource. Traversal depth is therefore
+ * bounded by declarations rather than a fixed limit - a chain ends at the
+ * first undeclared or unmapped hop.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -132,7 +138,13 @@ final readonly class QuerySurface
      */
     public function guardRelation(string $relation, Model $model): bool
     {
-        return $this->guard($this->permitsRelation($relation, $model), 'filters', $relation, $model);
+        return $this->guard(
+            $this->permitsRelation($relation, $model),
+            'filters',
+            $relation,
+            $model,
+            $this->posture === self::POSTURE_ALLOWLIST,
+        );
     }
 
     /**
@@ -184,9 +196,34 @@ final readonly class QuerySurface
      */
     private function permitsRelation(string $relation, Model $model): bool
     {
-        return $this->governsRoot($model)
-            ? in_array($relation, $this->traversableRelations, true)
-            : $this->introspector->isRelation($relation, $model);
+        if ($this->governsRoot($model)) {
+            return in_array($relation, $this->traversableRelations, true);
+        }
+
+        if ($this->posture === self::POSTURE_ALLOWLIST) {
+            return $this->permitsRelatedRelation($relation, $model);
+        }
+
+        return $this->introspector->isRelation($relation, $model);
+    }
+
+    /**
+     * Determine whether the relation is traversable on a related (non-root)
+     * model under the allowlist posture by checking the related resource's
+     * declared traversable set.
+     *
+     * When no resource is mapped for the related model the gate fails closed,
+     * matching the root secure-by-default behaviour.
+     *
+     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    private function permitsRelatedRelation(string $relation, Model $model): bool
+    {
+        $schema = $this->resolveRelatedSchema($model);
+
+        return $schema !== null && in_array($relation, $schema->getTraversableRelations(), true);
     }
 
     /**
@@ -204,16 +241,34 @@ final readonly class QuerySurface
      */
     private function permitsRelatedColumn(string $column, Model $model, bool $filterable): bool
     {
-        $resourceClass = $this->resourceMap[$model::class] ?? null;
+        $schema = $this->resolveRelatedSchema($model);
 
-        if ($resourceClass === null || !is_subclass_of($resourceClass, ApiResourceInterface::class)) {
+        if ($schema === null) {
             return false;
         }
 
-        $schema  = SchemaCompiler::compile($resourceClass);
         $columns = $filterable ? $schema->getFilterableColumns() : $schema->getSortableColumns();
 
         return in_array($column, $columns, true);
+    }
+
+    /**
+     * Resolve the compiled schema for a related model's mapped resource, or
+     * null when the model has no mapped resource (or the mapping does not
+     * implement the resource contract).
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \SineMacula\ApiToolkit\Schema\CompiledSchema|null
+     */
+    private function resolveRelatedSchema(Model $model): ?CompiledSchema
+    {
+        $resourceClass = $this->resourceMap[$model::class] ?? null;
+
+        if ($resourceClass === null || !is_subclass_of($resourceClass, ApiResourceInterface::class)) {
+            return null;
+        }
+
+        return SchemaCompiler::compile($resourceClass);
     }
 
     /**

--- a/tests/Fixtures/Resources/DeepTraversalPostResource.php
+++ b/tests/Fixtures/Resources/DeepTraversalPostResource.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\ApiToolkit\Schema\Relation;
+
+/**
+ * Fixture post resource that declares an onward traversable relation.
+ *
+ * Used to exercise multi-hop relation traversal under the allowlist posture:
+ * unlike PostResource, this resource declares 'user' traversable so a chain
+ * such as users -> posts -> user is permitted at every level.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class DeepTraversalPostResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'deep_traversal_posts';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'title'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('title')->filterable(),
+            Relation::to('user', UserResource::class)->traversable(),
+        );
+    }
+}

--- a/tests/Integration/QuerySurfaceIntegrationTest.php
+++ b/tests/Integration/QuerySurfaceIntegrationTest.php
@@ -16,6 +16,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use SineMacula\Http\Enums\HttpMethod;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\DeepTraversalPostResource;
 use Tests\Fixtures\Resources\FilterableUserResource;
 use Tests\Fixtures\Resources\PostResource;
 use Tests\TestCase;
@@ -227,6 +228,91 @@ final class QuerySurfaceIntegrationTest extends TestCase
         } catch (ValidationException $e) {
             self::assertArrayHasKey('filters.body', $e->errors());
         }
+    }
+
+    /**
+     * Under the allowlist posture a relation traversed at a nested hop is gated
+     * against the related resource's declared traversable set, not merely
+     * whether the relation exists.
+     *
+     * PostResource declares no traversable relations, so pivoting from a
+     * traversed post into its 'user' relation must be rejected fail-closed even
+     * though the relation is real.
+     *
+     * @return void
+     */
+    public function testNestedUndeclaredRelationTraversalIsRejectedFailClosed(): void
+    {
+        $this->parseQuery(['filters' => json_encode([
+            'posts' => [
+                'nested' => ['user' => ['name' => 'Alice']],
+            ],
+        ])]);
+
+        try {
+            $this->declaredCriteria()->apply(new User);
+            self::fail('Expected a ValidationException for undeclared nested relation "user".');
+        } catch (ValidationException $e) {
+            self::assertArrayHasKey('filters.user', $e->errors());
+        }
+    }
+
+    /**
+     * With fail-quiet rejection an undeclared nested relation is dropped rather
+     * than applied: the onward hop adds no constraint and no exception escapes.
+     *
+     * PostResource does not declare 'user' traversable, so under fail-quiet the
+     * nested 'user' constraint is dropped and only the outer 'posts' existence
+     * applies - the two users with posts remain (contrast the
+     * declared-traversal case, which narrows the same query to one).
+     *
+     * @return void
+     */
+    public function testNestedUndeclaredRelationTraversalIsDroppedFailQuiet(): void
+    {
+        Config::set('api-toolkit.repositories.reject_undeclared', false);
+
+        $this->parseQuery(['filters' => json_encode([
+            'posts' => [
+                'nested' => ['user' => ['name' => 'Alice']],
+            ],
+        ])]);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        self::assertCount(2, $results);
+    }
+
+    /**
+     * Under the allowlist posture a nested relation that the related resource
+     * declares traversable is applied end-to-end.
+     *
+     * DeepTraversalPostResource declares 'user' traversable, so the chain
+     * users -> posts -> user is permitted at every hop and the whereHas nesting
+     * is built: only Alice owns a post whose user is named Alice.
+     *
+     * @return void
+     */
+    public function testDeclaredNestedRelationTraversalIsAppliedUnderAllowlist(): void
+    {
+        Config::set('api-toolkit.resources.resource_map', [
+            Post::class => DeepTraversalPostResource::class,
+        ]);
+
+        $this->parseQuery(['filters' => json_encode([
+            'posts' => [
+                'nested' => ['user' => ['name' => 'Alice']],
+            ],
+        ])]);
+
+        $results = $this->declaredCriteria()->apply(new User)->get();
+
+        self::assertCount(1, $results);
+
+        /** @var \Tests\Fixtures\Models\User $first */
+        $first = $results->first();
+
+        self::assertSame('Alice', $first->name);
     }
 
     /**

--- a/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
+++ b/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\Repositories\Criteria;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\FilterableUserResource;
 use Tests\Fixtures\Resources\PostResource;
 use Tests\TestCase;
 
@@ -154,6 +156,19 @@ final class QuerySurfaceTest extends TestCase
     }
 
     /**
+     * Test that a related model mapped to a class that is not an API resource
+     * fails closed rather than attempting to compile the bogus class.
+     *
+     * @return void
+     */
+    public function testAllowlistFailsClosedWhenMappedResourceIsNotAnApiResource(): void
+    {
+        $surface = $this->make(resourceMap: [Post::class => \stdClass::class]);
+
+        $this->assertRejects(fn () => $surface->guardFilter('title', new Post), 'filters.title');
+    }
+
+    /**
      * Test that fail-quiet silently drops an undeclared related-model column
      * without throwing, even under the allowlist posture.
      *
@@ -214,6 +229,114 @@ final class QuerySurfaceTest extends TestCase
     }
 
     /**
+     * Test that under the allowlist posture a relation declared traversable in
+     * the related model's mapped resource is permitted at a non-root hop.
+     *
+     * FilterableUserResource declares 'posts' traversable, so with User reached
+     * as a related model the traversal must pass.
+     *
+     * @return void
+     */
+    public function testAllowlistPermitsDeclaredTraversableRelationOnRelatedModel(): void
+    {
+        $surface = $this->make(
+            resourceMap: [User::class => FilterableUserResource::class],
+            rootModel: new Post,
+        );
+
+        self::assertTrue($surface->guardRelation('posts', new User));
+    }
+
+    /**
+     * Test that under the allowlist posture a relation NOT declared traversable
+     * in the related model's resource is rejected at a non-root hop.
+     *
+     * FilterableUserResource declares 'organization' as a relation but not as
+     * traversable, so traversing it from a related User must be rejected.
+     *
+     * @return void
+     */
+    public function testAllowlistRejectsUndeclaredTraversableRelationOnRelatedModel(): void
+    {
+        $surface = $this->make(
+            resourceMap: [User::class => FilterableUserResource::class],
+            rootModel: new Post,
+        );
+
+        $this->assertRejects(fn () => $surface->guardRelation('organization', new User), 'filters.organization');
+    }
+
+    /**
+     * Test that under the allowlist posture a related model with no mapped
+     * resource fails closed: every onward relation is rejected.
+     *
+     * @return void
+     */
+    public function testAllowlistFailsClosedWhenRelatedModelHasNoMappedResourceForRelation(): void
+    {
+        // Empty resource map - User is not mapped, so its traversable set is
+        // unresolvable.
+        $surface = $this->make(rootModel: new Post);
+
+        $this->assertRejects(fn () => $surface->guardRelation('posts', new User), 'filters.posts');
+    }
+
+    /**
+     * Test that fail-quiet silently drops an undeclared related-model relation
+     * without throwing, even under the allowlist posture.
+     *
+     * @return void
+     */
+    public function testFailQuietDropsUndeclaredRelatedRelationWithoutThrowing(): void
+    {
+        $surface = $this->make(
+            reject: false,
+            resourceMap: [User::class => FilterableUserResource::class],
+            rootModel: new Post,
+        );
+
+        self::assertFalse($surface->guardRelation('organization', new User));
+    }
+
+    /**
+     * Test that the blocklist posture delegates a related-model relation to the
+     * schema introspector rather than the resource's traversable set.
+     *
+     * @return void
+     */
+    public function testBlocklistDelegatesRelationToIntrospectorForRelatedModel(): void
+    {
+        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
+        $introspector->shouldReceive('isRelation')->with('posts', \Mockery::type(User::class))->andReturnTrue(); // @phpstan-ignore method.notFound
+
+        $surface = $this->make(
+            posture: QuerySurface::POSTURE_BLOCKLIST,
+            introspector: $introspector,
+            resourceMap: [User::class => FilterableUserResource::class],
+            rootModel: new Post,
+        );
+
+        self::assertTrue($surface->guardRelation('posts', new User));
+    }
+
+    /**
+     * Test that the blocklist posture drops (rather than rejects) an undeclared
+     * relation the introspector does not recognise, confirming nested relations
+     * are not forced fail-closed outside the allowlist posture.
+     *
+     * @return void
+     */
+    public function testBlocklistDropsUndeclaredRelationWithoutThrowing(): void
+    {
+        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
+        $introspector->shouldReceive('isRelation')->with('ghost', \Mockery::type(User::class))->andReturnFalse(); // @phpstan-ignore method.notFound
+
+        $surface = $this->make(posture: QuerySurface::POSTURE_BLOCKLIST, introspector: $introspector);
+
+        self::assertFalse($surface->guardRelation('ghost', new User));
+    }
+
+    /**
      * Build a query surface with sensible defaults for the test under focus.
      *
      * @param  array<int, string>  $filterable
@@ -223,6 +346,7 @@ final class QuerySurfaceTest extends TestCase
      * @param  bool  $reject
      * @param  \SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider|null  $introspector
      * @param  array<string, string>  $resourceMap
+     * @param  \Illuminate\Database\Eloquent\Model|null  $rootModel
      * @return \SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface
      */
     private function make(
@@ -233,6 +357,7 @@ final class QuerySurfaceTest extends TestCase
         bool $reject = true,
         ?SchemaIntrospectionProvider $introspector = null,
         array $resourceMap = [],
+        ?Model $rootModel = null,
     ): QuerySurface {
         return new QuerySurface(
             $filterable,
@@ -241,7 +366,7 @@ final class QuerySurfaceTest extends TestCase
             $posture,
             $reject,
             $introspector ?? \Mockery::mock(SchemaIntrospectionProvider::class),
-            new User,
+            $rootModel    ?? new User,
             $resourceMap,
         );
     }


### PR DESCRIPTION
## Summary

Closes the defence-in-depth follow-up to the nested-column gate (BL-32): relation *traversal* was allowlist-gated only on the root model. On any related model reached after the first hop, `QuerySurface::permitsRelation()` fell through to `isRelation()`, which only confirms the relation exists. So after entering a root-declared-traversable relation, a request could pivot through any real relation on the traversed model even if that resource never declared it traversable.

This gates each hop against the related resource's declared traversable set (mirroring the BL-32 column gate): resolve the related resource from `resource_map`, require the relation to be in its `getTraversableRelations()`, and fail closed when the related model has no mapped resource. A shared `resolveRelatedSchema()` helper is extracted so the column and relation gates share one resolution path, and `guardRelation()` now passes the allowlist flag so a nested undeclared relation fails closed (named `ValidationException`) under fail-closed and is dropped under fail-quiet, exactly like filters/sorts.

## On depth

There is no max-depth cap, constant, or counter anywhere in the toolkit, and none is added. Traversal depth is bounded organically by declarations: an N-hop chain is permitted only if every hop is declared traversable on its owning resource, and it dead-ends at the first undeclared or unmapped hop. There was no '2' to raise to '3'; a numeric ceiling would be redundant with declaration-bounding.

## Reachability note

The pivot is reachable only through a nested filter structure where the onward relation appears as a key inside a traversed relation's filter object (the natural single-level nested form consumes the intermediate key as a field label). The practical surface is therefore narrow, consistent with the low severity, but the gate is now secure-by-default at every level.

## Behaviour

- Allowlist posture: a nested relation applies only when the related resource declares it via `Relation::to(...)->traversable()`; undeclared or unmapped hops fail closed (or drop under fail-quiet).
- Blocklist posture: unchanged (`isRelation()` at every level).
- Root-relation behaviour: unchanged.

## Tests

- QuerySurface unit tests for the non-root relation gate: declared-permitted, undeclared-rejected, unmapped fail-closed, non-resource-mapping fail-closed, fail-quiet drop, and blocklist passthrough/drop.
- Integration tests exercising the end-to-end pipeline: nested undeclared traversal rejected fail-closed, dropped fail-quiet, and a declared multi-hop chain applied.
- Full suite green (1976 tests). Diff-scoped mutation at 100% MSI.