### PR TITLE
perf: memoise assembled field lists across a homogeneous collection

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
 use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
@@ -57,6 +58,7 @@ final class CacheManager
         SchemaCompiler::clearCache();
         ValueResolver::clearCache();
         EagerLoadPlanner::clearCache();
+        FieldResolver::clearCache();
         FieldColumnMapper::clearCache();
 
         $this->container->make(SchemaIntrospectionProvider::class)->flush();

--- a/src/Http/Resources/Concerns/FieldResolver.php
+++ b/src/Http/Resources/Concerns/FieldResolver.php
@@ -17,9 +17,14 @@ use SineMacula\ApiToolkit\Schema\CompiledSchema;
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
+ *
+ * @managed-static
  */
 final class FieldResolver
 {
+    /** @var array<string, array<int, string>> Memo of assembled field lists, keyed by a fingerprint of the assembly inputs. */
+    private static array $resolvedCache = [];
+
     /** @var array<int, string>|null Explicit list of fields to be returned */
     private ?array $fields = null;
 
@@ -80,14 +85,33 @@ final class FieldResolver
             ? $schema->getFieldKeys()
             : (ApiQuery::getFields($resourceType) ?? $defaultFields);
 
-        $resolved = array_diff($this->fields, $this->excludedFields ?? []);
+        $excluded = $this->excludedFields ?? [];
 
         /** @var array<int, string> $configFixed */
         $configFixed = Config::get('api-toolkit.resources.fixed_fields', []);
-        $allFixed    = array_merge($configFixed, $fixedFields);
-        $merged      = array_merge($resolved, $allFixed);
 
-        return array_values(array_unique($merged));
+        // Memoise the assembled list keyed by a fingerprint of the exact inputs
+        // to the assembly, so a homogeneous collection page assembles it once
+        // instead of per row. The key fully determines the output, so a hit can
+        // only occur for identical inputs; the memo is request-scoped, cleared
+        // by CacheManager::flush() at request and worker boundaries.
+        $key = self::cacheKey($this->fields, $excluded, $configFixed, $fixedFields);
+
+        return self::$resolvedCache[$key] ??= array_values(array_unique(
+            array_merge(array_diff($this->fields, $excluded), $configFixed, $fixedFields),
+        ));
+    }
+
+    /**
+     * Clear the static assembled-field memo.
+     *
+     * Invoked by CacheManager::flush() at request and worker boundaries.
+     *
+     * @return void
+     */
+    public static function clearCache(): void
+    {
+        self::$resolvedCache = [];
     }
 
     /**
@@ -150,6 +174,25 @@ final class FieldResolver
     public function shouldIncludeAveragesField(string $resourceType, array $defaultFields): bool
     {
         return $this->shouldIncludeVirtualField('averages', $resourceType, $defaultFields);
+    }
+
+    /**
+     * Build the memo key fingerprinting the field-assembly inputs.
+     *
+     * @param  array<int, string>  $fields
+     * @param  array<int, string>  $excluded
+     * @param  array<int, string>  $configFixed
+     * @param  array<int, string>  $fixedFields
+     * @return string
+     */
+    private static function cacheKey(array $fields, array $excluded, array $configFixed, array $fixedFields): string
+    {
+        return implode('|', [
+            implode("\0", $fields),
+            implode("\0", $excluded),
+            implode("\0", $configFixed),
+            implode("\0", $fixedFields),
+        ]);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use SineMacula\ApiToolkit\ApiServiceProvider;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
 use Tests\Fixtures\Support\FunctionOverrides;
 
 /**
@@ -42,6 +43,8 @@ abstract class TestCase extends OrchestraTestCase
     protected function tearDown(): void
     {
         FunctionOverrides::reset();
+
+        FieldResolver::clearCache();
 
         Relation::morphMap([], false);
         Relation::requireMorphMap(false);

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -13,6 +13,7 @@ use SineMacula\ApiToolkit\Cache\MetadataKeyRegistry;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
 use SineMacula\ApiToolkit\Events\CacheFlushed;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
 use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
@@ -126,6 +127,28 @@ final class CacheManagerTest extends TestCase
 
         // Assert
         self::assertSame([], $this->getStaticProperty(EagerLoadPlanner::class, 'eagerLoadCache'));
+    }
+
+    /**
+     * Test that flush clears the FieldResolver assembled-field memo.
+     *
+     * @return void
+     */
+    public function testFlushClearsFieldResolverCache(): void
+    {
+        // Arrange
+        Event::fake();
+
+        $this->setStaticProperty(FieldResolver::class, 'resolvedCache', ['name\0email|||' => ['name', 'email']]);
+
+        self::assertNotEmpty($this->getStaticProperty(FieldResolver::class, 'resolvedCache'));
+
+        // Act
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        self::assertSame([], $this->getStaticProperty(FieldResolver::class, 'resolvedCache'));
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/FieldResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/FieldResolverTest.php
@@ -9,6 +9,7 @@ use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
 use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledSchema;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\TestCase;
 
 /**
@@ -22,6 +23,8 @@ use Tests\TestCase;
 #[CoversClass(FieldResolver::class)]
 final class FieldResolverTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /** @var \SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver */
     private FieldResolver $resolver;
 
@@ -36,6 +39,127 @@ final class FieldResolverTest extends TestCase
         parent::setUp();
 
         $this->resolver = new FieldResolver;
+    }
+
+    /**
+     * Test that the assembled field list is memoised across resolver instances,
+     * so a homogeneous collection assembles it once rather than per row.
+     *
+     * @return void
+     */
+    public function testGetFieldsMemoisesTheAssembledListAcrossInstances(): void
+    {
+        config()->set('api-toolkit.resources.fixed_fields', []);
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['name', 'email']);
+
+        $schema = new CompiledSchema([], []);
+
+        $first = (new FieldResolver)->getFields($schema, 'users', ['name', 'email'], []);
+
+        // Tamper the single cached entry so a second resolver with identical
+        // inputs can only return the assembled list if it reads the memo.
+        /** @var array<string, array<int, string>> $cache */
+        $cache = $this->getStaticProperty(FieldResolver::class, 'resolvedCache');
+        $this->setStaticProperty(FieldResolver::class, 'resolvedCache', [array_key_first($cache) => ['sentinel']]);
+
+        $second = (new FieldResolver)->getFields($schema, 'users', ['name', 'email'], []);
+
+        self::assertSame(['name', 'email'], $first);
+        self::assertSame(['sentinel'], $second);
+    }
+
+    /**
+     * Test that excluded fields form part of the memo key, so a resolver that
+     * excludes a field is never handed a list cached for one that kept it.
+     *
+     * @return void
+     */
+    public function testExcludedFieldsAreDistinguishedInTheMemo(): void
+    {
+        config()->set('api-toolkit.resources.fixed_fields', []);
+
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(null);
+
+        $schema = new CompiledSchema([], []);
+
+        $full = (new FieldResolver)->getFields($schema, 'users', ['name', 'email'], []);
+
+        $resolver = new FieldResolver;
+        $resolver->withoutFields(['email']);
+        $trimmed = $resolver->getFields($schema, 'users', ['name', 'email'], []);
+
+        self::assertSame(['name', 'email'], $full);
+        self::assertSame(['name'], $trimmed);
+    }
+
+    /**
+     * Test that the resolved base fields form part of the memo key, so two
+     * resolvers with different field sets never share a cached list.
+     *
+     * @return void
+     */
+    public function testBaseFieldsAreDistinguishedInTheMemo(): void
+    {
+        config()->set('api-toolkit.resources.fixed_fields', []);
+
+        ApiQuery::shouldReceive('getFields')->andReturn(null);
+
+        $schema = new CompiledSchema([], []);
+
+        $name  = (new FieldResolver)->getFields($schema, 'users', ['name'], []);
+        $title = (new FieldResolver)->getFields($schema, 'users', ['title'], []);
+
+        self::assertSame(['name'], $name);
+        self::assertSame(['title'], $title);
+    }
+
+    /**
+     * Test that the configured fixed fields form part of the memo key, so a
+     * change to the fixed-field config is reflected in the assembled list.
+     *
+     * @return void
+     */
+    public function testConfigFixedFieldsAreDistinguishedInTheMemo(): void
+    {
+        ApiQuery::shouldReceive('getFields')->with('users')->andReturn(null);
+
+        $schema = new CompiledSchema([], []);
+
+        config()->set('api-toolkit.resources.fixed_fields', ['id']);
+        $withId = (new FieldResolver)->getFields($schema, 'users', ['name'], []);
+
+        config()->set('api-toolkit.resources.fixed_fields', ['uuid']);
+        $withUuid = (new FieldResolver)->getFields($schema, 'users', ['name'], []);
+
+        self::assertSame(['name', 'id'], $withId);
+        self::assertSame(['name', 'uuid'], $withUuid);
+    }
+
+    /**
+     * Test that the per-resource fixed fields form part of the memo key, so a
+     * resource contributing its own fixed field is not handed a cached list
+     * assembled without it.
+     *
+     * @return void
+     */
+    public function testFixedFieldParameterIsDistinguishedInTheMemo(): void
+    {
+        config()->set('api-toolkit.resources.fixed_fields', []);
+
+        ApiQuery::shouldReceive('getFields')->with('users')->andReturn(null);
+
+        $schema = new CompiledSchema([], []);
+
+        $plain    = (new FieldResolver)->getFields($schema, 'users', ['name'], []);
+        $withUuid = (new FieldResolver)->getFields($schema, 'users', ['name'], ['uuid']);
+
+        self::assertSame(['name'], $plain);
+        self::assertSame(['name', 'uuid'], $withUuid);
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements the remaining part of the deferred field-resolution performance item. On a list endpoint the toolkit builds one resource object per row and each independently reassembled its response field list (`array_diff` against exclusions, merge fixed fields, dedupe) even though a homogeneous page yields the same list every time. `FieldResolver::getFields()` now memoises the assembled list in a static cache so a page assembles it once.

## Correctness (the whole point)

The memo key is a fingerprint of the **exact four inputs** to the assembly: the resolved fields, the exclusions, the configured fixed fields, and the per-resource fixed fields. Because the key fully determines the output, a cache hit can only ever occur for identical inputs - there is no path to returning the wrong fields for a row. This needs no request-scoping or flush-timing coupling to be correct; the memo is registered with `CacheManager::flush()` (managed-static, cleared at request/worker boundaries) purely for memory bounding, and cleared between test cases for order-independence.

Every dimension of the key is proven load-bearing by a dedicated test (a resolver that differs only in base fields, only in exclusions, only in configured fixed fields, or only in the per-resource fixed field never shares a cached list), plus a memoisation test that tampers the cache and asserts the tampered value is returned on an identical-input hit.

## What was left out, and why

The same backlog note also suggested hoisting the default-order sort comparator to a static. I dropped it: the ordering weights are arbitrary (only their relative order matters, and `id`/`_type` carry empty-string tiebreaks), so mutating a weight changes no output - it produced only equivalent mutants for a negligible per-row saving, which would have dragged the diff mutation gate down for no real correctness value.

## Honest note on impact

This is the low-priority, deferred item it was flagged as: the win is modest at the default page cap of 100. It is correct-by-construction and paid for in code, but only materially helps if `max_limit` is raised well beyond 100.

## Gates

- 1896 tests green, stable across repeated full runs (order-independent under the static memo)
- `composer check` / `format` / `smells` clean on coding-standards v1.9.2
- Diff-scoped mutation 13/13 killed (100% MSI)