### PR TITLE
feat: discover model-resource bindings via the ForModel attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,15 @@ Extend `ApiResource` and declare a `schema()` method using the `Field`, `Relatio
 schema helpers. The compiled schema drives field resolution, guard evaluation, and eager-load planning automatically.
 
 ```php
+use App\Models\User;
+use SineMacula\ApiToolkit\Attributes\ForModel;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Schema\Count;
 use SineMacula\ApiToolkit\Schema\Field;
 use SineMacula\ApiToolkit\Schema\Relation;
 use SineMacula\ApiToolkit\Schema\Sum;
 
+#[ForModel(User::class)]
 class UserResource extends ApiResource
 {
     const RESOURCE_TYPE = 'user';
@@ -143,6 +146,15 @@ class UserResource extends ApiResource
 Fields marked `filterable()` or `sortable()` are exposed under the allowlist posture. Relations marked
 `traversable()` can be targeted by nested filters. The `$default` static property declares the fields returned
 when the client sends no `?fields` parameter.
+
+**Model binding and discovery** - the `#[ForModel(...)]` attribute binds a resource to its model, and may be
+repeated to bind one resource to several models. Resources under the configured `api-toolkit.resources.paths`
+(default `app/Http/Resources`) are discovered at boot and compiled into the model-to-resource map automatically,
+so no central map needs maintaining. An explicit `api-toolkit.resources.resource_map` entry always wins over a
+discovered binding - use it as the canonical-resource tiebreak when a model has more than one resource, or to
+bind resources living outside the scanned paths. When two discovered resources claim the same model and no
+explicit entry resolves it, the first (in sorted file order) wins and a warning is logged; with
+`validate_schemas` enabled the conflict fails the boot instead.
 
 **Eager-load planning** - the resource builds `with()`/`withCount()`/`withSum()`/`withAvg()` maps from the
 resolved field set, so relations are loaded precisely and automatically:

--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -76,11 +76,15 @@ return [
     | runtime based on the configured resource classes, allowing for a flexible,
     | type-safe API design.
     |
-    | `resource_map`: This array should contain the mappings of model classes to
-    | their corresponding resource classes. This is used to define explicit
-    | morph maps for Eloquent models when using polymorphic relationships,
-    | enhancing the API's ability to serialize and deserialize these relations
-    | correctly.
+    | `paths`: The filesystem paths scanned at boot for resources carrying the
+    | ForModel attribute. Discovered bindings merge beneath the resource_map
+    | (an explicit entry always wins), so annotating a resource is the primary
+    | way to bind it to its model. Missing paths are skipped.
+    |
+    | `resource_map`: Explicit model to resource overrides. An entry here wins
+    | over a discovered binding, acting as the canonical-resource tiebreak when
+    | a model has more than one resource, and as the binding mechanism for
+    | resource classes that live outside the scanned paths.
     |
     | `fixed_fields`: This array should contain all globally fixed fields i.e.
     | the fields that should always be present in resource responses.
@@ -91,8 +95,13 @@ return [
 
         'enable_dynamic_morph_mapping' => env('DYNAMIC_MORPH_MAPPING', true),
 
+        'paths' => [
+            app_path('Http/Resources'),
+        ],
+
         'resource_map' => [
-            // This should be filled with the application's resource map
+            // Explicit overrides only; resources inside the scanned paths are
+            // bound via the ForModel attribute
             // e.g. User::class => UserResource::class
         ],
 

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use SineMacula\ApiToolkit\Console\ExportOpenApiCommand;
 use SineMacula\ApiToolkit\Console\ValidateSchemasCommand;
+use SineMacula\ApiToolkit\Http\Resources\ResourceDiscovery;
 use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
 use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
 use SineMacula\ApiToolkit\Providers\Registrars\LoggingRegistrar;
@@ -35,6 +36,7 @@ final class ApiServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->mergeDiscoveredResources();
         $this->loadTranslationFiles();
         $this->offerPublishing();
         $this->registerMorphMap();
@@ -106,6 +108,39 @@ final class ApiServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/api-toolkit.php' => config_path('api-toolkit.php'),
         ], 'config');
+    }
+
+    /**
+     * Merge the attribute-discovered resources beneath the configured map.
+     *
+     * Discovery scans the configured resource paths for classes carrying the
+     * ForModel attribute; an explicit resource_map entry always wins over a
+     * discovered binding, so the static map remains the canonical-resource
+     * tiebreak and the seam for resources outside the scanned paths.
+     *
+     * The merge is skipped while the config cache is being built: baking
+     * discovered bindings into the cached config would make them
+     * indistinguishable from explicit entries and mask later discovery
+     * changes. Runtime boots always merge fresh discoveries on top.
+     *
+     * @return void
+     */
+    private function mergeDiscoveredResources(): void
+    {
+        if (in_array('config:cache', (array) ($_SERVER['argv'] ?? []), true)) {
+            return;
+        }
+
+        $discovered = $this->app->make(ResourceDiscovery::class)->discover();
+
+        if ($discovered === []) {
+            return;
+        }
+
+        $map = Config::get('api-toolkit.resources.resource_map', []);
+        $map = is_array($map) ? $map : [];
+
+        Config::set('api-toolkit.resources.resource_map', $map + $discovered);
     }
 
     /**

--- a/src/Attributes/ForModel.php
+++ b/src/Attributes/ForModel.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Attributes;
+
+/**
+ * Declare the Eloquent model an API resource presents.
+ *
+ * Resources carrying this attribute are discovered at boot from the configured
+ * resource paths and compiled into the model to resource map, so the binding
+ * lives on the resource itself rather than in a hand-maintained config entry.
+ * The attribute may be repeated to bind one resource to several models. An
+ * explicit `resource_map` entry for the same model always wins, acting as
+ * the canonical-resource tiebreak when a model has more than one resource.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class ForModel
+{
+    /**
+     * Create a new resource model binding.
+     *
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $model
+     */
+    public function __construct(
+
+        /** The model class this resource presents. */
+        public string $model,
+    ) {}
+}

--- a/src/Enums/CacheKeys.php
+++ b/src/Enums/CacheKeys.php
@@ -29,6 +29,9 @@ enum CacheKeys: string
     // Store the resource associated with each model
     case MODEL_RESOURCES = 'model-resources:%s';
 
+    // Store the attribute-discovered model to resource bindings for a path set
+    case DISCOVERED_RESOURCES = 'discovered-resources:%s';
+
     // Store the cached collection data for a repository (reference mode)
     case REPOSITORY_CACHE = 'repository-cache:%s';
 

--- a/src/Http/Resources/ResourceDiscovery.php
+++ b/src/Http/Resources/ResourceDiscovery.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\ApiToolkit\Http\Resources;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
+use SineMacula\ApiToolkit\Enums\CacheKeys;
+
+/**
+ * Boot-time discovery of attribute-bound API resources.
+ *
+ * Scans the configured resource paths for classes carrying the ForModel
+ * attribute and compiles them into a model to resource map. The compiled map
+ * is memoised through the metadata cache under a key fingerprinted by the
+ * scanned file list and modification times, so the expensive tokenise and
+ * reflect pass runs only when a scanned file actually changes, while adding,
+ * editing, or removing a resource rotates the key and triggers a rescan on
+ * the next boot. When schema validation is enabled the cache is bypassed
+ * entirely so every diagnostic fires on every boot.
+ *
+ * Files are visited in a deterministic (sorted) order; when two resources
+ * claim the same model the first discovered binding wins and a warning is
+ * logged, or the scan fails hard when schema validation is enabled - unless
+ * the model is explicitly declared in the resource map, which resolves the
+ * ambiguity. A binding whose class is not an instantiable API resource, or
+ * whose model does not exist, is skipped with a warning.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final readonly class ResourceDiscovery
+{
+    /**
+     * Create a new resource discovery instance.
+     *
+     * @param  \SineMacula\ApiToolkit\Cache\MetadataCacheWriter  $cacheWriter
+     * @return void
+     */
+    public function __construct(
+
+        /** The writer used to memoise the compiled discovery map. */
+        private MetadataCacheWriter $cacheWriter,
+    ) {}
+
+    /**
+     * Discover the model to resource bindings from the configured paths.
+     *
+     * @return array<class-string, class-string>
+     */
+    public function discover(): array
+    {
+        // The default covers consumers whose published config predates the
+        // paths key; an explicit empty array still disables discovery.
+        $paths = Config::get('api-toolkit.resources.paths', [app_path('Http/Resources')]);
+        $paths = is_array($paths)
+            ? array_filter($paths, static fn (mixed $path): bool => is_string($path) && is_dir($path))
+            : [];
+
+        $files = $this->files($paths);
+
+        if ($files === []) {
+            return [];
+        }
+
+        if (Config::get('api-toolkit.resources.validate_schemas') === true) {
+            return $this->scan($files);
+        }
+
+        return $this->cacheWriter->rememberMetadataForever($this->cacheKey($files), fn (): array => $this->scan($files));
+    }
+
+    /**
+     * Build the cache key for the given file list, fingerprinted by path and
+     * modification time so any file change rotates the key.
+     *
+     * @param  array<int, string>  $files
+     * @return string
+     */
+    private function cacheKey(array $files): string
+    {
+        $fingerprint = array_map(static fn (string $file): string => $file . ':' . (int) filemtime($file), $files);
+
+        return CacheKeys::DISCOVERED_RESOURCES->resolveKey([md5(implode('|', $fingerprint))]);
+    }
+
+    /**
+     * Scan the given files and compile the discovered bindings.
+     *
+     * @param  array<int, string>  $files
+     * @return array<class-string, class-string>
+     */
+    private function scan(array $files): array
+    {
+        $map = [];
+
+        foreach ($files as $file) {
+            foreach ($this->classesFromFile($file) as $class) {
+                $map = $this->bindClass($map, $class);
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Merge the bindings declared by the given class into the map.
+     *
+     * A class that is not autoloadable is skipped silently (the scan derives
+     * names from file contents, so a stray file is not an error). A model
+     * that is already bound is never rebound - the first discovered binding
+     * wins - and the duplicate claim is reported.
+     *
+     * @param  array<class-string, class-string>  $map
+     * @param  string  $class
+     * @return array<class-string, class-string>
+     */
+    private function bindClass(array $map, string $class): array
+    {
+        if (!class_exists($class)) {
+            return $map;
+        }
+
+        foreach ((new \ReflectionClass($class))->getAttributes(ForModel::class) as $attribute) {
+
+            $model = $attribute->newInstance()->model;
+
+            if (isset($map[$model])) {
+                $this->reportConflict($map, $class, $model);
+            } elseif ($this->permitsBinding($class, $model)) {
+                $map[$model] = $class;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Report a duplicate claim on an already-bound model: silently for a
+     * re-declaration of the same class or a model resolved by an explicit
+     * resource map entry, with a warning otherwise - or fatally when schema
+     * validation is enabled.
+     *
+     * @param  array<class-string, class-string>  $map
+     * @param  class-string  $class
+     * @param  string  $model
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    private function reportConflict(array $map, string $class, string $model): void
+    {
+        if ($map[$model] === $class || $this->declaredExplicitly($model)) {
+            return;
+        }
+
+        $message = sprintf(
+            'Resource discovery found multiple resources for model [%s]: keeping [%s], ignoring [%s]. '
+            . 'Declare the canonical resource in the resource_map to resolve the ambiguity.',
+            $model,
+            $map[$model],
+            $class,
+        );
+
+        if (Config::get('api-toolkit.resources.validate_schemas') === true) {
+            throw new \LogicException($message);
+        }
+
+        Log::warning($message);
+    }
+
+    /**
+     * Determine whether the discovered binding is valid, logging a warning
+     * when it is not.
+     *
+     * @param  class-string  $class
+     * @param  string  $model
+     * @return bool
+     */
+    private function permitsBinding(string $class, string $model): bool
+    {
+        $diagnosis = $this->diagnoseBinding($class, $model);
+
+        if ($diagnosis === null) {
+            return true;
+        }
+
+        Log::warning($diagnosis);
+
+        return false;
+    }
+
+    /**
+     * Diagnose the discovered binding, returning null when it is valid, or
+     * the rejection message otherwise.
+     *
+     * @param  class-string  $class
+     * @param  string  $model
+     * @return string|null
+     */
+    private function diagnoseBinding(string $class, string $model): ?string
+    {
+        $reflection = new \ReflectionClass($class);
+
+        if (!$reflection->isInstantiable() || !$reflection->implementsInterface(ApiResourceInterface::class)) {
+            return sprintf('Resource discovery skipped [%s]: it declares a model binding but is not an instantiable API resource.', $class);
+        }
+
+        if (!class_exists($model)) {
+            return sprintf('Resource discovery skipped [%s]: its declared model [%s] does not exist.', $class, $model);
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine whether the model is explicitly declared in the configured
+     * resource map.
+     *
+     * @param  string  $model
+     * @return bool
+     */
+    private function declaredExplicitly(string $model): bool
+    {
+        $map = Config::get('api-toolkit.resources.resource_map');
+
+        return is_array($map) && array_key_exists($model, $map);
+    }
+
+    /**
+     * List every PHP file beneath the given paths in a deterministic order.
+     *
+     * @param  array<int, string>  $paths
+     * @return array<int, string>
+     */
+    private function files(array $paths): array
+    {
+        $files = [];
+
+        foreach ($paths as $path) {
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            );
+
+            /** @var \SplFileInfo $file */
+            foreach ($iterator as $file) {
+
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $real = $file->getRealPath();
+
+                if ($real === false) {
+                    continue; // @codeCoverageIgnore
+                }
+
+                $files[] = $real;
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * Resolve the fully qualified class names declared in the given file.
+     *
+     * Tokenising avoids loading the file, so a scanned file that is not a
+     * class (or is not autoloadable) has no side effects on the process. A
+     * class keyword preceded by a double colon (a ::class constant) or by
+     * new (an anonymous class) is not a declaration and is skipped.
+     *
+     * @param  string  $file
+     * @return array<int, string>
+     */
+    private function classesFromFile(string $file): array
+    {
+        $contents = file_get_contents($file);
+
+        if ($contents === false) {
+            return []; // @codeCoverageIgnore
+        }
+
+        $tokens    = \PhpToken::tokenize($contents);
+        $namespace = '';
+        $previous  = null;
+        $classes   = [];
+
+        foreach ($tokens as $index => $token) {
+
+            if ($token->isIgnorable()) {
+                continue;
+            }
+
+            if ($token->id === T_NAMESPACE) {
+                $namespace = $this->namespaceFromTokens($tokens, $index) ?? $namespace;
+            } elseif ($token->id === T_CLASS) {
+
+                $class = $this->declaredNameFromTokens($tokens, $index, $previous);
+
+                if ($class !== null) {
+                    $classes[] = ltrim($namespace . '\\' . $class, '\\');
+                }
+            }
+
+            $previous = $token;
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Resolve the namespace name following the namespace keyword at the given
+     * index, or null when the keyword declares no name.
+     *
+     * @param  array<int, \PhpToken>  $tokens
+     * @param  int  $index
+     * @return string|null
+     */
+    private function namespaceFromTokens(array $tokens, int $index): ?string
+    {
+        for ($next = $index + 1; $next < count($tokens); $next++) {
+
+            if ($tokens[$next]->isIgnorable()) {
+                continue;
+            }
+
+            return in_array($tokens[$next]->id, [T_STRING, T_NAME_QUALIFIED], true)
+                ? $tokens[$next]->text
+                : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the declared name following the class keyword at the given
+     * index, or null when the keyword is not a declaration - a ::class
+     * constant reference, an anonymous class expression, or a name-less
+     * trailing keyword.
+     *
+     * @param  array<int, \PhpToken>  $tokens
+     * @param  int  $index
+     * @param  \PhpToken|null  $previous
+     * @return string|null
+     */
+    private function declaredNameFromTokens(array $tokens, int $index, ?\PhpToken $previous): ?string
+    {
+        if (in_array($previous?->id, [T_DOUBLE_COLON, T_NEW], true)) {
+            return null;
+        }
+
+        for ($next = $index + 1; $next < count($tokens); $next++) {
+
+            if ($tokens[$next]->isIgnorable()) {
+                continue;
+            }
+
+            return $tokens[$next]->id === T_STRING
+                ? $tokens[$next]->text
+                : null;
+        }
+
+        return null;
+    }
+}

--- a/tests/Fixtures/Discovery/Conflict/FirstUserResource.php
+++ b/tests/Fixtures/Discovery/Conflict/FirstUserResource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Conflict;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture resource claiming the same model as its sibling; sorted first, so
+ * discovery must keep this binding.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(User::class)]
+final class FirstUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'first_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+        );
+    }
+}

--- a/tests/Fixtures/Discovery/Conflict/SecondUserResource.php
+++ b/tests/Fixtures/Discovery/Conflict/SecondUserResource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Conflict;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture resource claiming the same model as its sibling; sorted second, so
+ * discovery must ignore this binding and warn.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(User::class)]
+final class SecondUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'second_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+        );
+    }
+}

--- a/tests/Fixtures/Discovery/Invalid/AbstractAttributedResource.php
+++ b/tests/Fixtures/Discovery/Invalid/AbstractAttributedResource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Invalid;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture abstract resource with a model binding; discovery must skip it with
+ * a warning because it is not instantiable.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(User::class)]
+abstract class AbstractAttributedResource extends ApiResource {}

--- a/tests/Fixtures/Discovery/Invalid/AttributedPlainClass.php
+++ b/tests/Fixtures/Discovery/Invalid/AttributedPlainClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Invalid;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture class that declares a model binding without being an API resource;
+ * discovery must skip it with a warning.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(User::class)]
+final class AttributedPlainClass {}

--- a/tests/Fixtures/Discovery/Invalid/MissingModelResource.php
+++ b/tests/Fixtures/Discovery/Invalid/MissingModelResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Invalid;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+
+/**
+ * Fixture resource whose declared model does not exist; discovery must skip
+ * it with a warning.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @phpstan-ignore argument.type
+ */
+#[ForModel('Tests\Fixtures\Models\DoesNotExist')]
+final class MissingModelResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'missing_models';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+        );
+    }
+}

--- a/tests/Fixtures/Discovery/Multi/MultiModelResource.php
+++ b/tests/Fixtures/Discovery/Multi/MultiModelResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Multi;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture resource bound to two models via a repeated ForModel attribute.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(User::class)]
+#[ForModel(Post::class)]
+final class MultiModelResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'multi_models';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+        );
+    }
+}

--- a/tests/Fixtures/Discovery/Primary/AbHelper.php
+++ b/tests/Fixtures/Discovery/Primary/AbHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Primary;
+
+/**
+ * Fixture class sorted before the discoverable resources; the scan must pass
+ * over a class without the ForModel attribute and still discover the rest.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class AbHelper {}

--- a/tests/Fixtures/Discovery/Primary/ChildDiscoveredUserResource.php
+++ b/tests/Fixtures/Discovery/Primary/ChildDiscoveredUserResource.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Primary;
+
+/**
+ * Fixture child of an attributed resource without its own ForModel binding;
+ * class attributes are not inherited, so discovery must ignore it silently.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ChildDiscoveredUserResource extends DiscoveredUserResource {}

--- a/tests/Fixtures/Discovery/Primary/Contracts/AaContract.php
+++ b/tests/Fixtures/Discovery/Primary/Contracts/AaContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Primary\Contracts;
+
+/**
+ * Fixture interface sorted before the discoverable resources; the scan must
+ * pass over a file that declares no class and still discover the rest.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+interface AaContract {}

--- a/tests/Fixtures/Discovery/Primary/DiscoveredUserResource.php
+++ b/tests/Fixtures/Discovery/Primary/DiscoveredUserResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Primary;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture resource discovered via the ForModel attribute.
+ *
+ * @inheritable Extended by a child fixture proving attributes are not
+ *              inherited by subclasses.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(User::class)]
+class DiscoveredUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'discovered_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+        );
+    }
+}

--- a/tests/Fixtures/Discovery/Primary/Nested/DiscoveredPostResource.php
+++ b/tests/Fixtures/Discovery/Primary/Nested/DiscoveredPostResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Primary\Nested;
+
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use Tests\Fixtures\Models\Post;
+
+/**
+ * Fixture resource in a nested directory, proving recursive discovery.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+#[ForModel(Post::class)]
+final class DiscoveredPostResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'discovered_posts';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+        );
+    }
+}

--- a/tests/Fixtures/Discovery/Primary/PlainHelper.php
+++ b/tests/Fixtures/Discovery/Primary/PlainHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Discovery\Primary;
+
+/**
+ * Fixture class without the ForModel attribute; discovery must ignore it.
+ *
+ * The anonymous class exercises the tokenizer's anonymous-class skip when the
+ * file is scanned.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class PlainHelper
+{
+    /**
+     * Return a throwaway anonymous object.
+     *
+     * @return object
+     */
+    public function anonymous(): object
+    {
+        return new class {};
+    }
+}

--- a/tests/Integration/ApiServiceProviderTest.php
+++ b/tests/Integration/ApiServiceProviderTest.php
@@ -45,6 +45,8 @@ use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
 use SineMacula\ApiToolkit\Schema\Introspection\SchemaIntrospector;
 use SineMacula\ApiToolkit\Schema\Validation\SchemaValidator;
+use Tests\Fixtures\Discovery\Primary\Nested\DiscoveredPostResource;
+use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Resources\BrokenResource;
 use Tests\Fixtures\Resources\UserResource;
@@ -325,6 +327,63 @@ final class ApiServiceProviderTest extends TestCase
 
         // If we reach here the early-return executed without error.
         self::assertFalse((bool) $this->getConfig()->get('api-toolkit.notifications.enable_logging'));
+    }
+
+    /**
+     * Test that boot merges attribute-discovered resources beneath the
+     * configured resource map, with an explicit entry winning for its model.
+     *
+     * @return void
+     */
+    public function testBootMergesDiscoveredResourcesBeneathConfiguredMap(): void
+    {
+        $app = $this->getApplication();
+
+        $this->getConfig()->set('api-toolkit.resources.paths', [dirname(__DIR__) . '/Fixtures/Discovery/Primary']);
+        $this->getConfig()->set('api-toolkit.resources.resource_map', [
+            User::class => UserResource::class,
+        ]);
+
+        $provider = new ApiServiceProvider($app);
+        $provider->boot();
+
+        $map = $this->getConfig()->get('api-toolkit.resources.resource_map');
+
+        self::assertIsArray($map);
+        self::assertSame(UserResource::class, $map[User::class]);
+        self::assertSame(DiscoveredPostResource::class, $map[Post::class]);
+    }
+
+    /**
+     * Test that the discovery merge is skipped while the config cache is
+     * being built, so discovered bindings are never baked into the cached
+     * config as pseudo-explicit entries.
+     *
+     * @return void
+     */
+    public function testConfigCacheBuildSkipsTheDiscoveryMerge(): void
+    {
+        $app = $this->getApplication();
+
+        $this->getConfig()->set('api-toolkit.resources.paths', [dirname(__DIR__) . '/Fixtures/Discovery/Primary']);
+        $this->getConfig()->set('api-toolkit.resources.resource_map', [
+            User::class => UserResource::class,
+        ]);
+
+        $argv = $_SERVER['argv'] ?? null;
+
+        $_SERVER['argv'] = ['artisan', 'config:cache'];
+
+        try {
+            $provider = new ApiServiceProvider($app);
+            $provider->boot();
+        } finally {
+            $_SERVER['argv'] = $argv;
+        }
+
+        self::assertSame([
+            User::class => UserResource::class,
+        ], $this->getConfig()->get('api-toolkit.resources.resource_map'));
     }
 
     /**

--- a/tests/Integration/ResourceDiscoveryIntegrationTest.php
+++ b/tests/Integration/ResourceDiscoveryIntegrationTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiServiceProvider;
+use SineMacula\ApiToolkit\Http\Resources\PolymorphicResource;
+use SineMacula\ApiToolkit\Http\Resources\ResourceDiscovery;
+use Tests\Fixtures\Discovery\Primary\DiscoveredUserResource;
+use Tests\Fixtures\Discovery\Primary\Nested\DiscoveredPostResource;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Integration tests for attribute-based resource discovery at boot.
+ *
+ * Boots the service provider against the discovery fixtures and asserts the
+ * discovered bindings merge beneath the configured resource map (an explicit
+ * entry always wins), feed the dynamic morph map, and resolve end-to-end
+ * through polymorphic serialization.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiServiceProvider::class)]
+#[CoversClass(ResourceDiscovery::class)]
+final class ResourceDiscoveryIntegrationTest extends TestCase
+{
+    /**
+     * Test that discovered bindings merge beneath the configured resource
+     * map: an explicit entry wins for its model while discovered bindings
+     * fill the rest.
+     *
+     * @return void
+     */
+    public function testDiscoveredBindingsMergeBeneathConfiguredMap(): void
+    {
+        $this->configureDiscovery(map: [User::class => UserResource::class]);
+
+        $this->bootProvider();
+
+        $map = config('api-toolkit.resources.resource_map');
+
+        self::assertIsArray($map);
+        self::assertSame(UserResource::class, $map[User::class]);
+        self::assertSame(DiscoveredPostResource::class, $map[Post::class]);
+    }
+
+    /**
+     * Test that with no configured map at all, discovery alone populates the
+     * resource map - a consumer can omit the config entirely.
+     *
+     * @return void
+     */
+    public function testDiscoveryAlonePopulatesTheResourceMap(): void
+    {
+        $this->configureDiscovery();
+
+        $this->bootProvider();
+
+        self::assertSame([
+            User::class => DiscoveredUserResource::class,
+            Post::class => DiscoveredPostResource::class,
+        ], config('api-toolkit.resources.resource_map'));
+    }
+
+    /**
+     * Test that discovered bindings feed the dynamic morph map.
+     *
+     * @return void
+     */
+    public function testDiscoveredBindingsFeedTheMorphMap(): void
+    {
+        $this->configureDiscovery();
+
+        $this->bootProvider();
+
+        $morphMap = Relation::morphMap();
+
+        self::assertSame(User::class, $morphMap['discovered_users']);
+        self::assertSame(Post::class, $morphMap['discovered_posts']);
+    }
+
+    /**
+     * Test that a discovered binding resolves end-to-end through polymorphic
+     * serialization without any resource_map entry.
+     *
+     * @return void
+     */
+    public function testDiscoveredBindingResolvesPolymorphically(): void
+    {
+        $this->configureDiscovery();
+
+        $this->bootProvider();
+
+        $user = User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+
+        $data = (new PolymorphicResource($user))->toArray(Request::create('/test'));
+
+        self::assertIsArray($data);
+        self::assertSame('discovered_users', $data['_type']);
+    }
+
+    /**
+     * Test that boot leaves the resource map untouched when nothing is
+     * discovered.
+     *
+     * @return void
+     */
+    public function testBootLeavesMapUntouchedWhenNothingIsDiscovered(): void
+    {
+        $this->configureDiscovery(paths: [], map: [User::class => UserResource::class]);
+
+        $this->bootProvider();
+
+        self::assertSame([
+            User::class => UserResource::class,
+        ], config('api-toolkit.resources.resource_map'));
+    }
+
+    /**
+     * Configure the discovery paths and resource map for the test.
+     *
+     * @param  array<int, string>|null  $paths
+     * @param  array<class-string, class-string>  $map
+     * @return void
+     */
+    private function configureDiscovery(?array $paths = null, array $map = []): void
+    {
+        config()->set('api-toolkit.resources.paths', $paths ?? [dirname(__DIR__) . '/Fixtures/Discovery/Primary']);
+        config()->set('api-toolkit.resources.resource_map', $map);
+        config()->set('api-toolkit.resources.enable_dynamic_morph_mapping', true);
+    }
+
+    /**
+     * Re-boot the service provider so discovery runs against the configured
+     * environment.
+     *
+     * @return void
+     */
+    private function bootProvider(): void
+    {
+        assert($this->app !== null);
+
+        (new ApiServiceProvider($this->app))->boot();
+    }
+}

--- a/tests/Unit/Enums/CacheKeysTest.php
+++ b/tests/Unit/Enums/CacheKeysTest.php
@@ -33,6 +33,7 @@ final class CacheKeysTest extends TestCase
         yield 'MODEL_SCHEMA_COLUMN_DEFINITIONS' => [CacheKeys::MODEL_SCHEMA_COLUMN_DEFINITIONS, 'model-schema-column-definitions:%s'];
         yield 'MODEL_RELATIONS' => [CacheKeys::MODEL_RELATIONS, 'model-relations:%s:%s'];
         yield 'MODEL_RESOURCES' => [CacheKeys::MODEL_RESOURCES, 'model-resources:%s'];
+        yield 'DISCOVERED_RESOURCES' => [CacheKeys::DISCOVERED_RESOURCES, 'discovered-resources:%s'];
         yield 'REPOSITORY_CACHE' => [CacheKeys::REPOSITORY_CACHE, 'repository-cache:%s'];
         yield 'REPOSITORY_CACHE_META' => [CacheKeys::REPOSITORY_CACHE_META, 'repository-cache-meta:%s'];
         yield 'REPOSITORY_QUERY_CACHE' => [CacheKeys::REPOSITORY_QUERY_CACHE, 'repository-query:%s:%s'];
@@ -118,6 +119,6 @@ final class CacheKeysTest extends TestCase
      */
     public function testExpectedCaseCount(): void
     {
-        self::assertCount(9, CacheKeys::cases());
+        self::assertCount(10, CacheKeys::cases());
     }
 }

--- a/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
+++ b/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
@@ -1,0 +1,549 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Attributes\ForModel;
+use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
+use SineMacula\ApiToolkit\Enums\CacheKeys;
+use SineMacula\ApiToolkit\Http\Resources\ResourceDiscovery;
+use Tests\Fixtures\Discovery\Conflict\FirstUserResource;
+use Tests\Fixtures\Discovery\Multi\MultiModelResource;
+use Tests\Fixtures\Discovery\Primary\DiscoveredUserResource;
+use Tests\Fixtures\Discovery\Primary\Nested\DiscoveredPostResource;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Tests for the attribute-based resource discovery.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ResourceDiscovery::class)]
+#[CoversClass(ForModel::class)]
+final class ResourceDiscoveryTest extends TestCase
+{
+    /**
+     * Test that attributed resources are discovered recursively from the
+     * configured paths, in deterministic sorted-file order, while classes
+     * without the attribute are ignored.
+     *
+     * @return void
+     */
+    public function testDiscoversAttributedResourcesRecursively(): void
+    {
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Primary')]);
+
+        self::assertSame([
+            User::class => DiscoveredUserResource::class,
+            Post::class => DiscoveredPostResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that an invalid binding - a non-resource class, an abstract
+     * resource, or a resource whose model does not exist - is skipped with a
+     * warning and never joins the map.
+     *
+     * @return void
+     */
+    public function testInvalidBindingsAreSkippedWithAWarning(): void
+    {
+        Log::shouldReceive('warning')->times(3);
+
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Invalid')]);
+
+        self::assertSame([], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that when two resources claim the same model the first discovered
+     * binding wins and the conflict is logged.
+     *
+     * @return void
+     */
+    public function testConflictKeepsFirstDiscoveredBindingAndWarns(): void
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(static fn (string $message): bool => str_contains($message, 'multiple resources')
+                && str_contains($message, 'ignoring [Tests\Fixtures\Discovery\Conflict\SecondUserResource]. Declare the canonical resource'));
+
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Conflict')]);
+
+        self::assertSame([
+            User::class => FirstUserResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that a model conflict fails hard when schema validation is enabled.
+     *
+     * @return void
+     */
+    public function testConflictFailsHardUnderSchemaValidation(): void
+    {
+        Config::set('api-toolkit.resources.validate_schemas', true);
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Conflict')]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/ignoring \[Tests\\\Fixtures\\\Discovery\\\Conflict\\\SecondUserResource\]\. Declare the canonical resource/');
+
+        $this->discovery()->discover();
+    }
+
+    /**
+     * Test that overlapping configured paths do not duplicate a binding or
+     * produce a spurious conflict.
+     *
+     * @return void
+     */
+    public function testOverlappingPathsAreDeduplicated(): void
+    {
+        Log::shouldReceive('warning')->never();
+
+        Config::set('api-toolkit.resources.paths', [
+            $this->fixturePath('Primary'),
+            $this->fixturePath('Primary/Nested'),
+        ]);
+
+        self::assertSame([
+            User::class => DiscoveredUserResource::class,
+            Post::class => DiscoveredPostResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that files are visited in sorted order across the configured
+     * paths, so the first-discovered-wins conflict rule is deterministic
+     * regardless of path order.
+     *
+     * The Conflict directory sorts before Primary, so its resource must win
+     * the User binding even though Primary is configured first.
+     *
+     * @return void
+     */
+    public function testFilesAreVisitedInSortedOrderAcrossPaths(): void
+    {
+        Log::shouldReceive('warning')->times(2);
+
+        Config::set('api-toolkit.resources.paths', [
+            $this->fixturePath('Primary'),
+            $this->fixturePath('Conflict'),
+        ]);
+
+        self::assertSame([
+            User::class => FirstUserResource::class,
+            Post::class => DiscoveredPostResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that a configured path that does not exist is skipped without
+     * error.
+     *
+     * @return void
+     */
+    public function testMissingPathIsSkipped(): void
+    {
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('DoesNotExist')]);
+
+        self::assertSame([], $this->discovery()->discover());
+
+        // An empty path set must not touch the metadata cache at all.
+        self::assertFalse(Cache::has(CacheKeys::DISCOVERED_RESOURCES->resolveKey([md5('')])));
+    }
+
+    /**
+     * Test that a malformed paths value - not an array, or containing
+     * non-string entries - yields no discovery.
+     *
+     * @return void
+     */
+    public function testMalformedPathsConfigurationYieldsNoDiscovery(): void
+    {
+        Config::set('api-toolkit.resources.paths', 'not-an-array');
+
+        self::assertSame([], $this->discovery()->discover());
+
+        Config::set('api-toolkit.resources.paths', [123, null, ['nested']]);
+
+        self::assertSame([], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that the compiled map is memoised through the metadata cache: a
+     * warm cache entry for the scanned file fingerprint is returned without
+     * rescanning the filesystem.
+     *
+     * @return void
+     */
+    public function testCompiledMapIsMemoisedThroughTheMetadataCache(): void
+    {
+        $path = $this->fixturePath('Primary');
+
+        Config::set('api-toolkit.resources.paths', [$path]);
+
+        $sentinel = [User::class => FirstUserResource::class];
+
+        Cache::forever($this->discoveryCacheKey([$path]), $sentinel);
+
+        self::assertSame($sentinel, $this->discovery()->discover());
+    }
+
+    /**
+     * Test that the discovery cache key is registered with the metadata key
+     * registry, so the scoped lifecycle flush can forget it.
+     *
+     * @return void
+     */
+    public function testDiscoveryKeyIsRegisteredForTheScopedFlush(): void
+    {
+        assert($this->app !== null);
+
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Primary')]);
+
+        $this->discovery()->discover();
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataKeyRegistry $registry */
+        $registry = $this->app->make(MetadataKeyRegistry::class);
+
+        $registered = array_filter(
+            $registry->keys(),
+            static fn (string $key): bool => str_contains($key, 'discovered-resources:'),
+        );
+
+        self::assertNotEmpty($registered);
+    }
+
+    /**
+     * Test that a repeated ForModel attribute binds one resource to several
+     * models.
+     *
+     * @return void
+     */
+    public function testRepeatedAttributeBindsMultipleModels(): void
+    {
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Multi')]);
+
+        self::assertSame([
+            User::class => MultiModelResource::class,
+            Post::class => MultiModelResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that a model conflict is not diagnosed when the model is declared
+     * explicitly in the resource map: the explicit entry resolves the
+     * ambiguity, so no warning is logged and schema validation does not fail
+     * the scan.
+     *
+     * @return void
+     */
+    public function testConflictIsSuppressedWhenModelDeclaredExplicitly(): void
+    {
+        Log::shouldReceive('warning')->never();
+
+        Config::set('api-toolkit.resources.validate_schemas', true);
+        Config::set('api-toolkit.resources.resource_map', [User::class => UserResource::class]);
+        Config::set('api-toolkit.resources.paths', [$this->fixturePath('Conflict')]);
+
+        self::assertSame([
+            User::class => FirstUserResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that two scanned files declaring the same class produce a single
+     * binding silently - a duplicate file is not an ambiguity.
+     *
+     * @return void
+     */
+    public function testDuplicateDeclarationsOfTheSameClassAreSkippedSilently(): void
+    {
+        Log::shouldReceive('warning')->never();
+
+        $directory = sys_get_temp_dir() . '/resource-discovery-' . uniqid((string) getmypid(), true);
+
+        mkdir($directory, 0o755, true);
+
+        $contents = file_get_contents($this->fixturePath('Conflict') . '/FirstUserResource.php');
+
+        assert($contents !== false);
+
+        file_put_contents($directory . '/CopyOne.php', $contents);
+        file_put_contents($directory . '/CopyTwo.php', $contents);
+
+        try {
+            Config::set('api-toolkit.resources.paths', [$directory]);
+
+            self::assertSame([
+                User::class => FirstUserResource::class,
+            ], $this->discovery()->discover());
+        } finally {
+            unlink($directory . '/CopyOne.php');
+            unlink($directory . '/CopyTwo.php');
+            rmdir($directory);
+        }
+    }
+
+    /**
+     * Test that enabling schema validation bypasses the metadata cache, so
+     * every diagnostic runs on every boot.
+     *
+     * @return void
+     */
+    public function testSchemaValidationBypassesTheCache(): void
+    {
+        $path = $this->fixturePath('Primary');
+
+        Config::set('api-toolkit.resources.validate_schemas', true);
+        Config::set('api-toolkit.resources.paths', [$path]);
+
+        Cache::forever($this->discoveryCacheKey([$path]), [User::class => FirstUserResource::class]);
+
+        self::assertSame([
+            User::class => DiscoveredUserResource::class,
+            Post::class => DiscoveredPostResource::class,
+        ], $this->discovery()->discover());
+    }
+
+    /**
+     * Test that changing a scanned file rotates the cache key, so the next
+     * boot rescans instead of serving the stale map.
+     *
+     * @return void
+     */
+    public function testFileChangeRotatesTheCacheKey(): void
+    {
+        $directory = sys_get_temp_dir() . '/resource-discovery-' . uniqid((string) getmypid(), true);
+
+        mkdir($directory, 0o755, true);
+
+        $contents = file_get_contents($this->fixturePath('Primary') . '/DiscoveredUserResource.php');
+
+        assert($contents !== false);
+
+        $file = $directory . '/DiscoveredUserResource.php';
+
+        file_put_contents($file, $contents);
+
+        try {
+            Config::set('api-toolkit.resources.paths', [$directory]);
+
+            $sentinel = [User::class => FirstUserResource::class];
+
+            Cache::forever($this->discoveryCacheKey([$directory]), $sentinel);
+
+            // The warm entry for the current fingerprint is served as-is.
+            self::assertSame($sentinel, $this->discovery()->discover());
+
+            touch($file, time() + 10);
+            clearstatcache();
+
+            // The touched file rotates the key, forcing a fresh scan.
+            self::assertSame([
+                User::class => DiscoveredUserResource::class,
+            ], $this->discovery()->discover());
+        } finally {
+            unlink($file);
+            rmdir($directory);
+        }
+    }
+
+    /**
+     * Test that a published config predating the paths key falls back to the
+     * default application resource directory rather than silently disabling
+     * discovery.
+     *
+     * The scan is observed through its cache write rather than a binding, so
+     * the transient file cannot leak a discovery into concurrently booting
+     * tests: the class it declares is not autoloadable.
+     *
+     * @return void
+     */
+    public function testMissingPathsKeyFallsBackToTheDefaultDirectory(): void
+    {
+        $resources = Config::get('api-toolkit.resources');
+
+        assert(is_array($resources));
+
+        unset($resources['paths']);
+
+        Config::set('api-toolkit.resources', $resources);
+
+        $directory = app_path('Http/Resources');
+        $created   = !is_dir($directory);
+
+        if ($created) {
+            mkdir($directory, 0o755, true);
+        }
+
+        $file = $directory . '/FallbackProbe.php';
+
+        file_put_contents($file, "<?php\n\nnamespace Ghost\\Discovery;\n\nclass FallbackProbe {}\n");
+
+        try {
+            self::assertSame([], $this->discovery()->discover());
+
+            // The default path was scanned: the fingerprint key was written.
+            self::assertTrue(Cache::has($this->discoveryCacheKey([$directory])));
+        } finally {
+            unlink($file);
+
+            if ($created) {
+                rmdir($directory);
+            }
+        }
+    }
+
+    /**
+     * Test that every declared class in a multi-class, multi-namespace file
+     * is considered: both attributed resources bind, and a trailing
+     * unloadable class is skipped without disturbing the bindings already
+     * made.
+     *
+     * @return void
+     */
+    public function testEveryClassInAMultiClassFileIsDiscovered(): void
+    {
+        $directory = sys_get_temp_dir() . '/resource-discovery-' . uniqid((string) getmypid(), true);
+
+        mkdir($directory, 0o755, true);
+
+        $file = $directory . '/multi-class.php';
+
+        file_put_contents($file, implode("\n", [
+            '<?php',
+            'namespace Tests\Fixtures\Discovery\Primary;',
+            'class ZzUnloadableHelper {}',
+            'class DiscoveredUserResource {}',
+            'namespace Tests\Fixtures\Discovery\Primary\Nested;',
+            'class DiscoveredPostResource {}',
+            'namespace Ghost\Discovery;',
+            'class ZzTrailingGhost {}',
+        ]));
+
+        try {
+            Config::set('api-toolkit.resources.paths', [$directory]);
+
+            self::assertSame([
+                User::class => DiscoveredUserResource::class,
+                Post::class => DiscoveredPostResource::class,
+            ], $this->discovery()->discover());
+        } finally {
+            unlink($file);
+            rmdir($directory);
+        }
+    }
+
+    /**
+     * Test that a scanned file declaring no class, or declaring a class the
+     * autoloader cannot locate, is skipped without side effects.
+     *
+     * @return void
+     */
+    public function testFilesWithoutALoadableClassAreSkipped(): void
+    {
+        $directory = sys_get_temp_dir() . '/resource-discovery-' . uniqid((string) getmypid(), true);
+
+        mkdir($directory, 0o755, true);
+
+        $files = [
+            'functions.php'          => "<?php\n\nfunction resourceDiscoveryFixtureNoop(): void {}\n",
+            'ghost.php'              => "<?php\n\nnamespace Ghost\\Discovery;\n\nclass Ghost {}\n",
+            'global-class.php'       => "<?php\n\nclass ResourceDiscoveryGlobalFixture {}\n",
+            'dangling-class.php'     => '<?php class',
+            'trailing-namespace.php' => '<?php namespace ',
+            'braced-namespace.php'   => "<?php\n\nnamespace Ghost\\Braced {\n    class BracedGhost {}\n}\n",
+            'enum.php'               => "<?php\n\nnamespace Ghost\\Discovery;\n\nenum GhostShape {}\n",
+            'trait.php'              => "<?php\n\nnamespace Ghost\\Discovery;\n\ntrait GhostConcern {}\n",
+            'notes.txt'              => 'not a php file',
+        ];
+
+        foreach ($files as $name => $contents) {
+            file_put_contents($directory . '/' . $name, $contents);
+        }
+
+        try {
+            Config::set('api-toolkit.resources.paths', [$directory]);
+
+            self::assertSame([], $this->discovery()->discover());
+        } finally {
+            foreach (array_keys($files) as $name) {
+                unlink($directory . '/' . $name);
+            }
+
+            rmdir($directory);
+        }
+    }
+
+    /**
+     * Resolve the discovery service from the container.
+     *
+     * @return \SineMacula\ApiToolkit\Http\Resources\ResourceDiscovery
+     */
+    private function discovery(): ResourceDiscovery
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Http\Resources\ResourceDiscovery */
+        return $this->app->make(ResourceDiscovery::class);
+    }
+
+    /**
+     * Resolve the absolute path to a discovery fixture directory.
+     *
+     * @param  string  $directory
+     * @return string
+     */
+    private function fixturePath(string $directory): string
+    {
+        return dirname(__DIR__, 3) . '/Fixtures/Discovery/' . $directory;
+    }
+
+    /**
+     * Compute the discovery cache key for the given paths, mirroring the
+     * file-and-mtime fingerprint the service derives.
+     *
+     * @param  array<int, string>  $paths
+     * @return string
+     */
+    private function discoveryCacheKey(array $paths): string
+    {
+        $files = [];
+
+        foreach ($paths as $path) {
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            );
+
+            /** @var \SplFileInfo $file */
+            foreach ($iterator as $file) {
+
+                if ($file->getExtension() !== 'php' || $file->getRealPath() === false) {
+                    continue;
+                }
+
+                $files[] = $file->getRealPath();
+            }
+        }
+
+        sort($files);
+
+        $fingerprint = array_map(static fn (string $file): string => $file . ':' . (int) filemtime($file), $files);
+
+        return CacheKeys::DISCOVERED_RESOURCES->resolveKey([md5(implode('|', $fingerprint))]);
+    }
+}


### PR DESCRIPTION
## Summary

Removes the hand-maintained model-to-resource map. Resources under the configured `api-toolkit.resources.paths` (default `app/Http/Resources`) are discovered at boot: each class carrying `#[ForModel(Model::class)]` is compiled into the resource map automatically, and the attribute is repeatable to bind one resource to several models. The static `resource_map` stays as a narrow, on-merit override: the canonical-resource tiebreak when a model has more than one resource, and the binding seam for resources outside the scanned paths. All eight existing map consumers (morph maps, query surface, polymorphic resolution, schema validation, OpenAPI export, column narrowing, eager-load planning, repository resolution) are untouched - discovery merges beneath the config at boot, config always wins.

## Design notes

- **Attribute, not convention.** `#[ForModel]` keeps the binding a deliberate per-resource declaration, so the polymorphic exposure allowlist is never widened implicitly by file placement alone. (The attribute is named `ForModel` rather than `ApiResource` to avoid colliding with the base class every resource extends.)
- **Tokenised scan, no loading.** File contents are tokenised to derive FQCNs; files are never loaded, so stray, unloadable, multi-class, braced-namespace, enum, or trait files have no side effects. Multiple classes and multiple namespace statements per file are handled.
- **Fingerprinted memoisation.** The compiled map is memoised through the metadata cache under a key fingerprinted by the scanned file list and mtimes: adding, editing, or removing a resource rotates the key and triggers a rescan on the next boot - no manual cache clearing under php-fpm. The key registers with the metadata key registry for the scoped lifecycle flush.
- **Diagnostics that hold.** Conflicts keep the first binding in sorted file order (deterministic across path order) with a warning, or fail the boot under `validate_schemas` - which also bypasses the cache entirely so every diagnostic fires on every boot, and is suppressed when an explicit `resource_map` entry already resolves the ambiguity (making the prescribed remedy actually work). Duplicate declarations of the same class are silent. Invalid bindings (non-resource, abstract, missing model) are skipped with warnings.
- **Config cache safe.** The merge is skipped while `config:cache` is building, so discovered bindings are never baked into the cached config as pseudo-explicit entries. A published config predating the `paths` key falls back to the default directory rather than silently disabling discovery.

## Review

The diff went through a three-lens adversarial review (security, correctness, test-quality) with per-finding verification; all eleven confirmed findings are addressed in this PR (warm-cache validation bypass, php-fpm staleness, conflict-remedy contradiction, config:cache baking, multi-class files, repeated attributes, published-config fallback, registry pinning, non-inheritance coverage, tokenizer edge cases).

## Gates

- 2004 tests green (stable across 3 consecutive runs); 15 new discovery unit tests + 5 integration tests + provider boot tests
- qlty check / format / smells clean
- Diff-scoped mutation: 112/118 killed (94% covered MSI); the 6 survivors are verified equivalents (leading-backslash normalisation, whitespace-guaranteed token skips, readdir-order robustness)
- README documents the attribute as the primary binding mechanism