### PR TITLE
feat: resolve status-derived exception titles through translation keys

### DIFF
--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -106,4 +106,20 @@ return [
         'detail' => (is_string($name = config('app.name')) ? $name : 'The application') . ' is currently in maintenance mode, please try again a little later',
     ],
 
+    /*
+    |---------------------------------------------------------------------------
+    | Status-Derived Titles
+    |---------------------------------------------------------------------------
+    |
+    | Titles for the generic HTTP error path are derived from the HTTP status
+    | enum case name by default. Publish per-status overrides here to localise
+    | them, keyed by status code (e.g. 404 => 'Introuvable'). The unknown key
+    | covers exceptions whose status has no enum case.
+    |
+    */
+
+    'http' => [
+        'unknown' => 'Unknown Error',
+    ],
+
 ];

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -192,17 +192,26 @@ abstract class ApiException extends \Exception
     }
 
     /**
-     * Derive a human-readable title from the HTTP status enum case name.
+     * Derive a human-readable title from the HTTP status.
      *
-     * Falls back to a generic title for exceptions whose status has no
-     * corresponding enum case, ensuring rendering never fails for a missing
-     * title.
+     * A per-status translation (`exceptions.http.{status}`, or
+     * `exceptions.http.unknown` when the status has no enum case) is consulted
+     * first so the generic path can be localised; otherwise the title is
+     * derived from the status enum case name, with a generic literal fallback
+     * ensuring rendering never fails for a missing title.
      *
      * @return string
      */
     private function getDefaultTitle(): string
     {
         $status = $this->getStatus();
+        $key    = sprintf('%s::exceptions.http.%s', $this->getNamespace(), $status->value ?? 'unknown');
+
+        if (Lang::has($key)) {
+            $translation = Lang::get($key);
+
+            return is_string($translation) ? $translation : '';
+        }
 
         if ($status === null) {
             return 'Unknown Error';

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Enums\ErrorCode;
 use SineMacula\ApiToolkit\Exceptions\ApiException;
 use SineMacula\ApiToolkit\Exceptions\BadRequestException;
+use SineMacula\ApiToolkit\Exceptions\HttpException;
 use SineMacula\Http\Enums\HttpStatus;
 
 /**
@@ -373,6 +374,80 @@ final class ApiExceptionTest extends TestCase
         };
 
         self::assertSame('Unavailable For Legal Reasons', $exception->getCustomTitle());
+    }
+
+    /**
+     * Test that a published per-status translation localises the derived
+     * title for the generic HTTP error path.
+     *
+     * @return void
+     */
+    public function testGetCustomTitleUsesPerStatusTranslationWhenPublished(): void
+    {
+        Lang::addLines(['exceptions.http.451' => 'Statutairement Indisponible'], 'en', 'api-toolkit');
+
+        $exception = new HttpException(HttpStatus::UNAVAILABLE_FOR_LEGAL_REASONS);
+
+        self::assertSame('Statutairement Indisponible', $exception->getCustomTitle());
+    }
+
+    /**
+     * Test that an exception whose status has no enum case resolves its title
+     * through the unknown-status translation key, which a published lang file
+     * can localise.
+     *
+     * @return void
+     */
+    public function testGetCustomTitleResolvesUnknownStatusThroughTranslationKey(): void
+    {
+        $exception = new class extends ApiException {
+            /** The internal error code for the test exception. */
+            public const \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface CODE = ErrorCode::HTTP_ERROR;
+
+            /**
+             * Get the HTTP status code for this exception instance.
+             *
+             * @return int
+             */
+            #[\Override]
+            public function getStatusCode(): int
+            {
+                return 419;
+            }
+
+            /**
+             * Get the HTTP status for this exception instance.
+             *
+             * @return \SineMacula\Http\Enums\HttpStatus|null
+             */
+            #[\Override]
+            public function getStatus(): ?HttpStatus
+            {
+                return null;
+            }
+        };
+
+        // The shipped lang file resolves the unknown-status key.
+        self::assertSame('Unknown Error', $exception->getCustomTitle());
+
+        Lang::addLines(['exceptions.http.unknown' => 'Erreur Inconnue'], 'en', 'api-toolkit');
+
+        self::assertSame('Erreur Inconnue', $exception->getCustomTitle());
+    }
+
+    /**
+     * Test that a non-string per-status translation yields an empty title
+     * rather than an error, matching the code-keyed title guard.
+     *
+     * @return void
+     */
+    public function testGetCustomTitleReturnsEmptyStringForNonStringStatusTranslation(): void
+    {
+        Lang::addLines(['exceptions.http.451' => ['nested' => 'value']], 'en', 'api-toolkit');
+
+        $exception = new HttpException(HttpStatus::UNAVAILABLE_FOR_LEGAL_REASONS);
+
+        self::assertSame('', $exception->getCustomTitle());
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes the last localisation gap on the client-facing error surface. Every code-keyed `title`/`detail` already resolves through `api-toolkit::exceptions.{code}.*` translation keys, but the generic HTTP error path (e.g. `abort(409)`) derived its title from the HTTP status enum case name in hard-coded English, and the unknown-status fallback was a literal - neither could be localised by publishing the lang file.

`ApiException::getDefaultTitle()` now consults `exceptions.http.{status}` (or `exceptions.http.unknown` when the status has no enum case) before deriving from the enum name. The shipped lang file adds the `unknown` key; per-status keys are deliberately not shipped - the enum-derived English phrase is already the correct default, so consumers add per-status entries only to override or translate (e.g. `404 => 'Introuvable'`). The literal fallback remains as a last resort so rendering never fails when a published lang file predates the key.

## Behaviour

- Default output is byte-identical to before (existing rendering tests unchanged).
- Publishing `lang/vendor/api-toolkit` can now localise the generic-status titles and the unknown-status title.
- Non-string translations yield an empty title, matching the code-keyed guard.

## Gates

- 2007 tests green (4 consecutive full-suite runs); 3 new unit tests covering the per-status override, the unknown-key resolution + override, and the non-string guard
- qlty check / format clean
- Diff-scoped mutation: 4/4 killed (100% MSI)