### PR TITLE
test: real-usage + efficiency coverage (P1), and fix the maintenance except bypass

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
         <testsuite name="Integration">
             <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -98,7 +98,7 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
             $schema,
             static::getResourceType(),
             static::getDefaultFields(),
-            $this->getFixedFields(),
+            $this->fixed,
         );
 
         foreach ($fields as $field) {
@@ -381,31 +381,26 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
      */
     private function loadMissingAggregates(object $resource): void
     {
-        $resourceType      = static::getResourceType();
-        $requestedSums     = ApiQuery::getSums($resourceType)     ?? [];
-        $requestedAverages = ApiQuery::getAverages($resourceType) ?? [];
+        $resourceType  = static::getResourceType();
+        $defaultFields = static::getDefaultFields();
 
-        if (method_exists($resource, 'loadSum') && $this->fieldResolver->shouldIncludeSumsField($resourceType, static::getDefaultFields())) {
-            foreach (EagerLoadPlanner::buildSumMap(static::class, $requestedSums) as $entry) {
+        if (method_exists($resource, 'loadSum') && $this->fieldResolver->shouldIncludeSumsField($resourceType, $defaultFields)) {
+            $sums = $this->rejectLoadedAggregates($resource, EagerLoadPlanner::buildSumMap(static::class, ApiQuery::getSums($resourceType) ?? []));
 
-                if ($this->isAggregateLoaded($resource, $entry['relation'])) {
-                    continue;
-                }
-
+            foreach ($sums as $entry) {
+                // @var array<string, mixed> $entry
                 $resource->loadSum($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
             }
         }
 
-        if (!method_exists($resource, 'loadAvg') || !$this->fieldResolver->shouldIncludeAveragesField($resourceType, static::getDefaultFields())) {
+        if (!method_exists($resource, 'loadAvg') || !$this->fieldResolver->shouldIncludeAveragesField($resourceType, $defaultFields)) {
             return;
         }
 
-        foreach (EagerLoadPlanner::buildAvgMap(static::class, $requestedAverages) as $entry) {
+        $averages = $this->rejectLoadedAggregates($resource, EagerLoadPlanner::buildAvgMap(static::class, ApiQuery::getAverages($resourceType) ?? []));
 
-            if ($this->isAggregateLoaded($resource, $entry['relation'])) {
-                continue;
-            }
-
+        foreach ($averages as $entry) {
+            // @var array<string, mixed> $entry
             $resource->loadAvg($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
         }
     }
@@ -415,7 +410,9 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
      *
      * The criteria pre-loads counts and aggregates on the base query, so a
      * per-row load would re-run them; unlike loadMissing() for relations, the
-     * load{Count,Sum,Avg} helpers are not idempotent, so filter them here.
+     * load{Count,Sum,Avg} helpers are not idempotent, so filter them here. The
+     * spec is read from a count entry (string, or aliased key with a closure)
+     * or from an aggregate entry's relation.
      *
      * @param  object  $resource
      * @param  array<int|string, mixed>  $specifications
@@ -423,41 +420,17 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
      */
     private function rejectLoadedAggregates(object $resource, array $specifications): array
     {
-        return array_filter(
-            $specifications,
-            fn ($value, $key): bool => !$this->isAggregateLoaded($resource, is_string($key) ? $key : $value),
-            ARRAY_FILTER_USE_BOTH,
-        );
-    }
+        return array_filter($specifications, static function ($value, $key) use ($resource): bool {
 
-    /**
-     * Determine whether the aggregate for the given relation specification is
-     * already an attribute on the resource.
-     *
-     * @param  object  $resource
-     * @param  array<string, mixed>|string  $relation
-     * @return bool
-     */
-    private function isAggregateLoaded(object $resource, array|string $relation): bool
-    {
-        if (!method_exists($resource, 'getAttributes')) {
-            return false;
-        }
+            $spec = $value;
 
-        $specification = is_array($relation) ? (string) array_key_first($relation) : $relation;
-        $position      = strpos($specification, ' as ');
-        $alias         = $position === false ? $specification : substr($specification, $position + 4);
+            if (is_array($value) && isset($value['relation'])) {
+                $spec = $value['relation'];
+            } elseif (is_string($key)) {
+                $spec = $key;
+            }
 
-        return array_key_exists($alias, $resource->getAttributes());
-    }
-
-    /**
-     * Get the fields that should always be included in the response.
-     *
-     * @return array<int, string>
-     */
-    private function getFixedFields(): array
-    {
-        return $this->fixed;
+            return !EagerLoadPlanner::isAggregateAttributeLoaded($resource, $spec);
+        }, ARRAY_FILTER_USE_BOTH);
     }
 }

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -321,7 +321,10 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
         $requestedCounts = ApiQuery::getCounts(static::getResourceType()) ?? [];
 
         if (method_exists($resource, 'loadCount') && $this->fieldResolver->shouldIncludeCountsField(static::getResourceType(), static::getDefaultFields())) {
-            $withCounts = EagerLoadPlanner::buildCountMap(static::class, $requestedCounts);
+            $withCounts = $this->rejectLoadedAggregates(
+                $resource,
+                EagerLoadPlanner::buildCountMap(static::class, $requestedCounts),
+            );
 
             if ($withCounts !== []) {
                 $resource->loadCount($withCounts);
@@ -384,6 +387,11 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
 
         if (method_exists($resource, 'loadSum') && $this->fieldResolver->shouldIncludeSumsField($resourceType, static::getDefaultFields())) {
             foreach (EagerLoadPlanner::buildSumMap(static::class, $requestedSums) as $entry) {
+
+                if ($this->isAggregateLoaded($resource, $entry['relation'])) {
+                    continue;
+                }
+
                 $resource->loadSum($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
             }
         }
@@ -393,8 +401,54 @@ abstract class ApiResource extends ToolkitResource implements ApiResourceInterfa
         }
 
         foreach (EagerLoadPlanner::buildAvgMap(static::class, $requestedAverages) as $entry) {
+
+            if ($this->isAggregateLoaded($resource, $entry['relation'])) {
+                continue;
+            }
+
             $resource->loadAvg($entry['relation'], $entry['column']); // @phpstan-ignore argument.type
         }
+    }
+
+    /**
+     * Reject aggregate specifications already loaded on the resource.
+     *
+     * The criteria pre-loads counts and aggregates on the base query, so a
+     * per-row load would re-run them; unlike loadMissing() for relations, the
+     * load{Count,Sum,Avg} helpers are not idempotent, so filter them here.
+     *
+     * @param  object  $resource
+     * @param  array<int|string, mixed>  $specifications
+     * @return array<int|string, mixed>
+     */
+    private function rejectLoadedAggregates(object $resource, array $specifications): array
+    {
+        return array_filter(
+            $specifications,
+            fn ($value, $key): bool => !$this->isAggregateLoaded($resource, is_string($key) ? $key : $value),
+            ARRAY_FILTER_USE_BOTH,
+        );
+    }
+
+    /**
+     * Determine whether the aggregate for the given relation specification is
+     * already an attribute on the resource.
+     *
+     * @param  object  $resource
+     * @param  array<string, mixed>|string  $relation
+     * @return bool
+     */
+    private function isAggregateLoaded(object $resource, array|string $relation): bool
+    {
+        if (!method_exists($resource, 'getAttributes')) {
+            return false;
+        }
+
+        $specification = is_array($relation) ? (string) array_key_first($relation) : $relation;
+        $position      = strpos($specification, ' as ');
+        $alias         = $position === false ? $specification : substr($specification, $position + 4);
+
+        return array_key_exists($alias, $resource->getAttributes());
     }
 
     /**

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -163,6 +163,36 @@ final class EagerLoadPlanner
     }
 
     /**
+     * Determine whether the aggregate for the given relation specification is
+     * already an attribute on the resource.
+     *
+     * The specification is a relation string, a `relation as alias` string, or
+     * a `[aliased => constraint]` map; the alias after ` as ` (or the plain
+     * relation) is matched against the model's loaded attributes.
+     *
+     * @param  object  $resource
+     * @param  mixed  $relation
+     * @return bool
+     */
+    public static function isAggregateAttributeLoaded(object $resource, mixed $relation): bool
+    {
+        if (!method_exists($resource, 'getAttributes')) {
+            return false;
+        }
+
+        $specification = is_array($relation) ? array_key_first($relation) : $relation;
+
+        if (!is_string($specification)) {
+            return false;
+        }
+
+        $position = strpos($specification, ' as ');
+        $alias    = $position === false ? $specification : substr($specification, $position + 4);
+
+        return array_key_exists($alias, $resource->getAttributes());
+    }
+
+    /**
      * Build a withSum/withAvg-ready entry list for the given resource class and
      * metric ('sum' or 'avg').
      *

--- a/src/Http/Resources/ResourceDiscovery.php
+++ b/src/Http/Resources/ResourceDiscovery.php
@@ -270,6 +270,29 @@ final readonly class ResourceDiscovery
     }
 
     /**
+     * Read a file's contents, tolerating a file removed between enumeration
+     * and read (a hot deploy swapping resources mid-scan, or a concurrent
+     * test) by returning null rather than aborting discovery.
+     *
+     * @param  string  $file
+     * @return string|null
+     */
+    private function readFileContents(string $file): ?string
+    {
+        try {
+            $contents = file_get_contents($file);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if ($contents === false) {
+            return null; // @codeCoverageIgnore
+        }
+
+        return $contents;
+    }
+
+    /**
      * Resolve the fully qualified class names declared in the given file.
      *
      * Tokenising avoids loading the file, so a scanned file that is not a
@@ -282,17 +305,10 @@ final readonly class ResourceDiscovery
      */
     private function classesFromFile(string $file): array
     {
-        try {
-            $contents = file_get_contents($file);
-        } catch (\Throwable) {
-            // A file removed between enumeration and read - a hot deploy
-            // swapping resources mid-scan, or a concurrent test - must not
-            // abort discovery.
-            return [];
-        }
+        $contents = $this->readFileContents($file);
 
-        if ($contents === false) {
-            return []; // @codeCoverageIgnore
+        if ($contents === null) {
+            return [];
         }
 
         $tokens    = \PhpToken::tokenize($contents);

--- a/src/Http/Resources/ResourceDiscovery.php
+++ b/src/Http/Resources/ResourceDiscovery.php
@@ -282,7 +282,14 @@ final readonly class ResourceDiscovery
      */
     private function classesFromFile(string $file): array
     {
-        $contents = file_get_contents($file);
+        try {
+            $contents = file_get_contents($file);
+        } catch (\Throwable) {
+            // A file removed between enumeration and read - a hot deploy
+            // swapping resources mid-scan, or a concurrent test - must not
+            // abort discovery.
+            return [];
+        }
 
         if ($contents === false) {
             return []; // @codeCoverageIgnore

--- a/src/Listeners/WritePoolFlushSubscriber.php
+++ b/src/Listeners/WritePoolFlushSubscriber.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Events\WritePoolFlushFailed;
 use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
-use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
 
@@ -59,17 +58,15 @@ final class WritePoolFlushSubscriber
      * Flush the write pool and handle any failures.
      *
      * The pool is resolved from the container at event time to ensure the
-     * correct scoped instance is used in Octane environments. When the flush
-     * returns a result with failures, or raises a WritePoolFlushException under
-     * the throw strategy, the failure is escalated loudly: a warning is logged
-     * and a WritePoolFlushFailed event is dispatched. The exception is only
-     * re-thrown when the rethrow_at_boundary config flag is enabled, so the
-     * lifecycle boundary is never hard-crashed by default. Any other throwable
-     * is unexpected and logged at error level.
-     *
-     * Regardless of outcome, the per-query cache for every table the flush
-     * attempted is invalidated so a deferred insert never leaves a stale cached
-     * collection behind.
+     * correct scoped instance is used in Octane environments. The flush itself
+     * invalidates the per-query cache for the tables it persists, so this
+     * subscriber only escalates failures: when the flush returns a result with
+     * failures, or raises a WritePoolFlushException under the throw strategy,
+     * the failure is escalated loudly - a warning is logged and a
+     * WritePoolFlushFailed event is dispatched. The exception is only re-thrown
+     * when the rethrow_at_boundary config flag is enabled, so the lifecycle
+     * boundary is never hard-crashed by default. Any other throwable is
+     * unexpected and logged at error level.
      *
      * @return void
      *
@@ -81,8 +78,6 @@ final class WritePoolFlushSubscriber
 
             $flushResult = $this->container->make(WritePool::class)->flush();
 
-            $this->invalidateQueryCache($flushResult);
-
             if ($flushResult->isSuccessful()) {
                 return;
             }
@@ -90,7 +85,6 @@ final class WritePoolFlushSubscriber
             $this->escalate($flushResult);
         } catch (WritePoolFlushException $exception) {
 
-            $this->invalidateQueryCache($exception->flushResult());
             $this->escalate($exception->flushResult());
 
             if (Config::get('api-toolkit.deferred_writes.rethrow_at_boundary', false)) {
@@ -100,28 +94,6 @@ final class WritePoolFlushSubscriber
 
             Log::error('WritePool flush subscriber failed', ['error' => $e->getMessage(), 'exception' => $e]);
         }
-    }
-
-    /**
-     * Invalidate the per-query cache for every table this flush attempted to
-     * persist.
-     *
-     * Best-effort and gated by the invalidate_query_cache config flag: it
-     * covers default-config Cacheable repositories, mirroring what an immediate
-     * write does. A repository on a custom cache store or key prefix is not
-     * covered and must invalidate manually.
-     *
-     * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult  $flushResult
-     * @return void
-     */
-    private function invalidateQueryCache(WritePoolFlushResult $flushResult): void
-    {
-        if (!Config::get('api-toolkit.deferred_writes.invalidate_query_cache', true)) {
-            return;
-        }
-
-        $this->container->make(DeferredWriteCacheInvalidator::class)
-            ->invalidate($flushResult->flushedTables());
     }
 
     /**

--- a/src/Providers/Registrars/MiddlewareRegistrar.php
+++ b/src/Providers/Registrars/MiddlewareRegistrar.php
@@ -7,6 +7,7 @@ namespace SineMacula\ApiToolkit\Providers\Registrars;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance as FrameworkMaintenance;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Http\Middleware\DetectsCapabilities;
@@ -65,10 +66,11 @@ final class MiddlewareRegistrar
     /**
      * Register the maintenance mode middleware swap.
      *
-     * When enabled, the toolkit's PreventRequestsDuringMaintenance middleware
-     * is prepended to the global middleware stack. Since it extends Laravel's
-     * built-in middleware, it takes precedence without requiring removal of the
-     * original.
+     * When enabled, the framework's built-in maintenance middleware is removed
+     * from the global stack and the toolkit's is prepended in its place. The
+     * toolkit middleware extends and fully supersedes the original, so leaving
+     * the original in place would re-throw a raw 503 for the paths the toolkit
+     * bypasses, defeating the configured maintenance exceptions.
      *
      * @param  \Illuminate\Foundation\Http\Kernel  $kernel
      * @return void
@@ -78,6 +80,11 @@ final class MiddlewareRegistrar
         if (!Config::get('api-toolkit.middleware.maintenance_mode_swap.enabled', true)) {
             return;
         }
+
+        $kernel->setGlobalMiddleware(array_filter(
+            $kernel->getGlobalMiddleware(),
+            static fn ($middleware): bool => $middleware !== FrameworkMaintenance::class,
+        ));
 
         $kernel->prependMiddleware(PreventRequestsDuringMaintenance::class);
     }

--- a/src/Repositories/Concerns/WritePool.php
+++ b/src/Repositories/Concerns/WritePool.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace SineMacula\ApiToolkit\Repositories\Concerns;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use SineMacula\ApiToolkit\Enums\FlushStrategy;
@@ -92,7 +93,17 @@ final class WritePool
             return new WritePoolFlushResult(successCount: 0, failureCount: 0);
         }
 
-        return $this->executeFlush($strategy ?? $this->strategy);
+        try {
+            $result = $this->executeFlush($strategy ?? $this->strategy);
+        } catch (WritePoolFlushException $exception) {
+            $this->invalidateFlushedTables($exception->flushResult());
+
+            throw $exception;
+        }
+
+        $this->invalidateFlushedTables($result);
+
+        return $result;
     }
 
     /**
@@ -138,6 +149,26 @@ final class WritePool
     public function isEmpty(): bool
     {
         return $this->count() === 0;
+    }
+
+    /**
+     * Invalidate the per-query cache for the tables a flush persisted.
+     *
+     * Gated by the invalidate_query_cache config flag, so every flush - the
+     * auto-flush triggered when the pool limit is reached as well as the
+     * boundary flush - keeps a Cacheable repository's cached collections in
+     * step with the rows it just committed.
+     *
+     * @param  \SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult  $result
+     * @return void
+     */
+    private function invalidateFlushedTables(WritePoolFlushResult $result): void
+    {
+        if (!Config::get('api-toolkit.deferred_writes.invalidate_query_cache', true)) {
+            return;
+        }
+
+        (new DeferredWriteCacheInvalidator)->invalidate($result->flushedTables());
     }
 
     /**

--- a/tests/Concerns/RegistersApiExceptionHandler.php
+++ b/tests/Concerns/RegistersApiExceptionHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Concerns;
+
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Exceptions\Handler;
+use PHPUnit\Framework\Assert;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+
+/**
+ * Registers the toolkit exception handler for full-stack feature tests.
+ *
+ * Mirrors the bootstrap/app.php withExceptions() wiring used by consuming
+ * applications, so dispatched requests render failures through the toolkit JSON
+ * error envelope rather than the framework default.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+trait RegistersApiExceptionHandler
+{
+    /**
+     * Register the toolkit exception handler against the application's real
+     * exception handler.
+     *
+     * @return void
+     */
+    protected function registerApiExceptionHandler(): void
+    {
+        $handler = app(ExceptionHandlerContract::class);
+
+        if (!$handler instanceof Handler) {
+            Assert::fail('The application exception handler must extend the foundation handler.');
+        }
+
+        ApiExceptionHandler::handles(new Exceptions($handler));
+    }
+}

--- a/tests/Feature/AllowlistRejectionTest.php
+++ b/tests/Feature/AllowlistRejectionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the allowlist query-surface posture through the kernel.
+ *
+ * Exercises the secure-by-default posture as a consuming application does: a
+ * real request travels through the ParseApiQuery middleware and the repository
+ * criteria under the default posture (no posture configured). A declared column
+ * is applied and narrows the result set, while an undeclared filter or sort key
+ * is rejected and rendered as the toolkit 422 envelope keyed on the offending
+ * field.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+final class AllowlistRejectionTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test under the default allowlist posture.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        // No query_posture is configured, so the default allowlist posture is
+        // in force: only columns FilterableUserResource declares are usable.
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'status' => 'inactive']);
+    }
+
+    /**
+     * Test that a declared filterable column is applied and narrows the result.
+     *
+     * @return void
+     */
+    public function testDeclaredFilterIsApplied(): void
+    {
+        $filters = json_encode(['name' => 'Alice']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Alice');
+    }
+
+    /**
+     * Test that an undeclared filter column is rejected as a 422 envelope keyed
+     * on the offending field.
+     *
+     * @return void
+     */
+    public function testUndeclaredFilterIsRejectedWithValidationEnvelope(): void
+    {
+        $filters = json_encode(['status' => 'active']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error.status', 422);
+        $response->assertJsonPath('error.code', 10106);
+
+        self::assertArrayHasKey('filters.status', (array) $response->json('error.meta'));
+    }
+
+    /**
+     * Test that a column declared filterable but not sortable is rejected when
+     * used to order the result set.
+     *
+     * @return void
+     */
+    public function testUndeclaredSortKeyIsRejectedWithValidationEnvelope(): void
+    {
+        $response = $this->getJson('/api/users?order=email:asc');
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error.status', 422);
+
+        self::assertArrayHasKey('order.email', (array) $response->json('error.meta'));
+    }
+}

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Routing\AuthorizedController;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Actors\ActorUser;
+use Tests\Fixtures\Controllers\TestingAuthorizedController;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Policies\UserPolicy;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the authorized controller guard through the HTTP kernel.
+ *
+ * Dispatches real requests to an authorized controller backed by a policy: an
+ * action outside the guard exclusions is gated by its ability and, when
+ * denied, renders the toolkit forbidden envelope, while an excluded action
+ * bypasses the guard entirely.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(AuthorizedController::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+final class AuthorizationTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with the policy registered and the controller routed.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Gate::policy(User::class, UserPolicy::class);
+
+        Route::get('/api/users', [TestingAuthorizedController::class, 'index']);
+        Route::post('/api/users', [TestingAuthorizedController::class, 'store']);
+    }
+
+    /**
+     * Test that an excluded action bypasses the authorization guard.
+     *
+     * @return void
+     */
+    public function testExcludedActionBypassesTheGuard(): void
+    {
+        $actor = ActorUser::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+
+        $response = $this->actingAs($actor)->getJson('/api/users');
+
+        $response->assertOk();
+    }
+
+    /**
+     * Test that a denied ability renders the toolkit forbidden envelope.
+     *
+     * @return void
+     */
+    public function testDeniedAbilityRendersForbiddenEnvelope(): void
+    {
+        $actor = ActorUser::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+
+        $response = $this->actingAs($actor)->postJson('/api/users', []);
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error.status', 403);
+        $response->assertJsonPath('error.code', 10102);
+    }
+}

--- a/tests/Feature/CombinedRequestTest.php
+++ b/tests/Feature/CombinedRequestTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test combining every read modifier in a single request.
+ *
+ * Under the default allowlist posture a real request narrows the fieldset,
+ * applies a declared filter, orders by a declared sortable column, and
+ * truncates with a page limit. The four modifiers are proven to apply
+ * together: the fieldset drops undeclared keys, the filtered total excludes
+ * non-matching rows, the ordering fixes row positions, and the limit caps the
+ * page while the meta still reports the filtered total.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(OrderApplier::class)]
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class CombinedRequestTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded rows.
+     *
+     * Four rows carry the retained email domain and two carry a dropped domain
+     * whose names sort ahead of every retained row, so a missing filter would
+     * surface them first under the descending sort.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alpha', 'email' => 'alpha@keep.com']);
+        User::create(['name' => 'Bravo', 'email' => 'bravo@keep.com']);
+        User::create(['name' => 'Charlie', 'email' => 'charlie@keep.com']);
+        User::create(['name' => 'Delta', 'email' => 'delta@keep.com']);
+        User::create(['name' => 'Yankee', 'email' => 'yankee@drop.com']);
+        User::create(['name' => 'Zulu', 'email' => 'zulu@drop.com']);
+    }
+
+    /**
+     * Test that a fieldset, a filter, a sort, and a limit apply together in one
+     * request.
+     *
+     * @return void
+     */
+    public function testFieldsFilterSortAndLimitApplyTogether(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields'  => ['filterable_users' => 'name'],
+            'filters' => json_encode(['email' => ['$like' => '@keep.com']]),
+            'order'   => 'name:desc',
+            'limit'   => 2,
+        ]));
+
+        $response->assertOk();
+
+        // Limit applied: two of the four matching rows are returned.
+        $response->assertJsonCount(2, 'data');
+
+        // Sort applied: descending by name over the filtered set.
+        $response->assertJsonPath('data.0.name', 'Delta');
+        $response->assertJsonPath('data.1.name', 'Charlie');
+
+        // Filter applied: the meta total reflects the four retained rows only,
+        // and the two dropped-domain rows never reach the top of the sort.
+        $response->assertJsonPath('meta.total', 4);
+        $response->assertJsonPath('meta.count', 2);
+        $response->assertJsonPath('meta.continue', true);
+
+        // Fieldset applied: the requested key is present and the undeclared key
+        // is absent.
+        $record = $response->json('data.0');
+
+        self::assertIsArray($record);
+        self::assertArrayHasKey('name', $record);
+        self::assertArrayNotHasKey('email', $record);
+    }
+}

--- a/tests/Feature/CursorPaginationTest.php
+++ b/tests/Feature/CursorPaginationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\ProvidesApiEnvelope;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for cursor-paginated collections through the kernel.
+ *
+ * Requesting cursor mode via the query string selects the cursor paginator, so
+ * the response carries the cursor envelope: a data block, a boolean
+ * `meta.continue` flag, and `links` exposing the next/prev cursors. Following
+ * the emitted next cursor returns the subsequent page of rows.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+#[CoversTrait(ProvidesApiEnvelope::class)]
+final class CursorPaginationTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a cursor-capable users route and ordered rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        // Created in ascending id order; the cursor paginator orders by the
+        // primary key by default, so page order follows creation order.
+        User::create(['name' => 'Anna', 'email' => 'anna@example.com']);
+        User::create(['name' => 'Ben', 'email' => 'ben@example.com']);
+        User::create(['name' => 'Cara', 'email' => 'cara@example.com']);
+        User::create(['name' => 'Dan', 'email' => 'dan@example.com']);
+        User::create(['name' => 'Evan', 'email' => 'evan@example.com']);
+    }
+
+    /**
+     * Test that requesting cursor mode returns the cursor envelope on the first
+     * page: data, a boolean continue flag, a next cursor, and a null prev.
+     *
+     * @return void
+     */
+    public function testCursorModeReturnsTheCursorEnvelope(): void
+    {
+        $response = $this->getJson('/api/users?pagination=cursor&limit=2');
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('data.0.name', 'Anna');
+        $response->assertJsonPath('data.1.name', 'Ben');
+
+        self::assertIsBool($response->json('meta.continue'));
+        self::assertTrue($response->json('meta.continue'));
+
+        self::assertNull($response->json('links.prev'));
+        self::assertIsString($response->json('links.next'));
+    }
+
+    /**
+     * Test that following the emitted next cursor returns the following page of
+     * rows while the envelope shape is preserved.
+     *
+     * @return void
+     */
+    public function testFollowingTheNextCursorReturnsTheFollowingPage(): void
+    {
+        $first = $this->getJson('/api/users?pagination=cursor&limit=2');
+
+        $first->assertOk();
+
+        $next = $first->json('links.next');
+
+        self::assertIsString($next);
+
+        $parts = parse_url($next);
+
+        self::assertIsArray($parts);
+        self::assertArrayHasKey('query', $parts);
+
+        $second = $this->getJson('/api/users?' . $parts['query']);
+
+        $second->assertOk();
+        $second->assertJsonCount(2, 'data');
+        $second->assertJsonPath('data.0.name', 'Cara');
+        $second->assertJsonPath('data.1.name', 'Dan');
+
+        self::assertTrue($second->json('meta.continue'));
+
+        // The prev cursor is populated once past the first page.
+        self::assertIsString($second->json('links.prev'));
+    }
+}

--- a/tests/Feature/ExceptionTaxonomyTest.php
+++ b/tests/Feature/ExceptionTaxonomyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\TestCase;
+
+/**
+ * Feature tests rounding out the exception taxonomy through the real kernel.
+ *
+ * With the toolkit handler wired as a consuming application wires it, a missing
+ * model surfaces as a not-found envelope and an authorization failure surfaces
+ * as a forbidden envelope, each carrying the matching HTTP status and internal
+ * error code.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiExceptionHandler::class)]
+final class ExceptionTaxonomyTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with the toolkit handler wired and throwing routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        // findOrFail on an empty table raises a ModelNotFoundException, which
+        // Laravel prepares into a NotFoundHttpException before the toolkit
+        // render callback maps it to the not-found envelope.
+        Route::get('/api/model-missing', static function (): void {
+            User::findOrFail(99999);
+        });
+
+        // A statusless AuthorizationException is prepared into an
+        // AccessDeniedHttpException, which the toolkit maps to the forbidden
+        // envelope. abort(403) would instead yield a generic HTTP error code.
+        Route::get('/api/forbidden', static function (): never {
+            throw new AuthorizationException('This action is unauthorized.');
+        });
+    }
+
+    /**
+     * Test that a missing model renders as a 404 not-found envelope.
+     *
+     * @return void
+     */
+    public function testModelNotFoundIsRenderedAsNotFound(): void
+    {
+        $response = $this->getJson('/api/model-missing');
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error.status', 404);
+        $response->assertJsonPath('error.code', 10103);
+    }
+
+    /**
+     * Test that an authorization failure renders as a 403 forbidden envelope.
+     *
+     * @return void
+     */
+    public function testAuthorizationFailureIsRenderedAsForbidden(): void
+    {
+        $response = $this->getJson('/api/forbidden');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error.status', 403);
+        $response->assertJsonPath('error.code', 10102);
+    }
+}

--- a/tests/Feature/FieldGuardResponseTest.php
+++ b/tests/Feature/FieldGuardResponseTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\GuardedUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for field guards and transformers in a real JSON body.
+ *
+ * A request-scoped guard is security-adjacent: a consumer needs proof the field
+ * is absent from the actual response body, not merely from a unit resolve. This
+ * drives a resource whose schema carries a guarded field and a transformed
+ * field through a real response, asserting the guarded key drops out unless
+ * permitted and the transformer's output appears verbatim.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiResource::class)]
+final class FieldGuardResponseTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a guarded resource route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+
+        // Fetch a fresh instance per request so the model is not flagged as
+        // recently created, which would make the resource response a 201.
+        Route::get('/api/guarded', static fn (): GuardedUserResource => new GuardedUserResource(User::query()->firstOrFail()));
+    }
+
+    /**
+     * Test that the guard hides the field and the transformer applies when the
+     * guard query parameter is absent.
+     *
+     * @return void
+     */
+    public function testGuardHidesFieldAndTransformerAppliesInResponse(): void
+    {
+        $response = $this->getJson('/api/guarded');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.name', 'ALICE');
+
+        self::assertArrayNotHasKey('email', (array) $response->json('data'));
+    }
+
+    /**
+     * Test that the guarded field is present with its value when the guard
+     * permits it.
+     *
+     * @return void
+     */
+    public function testGuardRevealsFieldWhenPermitted(): void
+    {
+        $response = $this->getJson('/api/guarded?show=yes');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.email', 'alice@example.com');
+    }
+}

--- a/tests/Feature/LimitAndOperatorTest.php
+++ b/tests/Feature/LimitAndOperatorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for limit clamping and filter-operator grammar over HTTP.
+ *
+ * A client-supplied page limit above the configured ceiling is clamped down to
+ * the ceiling rather than honoured, and a small sample of declared filter
+ * operators - greater-than, like, and in - each narrow the result set through
+ * the parsed query string.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(FilterApplier::class)]
+final class LimitAndOperatorTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        User::create(['name' => 'Alan', 'email' => 'alan@example.com']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+        User::create(['name' => 'Carol', 'email' => 'carol@example.com']);
+        User::create(['name' => 'Dave', 'email' => 'dave@example.com']);
+    }
+
+    /**
+     * Test that a per-page limit above the configured ceiling is clamped to the
+     * ceiling.
+     *
+     * @return void
+     */
+    public function testLimitAboveTheCeilingIsClampedToTheCeiling(): void
+    {
+        Config::set('api-toolkit.parser.max_limit', 2);
+
+        $response = $this->getJson('/api/users?limit=50');
+
+        $response->assertOk();
+
+        // Clamped to the ceiling of two despite the requested fifty, while the
+        // meta still reports every seeded row as the total.
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('meta.count', 2);
+        $response->assertJsonPath('meta.total', 5);
+        $response->assertJsonPath('meta.continue', true);
+    }
+
+    /**
+     * Test that the greater-than operator narrows the result set by id.
+     *
+     * @return void
+     */
+    public function testGreaterThanOperatorNarrowsById(): void
+    {
+        $filters = json_encode(['id' => ['$gt' => 3]]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+
+        $names = array_column((array) $response->json('data'), 'name');
+
+        self::assertContains('Carol', $names);
+        self::assertContains('Dave', $names);
+        self::assertNotContains('Alice', $names);
+    }
+
+    /**
+     * Test that the like operator narrows the result set by a name substring.
+     *
+     * @return void
+     */
+    public function testLikeOperatorNarrowsByName(): void
+    {
+        $filters = json_encode(['name' => ['$like' => 'Al']]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+
+        $names = array_column((array) $response->json('data'), 'name');
+
+        self::assertContains('Alice', $names);
+        self::assertContains('Alan', $names);
+        self::assertNotContains('Bob', $names);
+    }
+
+    /**
+     * Test that the in operator narrows the result set to a set of names.
+     *
+     * @return void
+     */
+    public function testInOperatorNarrowsByNameSet(): void
+    {
+        $filters = json_encode(['name' => ['$in' => ['Bob', 'Dave']]]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+
+        $names = array_column((array) $response->json('data'), 'name');
+
+        self::assertContains('Bob', $names);
+        self::assertContains('Dave', $names);
+        self::assertNotContains('Alice', $names);
+    }
+}

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Middleware\PreventRequestsDuringMaintenance;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the maintenance-mode middleware through the HTTP kernel.
+ *
+ * Activates maintenance mode and dispatches real requests: a guarded route
+ * renders the toolkit service-unavailable envelope rather than a raw HTML error
+ * page, while a route named in the bypass list is served as normal - which only
+ * holds because the swap removes the framework default so the toolkit except
+ * list is authoritative.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(PreventRequestsDuringMaintenance::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+final class MaintenanceModeTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with maintenance-guarded routes and a bypass list.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.maintenance_mode.except', ['api/health']);
+
+        Route::middleware(PreventRequestsDuringMaintenance::class)->get('/api/data', static fn (): array => ['ok' => true]);
+        Route::middleware(PreventRequestsDuringMaintenance::class)->get('/api/health', static fn (): array => ['ok' => true]);
+    }
+
+    /**
+     * Test that a guarded route renders the service-unavailable envelope
+     * while maintenance mode is active.
+     *
+     * @return void
+     */
+    public function testGuardedRouteRendersServiceUnavailableEnvelope(): void
+    {
+        $response = $this->duringMaintenance(fn () => $this->getJson('/api/data'));
+
+        $response->assertStatus(503);
+        $response->assertJsonPath('error.status', 503);
+        $response->assertJsonPath('error.code', 10200);
+    }
+
+    /**
+     * Test that a bypass-list route is served as normal during maintenance
+     * mode.
+     *
+     * @return void
+     */
+    public function testBypassListIsServedDuringMaintenance(): void
+    {
+        $response = $this->duringMaintenance(fn () => $this->getJson('/api/health'));
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+    }
+
+    /**
+     * Activate maintenance mode, run the callback, and deactivate afterwards.
+     *
+     * @template TReturn
+     *
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    private function duringMaintenance(\Closure $callback): mixed
+    {
+        assert($this->app !== null);
+
+        $this->app->maintenanceMode()->activate([
+            'redirect' => null,
+            'retry'    => 60,
+            'refresh'  => null,
+            'secret'   => null,
+            'status'   => 503,
+            'template' => null,
+        ]);
+
+        try {
+            return $callback();
+        } finally {
+            $this->app->maintenanceMode()->deactivate();
+        }
+    }
+}

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Tests\Feature;
 
+use Illuminate\Contracts\Foundation\MaintenanceMode;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
 use SineMacula\ApiToolkit\Http\Middleware\PreventRequestsDuringMaintenance;
 use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Support\ArrayMaintenanceMode;
 use Tests\TestCase;
 
 /**
@@ -43,6 +45,12 @@ final class MaintenanceModeTest extends TestCase
         parent::setUp();
 
         $this->registerApiExceptionHandler();
+
+        // Use an in-memory maintenance driver so activation stays scoped to
+        // this test's app; the default file driver writes a process-global down
+        // file that 503s unrelated tests in parallel workers.
+        assert($this->app !== null);
+        $this->app->instance(MaintenanceMode::class, new ArrayMaintenanceMode);
 
         Config::set('api-toolkit.maintenance_mode.except', ['api/health']);
 

--- a/tests/Feature/PolymorphicCollectionTest.php
+++ b/tests/Feature/PolymorphicCollectionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Resources\PolymorphicResource;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Organization;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\OrganizationResource;
+use Tests\Fixtures\Resources\PostResource;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for polymorphic collection serialization through the HTTP
+ * kernel.
+ *
+ * A heterogeneous collection of mixed models is returned from a real route and
+ * asserted to carry the correct per-type discriminator and field set for each
+ * element - the mixed-type feed shape that unit tests only exercise one item at
+ * a time. An unmapped model renders an error rather than a partial payload.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(PolymorphicResource::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+final class PolymorphicCollectionTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a mapped heterogeneous feed route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('app.debug', false);
+        Config::set('api-toolkit.resources.resource_map', [
+            User::class         => UserResource::class,
+            Organization::class => OrganizationResource::class,
+            Post::class         => PostResource::class,
+        ]);
+
+        $organization = Organization::create(['name' => 'Acme Corp', 'slug' => 'acme-corp']);
+        $user         = User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active', 'organization_id' => $organization->id]);
+        $post         = Post::create(['user_id' => $user->id, 'title' => 'Hello World', 'body' => 'Content', 'published' => true]);
+
+        Route::get('/api/feed', static fn () => PolymorphicResource::collection(collect([$user, $organization, $post])));
+    }
+
+    /**
+     * Test that each element carries its own discriminator and field set.
+     *
+     * @return void
+     */
+    public function testHeterogeneousCollectionCarriesPerTypeDiscriminators(): void
+    {
+        $response = $this->getJson('/api/feed');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0._type', 'users');
+        $response->assertJsonPath('data.1._type', 'organizations');
+        $response->assertJsonPath('data.2._type', 'posts');
+        $response->assertJsonPath('data.0.name', 'Alice');
+        $response->assertJsonPath('data.1.name', 'Acme Corp');
+        $response->assertJsonPath('data.2.title', 'Hello World');
+    }
+
+    /**
+     * Test that a model absent from the map renders an error rather than a
+     * partial payload.
+     *
+     * @return void
+     */
+    public function testUnmappedModelRendersAnError(): void
+    {
+        Config::set('api-toolkit.resources.resource_map', []);
+
+        $response = $this->getJson('/api/feed');
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error.status', 500);
+    }
+}

--- a/tests/Feature/ReportCollectionTest.php
+++ b/tests/Feature/ReportCollectionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\ReportCollection;
+use SineMacula\ApiToolkit\Http\Resources\ReportResource;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Reports\SalesSummaryResource;
+use Tests\Fixtures\Reports\SalesSummaryRow;
+use Tests\TestCase;
+
+/**
+ * Feature tests for report read-model serialization through the HTTP kernel.
+ *
+ * A paginated report of DTO rows is returned from a real route and asserted to
+ * inherit the identical envelope as an entity collection - `data`, `meta`,
+ * `links`, and the `Total-Count` header - which only a real dispatch confirms
+ * because the pagination hooks fire through the response, not `toArray()`.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ReportResource::class)]
+#[CoversClass(ReportCollection::class)]
+final class ReportCollectionTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with paginated and single report routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::get('/api/reports/sales', static function (): ReportCollection {
+
+            $rows = [
+                new SalesSummaryRow('2026-06', 120, '15000.00'),
+                new SalesSummaryRow('2026-07', 98, '12250.00'),
+            ];
+
+            /** @var \SineMacula\ApiToolkit\Http\Resources\ReportCollection */
+            return SalesSummaryResource::collection(new LengthAwarePaginator($rows, 2, 15, 1));
+        });
+
+        Route::get('/api/reports/sales/first', static fn (): SalesSummaryResource => new SalesSummaryResource(new SalesSummaryRow('2026-06', 120, '15000.00')));
+    }
+
+    /**
+     * Test that a paginated report collection renders the toolkit envelope with
+     * the Total-Count header and per-row discriminator.
+     *
+     * @return void
+     */
+    public function testPaginatedReportRendersTheToolkitEnvelope(): void
+    {
+        $response = $this->getJson('/api/reports/sales');
+
+        $response->assertOk();
+        $response->assertJsonStructure(['data', 'meta', 'links']);
+        $response->assertJsonPath('data.0._type', 'sales-summary');
+        $response->assertJsonPath('data.0.month', '2026-06');
+        $response->assertJsonPath('data.0.orders', 120);
+        $response->assertJsonPath('meta.total', 2);
+        $response->assertHeader('Total-Count', '2');
+    }
+
+    /**
+     * Test that a single report resource renders the data-wrapped item with its
+     * discriminator.
+     *
+     * @return void
+     */
+    public function testSingleReportRendersTheDataWrappedItem(): void
+    {
+        $response = $this->getJson('/api/reports/sales/first');
+
+        $response->assertOk();
+        $response->assertJsonPath('data._type', 'sales-summary');
+        $response->assertJsonPath('data.month', '2026-06');
+    }
+}

--- a/tests/Feature/ResourceResponseShapeTest.php
+++ b/tests/Feature/ResourceResponseShapeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Organization;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for nested field selection and relation aggregates in a real
+ * JSON response body.
+ *
+ * Drives the full request lifecycle so the serialization and embedding step is
+ * proven on the wire: a nested sparse fieldset restricts an embedded relation
+ * to its requested keys, and the count/sum/average aggregates surface under an
+ * item.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiResource::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class ResourceResponseShapeTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded data.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(UserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, UserResource::class);
+        });
+
+        $organization = Organization::create(['name' => 'Acme Corp', 'slug' => 'acme-corp']);
+        $alice        = User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active', 'organization_id' => $organization->id]);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'First Post', 'body' => 'Content', 'published' => true]);
+        Post::create(['user_id' => $alice->id, 'title' => 'Second Post', 'body' => 'Content', 'published' => false]);
+    }
+
+    /**
+     * Test that a nested sparse fieldset restricts the embedded relation to its
+     * requested keys.
+     *
+     * @return void
+     */
+    public function testNestedSparseFieldsetRestrictsTheEmbeddedRelation(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields' => ['users' => 'name,posts', 'posts' => 'title'],
+        ]));
+
+        $response->assertOk();
+
+        /** @var array<int, array<string, mixed>> $posts */
+        $posts = $response->json('data.0.posts');
+
+        self::assertNotEmpty($posts);
+        self::assertArrayHasKey('title', $posts[0]);
+        self::assertArrayHasKey('_type', $posts[0]);
+        self::assertArrayNotHasKey('body', $posts[0]);
+        self::assertArrayNotHasKey('published', $posts[0]);
+    }
+
+    /**
+     * Test that count, sum, and average aggregates surface under an item.
+     *
+     * @return void
+     */
+    public function testAggregatesSurfaceInThePayload(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields'   => ['users' => 'name,counts,sums,averages'],
+            'counts'   => ['users' => 'posts'],
+            'sums'     => ['users' => ['posts' => 'id']],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0.counts.posts', 2);
+
+        /** @var array<string, mixed> $item */
+        $item = $response->json('data.0');
+
+        self::assertArrayHasKey('posts_id', (array) $item['sums']);
+        self::assertArrayHasKey('posts_id', (array) $item['averages']);
+    }
+}

--- a/tests/Feature/SensitiveDataRedactionTest.php
+++ b/tests/Feature/SensitiveDataRedactionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Log\Logger;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger as MonologLogger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Exceptions\ConflictException;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\TestCase;
+
+/**
+ * Feature tests for sensitive-key redaction reaching a real log record.
+ *
+ * Dispatches a real request carrying sensitive keys to a route that throws a
+ * toolkit exception, then reads the record captured on the api-exceptions
+ * channel to prove the redaction guarantee holds on the actual logging path -
+ * report() -> logApiException() -> the channel - not merely under reflection.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiExceptionHandler::class)]
+final class SensitiveDataRedactionTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a capturing log channel and a throwing route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('app.debug', false);
+        Config::set('logging.channels.api-exceptions', [
+            'driver'  => 'monolog',
+            'handler' => TestHandler::class,
+        ]);
+
+        $this->registerApiExceptionHandler();
+
+        Route::post('/api/orders', static function (): never {
+            throw new ConflictException;
+        });
+    }
+
+    /**
+     * Test that sensitive request keys are redacted in the logged context while
+     * benign keys survive.
+     *
+     * @return void
+     */
+    public function testSensitiveKeysAreRedactedInTheLoggedContext(): void
+    {
+        $response = $this->postJson('/api/orders', [
+            'email'     => 'alice@example.com',
+            'password'  => 'hunter2',
+            'api_token' => 'secret-value',
+        ]);
+
+        $response->assertStatus(409);
+
+        $records = $this->capturedRecords();
+
+        self::assertNotEmpty($records);
+
+        /** @var array<string, mixed> $context */
+        $context = $records[array_key_last($records)]['context'];
+
+        /** @var array<string, mixed> $data */
+        $data = $context['data'];
+
+        self::assertSame('[redacted]', $data['password']);
+        self::assertSame('[redacted]', $data['api_token']);
+        self::assertSame('alice@example.com', $data['email']);
+    }
+
+    /**
+     * Read the records captured on the api-exceptions channel.
+     *
+     * @return array<int, \Monolog\LogRecord>
+     */
+    private function capturedRecords(): array
+    {
+        $channel = Log::channel('api-exceptions');
+
+        assert($channel instanceof Logger);
+
+        $monolog = $channel->getLogger();
+
+        assert($monolog instanceof MonologLogger);
+
+        foreach ($monolog->getHandlers() as $handler) {
+            if ($handler instanceof TestHandler) {
+                return $handler->getRecords();
+            }
+        }
+
+        return [];
+    }
+}

--- a/tests/Feature/ThrottleTest.php
+++ b/tests/Feature/ThrottleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Middleware\Concerns\ThrottleRequestsTrait;
+use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequests;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the throttle middleware through the HTTP kernel.
+ *
+ * Dispatches real requests against a rate-limited route and asserts that an
+ * exhausted bucket produces the toolkit too-many-requests envelope with a
+ * Retry-After header, rather than the framework default.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ThrottleRequests::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+#[CoversTrait(ThrottleRequestsTrait::class)]
+final class ThrottleTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a route limited to a single request.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ThrottleRequests::class . ':1,1')->get('/api/ping', static fn (): array => ['ok' => true]);
+    }
+
+    /**
+     * Test that exceeding the rate limit renders the toolkit throttled envelope
+     * with a Retry-After header.
+     *
+     * @return void
+     */
+    public function testExceedingTheRateLimitRendersTheThrottledEnvelope(): void
+    {
+        $this->getJson('/api/ping')->assertOk();
+
+        $response = $this->getJson('/api/ping');
+
+        $response->assertStatus(429);
+        $response->assertJsonPath('error.status', 429);
+        $response->assertJsonPath('error.code', 10107);
+        $response->assertHeader('Retry-After');
+    }
+}

--- a/tests/Fixtures/Controllers/TestingAuthorizedController.php
+++ b/tests/Fixtures/Controllers/TestingAuthorizedController.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Tests\Fixtures\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use SineMacula\ApiToolkit\Http\Routing\AuthorizedController;
 use Tests\Fixtures\Models\User;
 
@@ -23,4 +24,24 @@ final class TestingAuthorizedController extends AuthorizedController
 
     /** @var array<int, string> */
     public const array GUARD_EXCLUSIONS = ['index', 'show'];
+
+    /**
+     * List users. Excluded from the authorization guard.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index(): JsonResponse
+    {
+        return new JsonResponse(['data' => []]);
+    }
+
+    /**
+     * Create a user. Guarded by the create ability.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(): JsonResponse
+    {
+        return new JsonResponse(['data' => []], 201);
+    }
 }

--- a/tests/Fixtures/Models/Tag.php
+++ b/tests/Fixtures/Models/Tag.php
@@ -11,6 +11,9 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 /**
  * Fixture tag model.
  *
+ * @property int $id
+ * @property string $name
+ *
  * @method static static create(array<string, mixed> $attributes = [])
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/tests/Fixtures/Overrides/functions.php
+++ b/tests/Fixtures/Overrides/functions.php
@@ -72,3 +72,80 @@ function ob_get_level(): int
 
     return \ob_get_level();
 }
+
+namespace SineMacula\ApiToolkit\OpenApi\Metadata;
+
+use Tests\Fixtures\Support\FunctionOverrides;
+
+/**
+ * Override glob() within the OpenApi\Metadata namespace.
+ *
+ * Lets tests drive the exceptions-directory scan, including the failure path
+ * where glob() reports an error by returning false.
+ *
+ * @param  string  $pattern
+ * @param  int  $flags
+ * @return array<int, string>|false
+ */
+function glob(string $pattern, int $flags = 0): array|false
+{
+    $override = FunctionOverrides::get('glob');
+
+    if ($override !== null) {
+        /** @var array<int, string>|false */
+        return $override($pattern, $flags);
+    }
+
+    return \glob($pattern, $flags);
+}
+
+/**
+ * Override defined() within the OpenApi\Metadata namespace.
+ *
+ * Lets tests simulate an exception subclass that declares no CODE constant so
+ * the catalogue scan's guard against it is observable.
+ *
+ * @param  string  $constant
+ * @return bool
+ *
+ * @SuppressWarnings("php:S4144")
+ */
+function defined(string $constant): bool
+{
+    $override = FunctionOverrides::get('defined');
+
+    if ($override !== null) {
+        return (bool) $override($constant);
+    }
+
+    return \defined($constant);
+}
+
+namespace SineMacula\ApiToolkit\Providers\Registrars;
+
+use Tests\Fixtures\Support\FunctionOverrides;
+
+/**
+ * Override class_exists() within the Providers\Registrars namespace.
+ *
+ * Lets tests simulate the presence or absence of optional integration
+ * packages (Octane, notifications) so the class_exists guards on both branches
+ * are observable without changing the installed dependency set.
+ *
+ * @SuppressWarnings("php:S100")
+ * @SuppressWarnings("php:S4144")
+ *
+ * @param  string  $class
+ * @param  bool  $autoload
+ * @return bool
+ */
+function class_exists(string $class, bool $autoload = true): bool
+{
+    $override = FunctionOverrides::get('class_exists');
+
+    if ($override !== null) {
+        return (bool) $override($class, $autoload);
+    }
+
+    return \class_exists($class, $autoload);
+}

--- a/tests/Fixtures/Policies/UserPolicy.php
+++ b/tests/Fixtures/Policies/UserPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Policies;
+
+use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Fixture user policy.
+ *
+ * Denies the create ability so an authorized controller action guarded by the
+ * gate renders a forbidden response.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class UserPolicy
+{
+    /**
+     * Determine whether the actor may create users.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $actor
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @SuppressWarnings("php:S1172")
+     */
+    public function create(Authenticatable $actor): Response
+    {
+        return Response::deny();
+    }
+}

--- a/tests/Fixtures/Resources/ConstrainedUserResource.php
+++ b/tests/Fixtures/Resources/ConstrainedUserResource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use Illuminate\Database\Eloquent\Builder;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use SineMacula\ApiToolkit\Schema\Relation;
+
+/**
+ * Fixture user resource whose posts relation is eager-load constrained.
+ *
+ * The posts relation carries a constraint closure that limits the eager load
+ * to published posts, so the whole collection resolves through one constrained
+ * sub-query rather than a per-row filtered load.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ConstrainedUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'constrained_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name'),
+            Relation::to('posts', PostResource::class)->constrain(
+                static function (Builder $query): void {
+                    $query->where('published', true);
+                },
+            ),
+        );
+    }
+}

--- a/tests/Fixtures/Resources/GuardedUserResource.php
+++ b/tests/Fixtures/Resources/GuardedUserResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+
+/**
+ * Fixture user resource exercising a request-scoped guard and a transformer.
+ *
+ * The name field carries a transformer so its output can be checked in the JSON
+ * body, and the email field carries a request-scoped guard so the key can be
+ * proven to drop out of the response unless the request permits it.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class GuardedUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'guarded_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name')->transform(static fn ($resource, $value): string => strtoupper(is_string($value) ? $value : '')),
+            Field::scalar('email')->guard(static fn ($resource, $request): bool => $request?->query('show') === 'yes'),
+        );
+    }
+}

--- a/tests/Fixtures/Services/Concerns/InnerRecordingConcern.php
+++ b/tests/Fixtures/Services/Concerns/InnerRecordingConcern.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Services\Concerns;
+
+/**
+ * Inner recording concern declared second in the concern list.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class InnerRecordingConcern extends RecordingConcern
+{
+    /**
+     * Return the label for this concern.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected function label(): string
+    {
+        return 'inner';
+    }
+}

--- a/tests/Fixtures/Services/Concerns/OuterRecordingConcern.php
+++ b/tests/Fixtures/Services/Concerns/OuterRecordingConcern.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Services\Concerns;
+
+/**
+ * Outer recording concern declared first in the concern list.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class OuterRecordingConcern extends RecordingConcern
+{
+    /**
+     * Return the label for this concern.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected function label(): string
+    {
+        return 'outer';
+    }
+}

--- a/tests/Fixtures/Services/Concerns/RecordingConcern.php
+++ b/tests/Fixtures/Services/Concerns/RecordingConcern.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Services\Concerns;
+
+use Illuminate\Support\Facades\DB;
+use SineMacula\ApiToolkit\Services\Contracts\ServiceConcern;
+use SineMacula\ApiToolkit\Services\ServiceContext;
+
+/**
+ * Base recording concern that logs entry/exit order and transaction depth.
+ *
+ * Concrete subclasses supply a label; each records "<label>:before" before
+ * delegating to the next stage and "<label>:after" after it returns, and
+ * captures the active database transaction level. A shared static trace lets a
+ * test assert the composition order and that every concern ran inside the one
+ * transaction.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+abstract class RecordingConcern implements ServiceConcern
+{
+    /** @var array<int, string> Ordered entry/exit markers across all concerns */
+    public static array $trace = [];
+
+    /** @var array<string, int> Transaction level captured per label */
+    public static array $levels = [];
+
+    /**
+     * Reset the shared static capture between tests.
+     *
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::$trace  = [];
+        self::$levels = [];
+    }
+
+    /**
+     * Append an entry to the shared trace.
+     *
+     * @param  string  $entry
+     * @return void
+     */
+    public static function push(string $entry): void
+    {
+        self::$trace[] = $entry;
+    }
+
+    /**
+     * Record the transaction level captured under the given key.
+     *
+     * @param  string  $key
+     * @param  int  $level
+     * @return void
+     */
+    public static function recordLevel(string $key, int $level): void
+    {
+        self::$levels[$key] = $level;
+    }
+
+    /**
+     * Record the label around the next stage and capture the transaction level.
+     *
+     * The context is required by the concern contract but not used here.
+     *
+     * @SuppressWarnings("php:S1172")
+     *
+     * @param  \SineMacula\ApiToolkit\Services\ServiceContext  $context
+     * @param  \Closure(): mixed  $next
+     * @return mixed
+     */
+    #[\Override]
+    public function handle(ServiceContext $context, \Closure $next): mixed
+    {
+        $label = $this->label();
+
+        self::push($label . ':before');
+        self::recordLevel($label, DB::transactionLevel());
+
+        $result = $next();
+
+        self::push($label . ':after');
+
+        return $result;
+    }
+
+    /**
+     * Return the unique label for this concern.
+     *
+     * @return string
+     */
+    abstract protected function label(): string;
+}

--- a/tests/Fixtures/Services/ValidatingUserService.php
+++ b/tests/Fixtures/Services/ValidatingUserService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Services;
+
+use Illuminate\Support\Facades\DB;
+use SineMacula\ApiToolkit\Services\Contracts\ServiceInput;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Service;
+use Tests\Fixtures\Input\SampleInput;
+
+/**
+ * Fixture service that validates a typed SampleInput inside the lifecycle.
+ *
+ * Carries the raw request snapshot as an ArrayInput and promotes it to a typed,
+ * validated SampleInput from within the validate() lifecycle hook. A missing
+ * required field makes from() throw ValidationException, which the runner
+ * captures as a failure before the transaction is opened, so handle() never
+ * runs and the users row is never written. On valid input, handle() inserts a
+ * row and returns the validated city, proving the core executed.
+ *
+ * @extends \SineMacula\ApiToolkit\Services\Service<\SineMacula\ApiToolkit\Services\Input\ArrayInput, string>
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ValidatingUserService extends Service
+{
+    /** @var \Tests\Fixtures\Input\SampleInput|null The validated typed input */
+    private ?SampleInput $validated = null;
+
+    /**
+     * Constructor.
+     *
+     * @param  \SineMacula\ApiToolkit\Services\Contracts\ServiceInput  $input
+     */
+    public function __construct(ServiceInput $input = new ArrayInput([]))
+    {
+        parent::__construct($input);
+    }
+
+    /**
+     * Validate the raw input and promote it to a typed SampleInput.
+     *
+     * Runs inside the lifecycle before the lock and transaction. Throws
+     * ValidationException when the source fails the SampleInput rules.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    #[\Override]
+    protected function validate(): void
+    {
+        $this->validated = SampleInput::from($this->input->toArray());
+    }
+
+    /**
+     * Insert a users row from the validated input and return the city.
+     *
+     * @return string
+     */
+    #[\Override]
+    protected function handle(): mixed
+    {
+        assert($this->validated !== null);
+
+        $city = $this->validated->city;
+
+        DB::table('users')->insert([
+            'name'  => $city,
+            'email' => strtolower($city) . '@validated.test',
+        ]);
+
+        return $city;
+    }
+}

--- a/tests/Fixtures/Support/ArrayMaintenanceMode.php
+++ b/tests/Fixtures/Support/ArrayMaintenanceMode.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Support;
+
+use Illuminate\Contracts\Foundation\MaintenanceMode;
+
+/**
+ * In-memory maintenance mode driver for isolated tests.
+ *
+ * The default file-based driver writes a process-global down file under the
+ * storage path, which bleeds across parallel test workers and trips the global
+ * maintenance middleware in unrelated tests. This driver keeps the state in
+ * memory so activation is scoped to the binding test's application instance.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class ArrayMaintenanceMode implements MaintenanceMode
+{
+    /** @var array<array-key, mixed>|null The active payload, or null when inactive. */
+    private ?array $payload = null;
+
+    /**
+     * Activate maintenance mode.
+     *
+     * @param  array<array-key, mixed>  $payload
+     * @return void
+     */
+    #[\Override]
+    public function activate(array $payload): void
+    {
+        $this->payload = $payload;
+    }
+
+    /**
+     * Deactivate maintenance mode.
+     *
+     * @return void
+     */
+    #[\Override]
+    public function deactivate(): void
+    {
+        $this->payload = null;
+    }
+
+    /**
+     * Determine whether maintenance mode is active.
+     *
+     * @return bool
+     */
+    #[\Override]
+    public function active(): bool // phpcs:ignore SineMacula.NamingConventions.BooleanMethodName.NotPredicate
+    {
+        return $this->payload !== null;
+    }
+
+    /**
+     * Get the active maintenance mode payload.
+     *
+     * @return array<array-key, mixed>
+     */
+    #[\Override]
+    public function data(): array
+    {
+        return $this->payload ?? [];
+    }
+}

--- a/tests/Integration/CacheableDeferrableInvalidationTest.php
+++ b/tests/Integration/CacheableDeferrableInvalidationTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\Attributes\CoversTrait;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
 use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
 use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
-use SineMacula\Repositories\Concerns\Cacheable;
 use Tests\Fixtures\Models\Tag;
 use Tests\Fixtures\Repositories\CacheableDeferrableTagRepository;
 use Tests\TestCase;
@@ -36,7 +35,6 @@ use Tests\TestCase;
  */
 #[CoversClass(DeferredWriteCacheInvalidator::class)]
 #[CoversClass(WritePoolFlushSubscriber::class)]
-#[CoversTrait(Cacheable::class)]
 #[CoversTrait(Deferrable::class)]
 final class CacheableDeferrableInvalidationTest extends TestCase
 {

--- a/tests/Integration/CacheableDeferrableInvalidationTest.php
+++ b/tests/Integration/CacheableDeferrableInvalidationTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
+use SineMacula\Repositories\Concerns\Cacheable;
+use Tests\Fixtures\Models\Tag;
+use Tests\Fixtures\Repositories\CacheableDeferrableTagRepository;
+use Tests\TestCase;
+
+/**
+ * Integration tests for a repository that is both Cacheable and Deferrable
+ * invalidating its own per-query cache at the request boundary.
+ *
+ * This exercises the full consumer path end to end: a read warms the combined
+ * repository's per-query cache, a deferred create is buffered through the same
+ * repository inside a route handler, and completing the request fires the real
+ * RequestHandled event so the subscribed listener flushes the write pool and
+ * invalidates the tags-table cache. Existing suites cover the cache-only repo,
+ * the direct pool flush, and the request boundary separately; this joins them.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(DeferredWriteCacheInvalidator::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+#[CoversTrait(Cacheable::class)]
+#[CoversTrait(Deferrable::class)]
+final class CacheableDeferrableInvalidationTest extends TestCase
+{
+    /**
+     * Set up the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Route::post('/api/deferred-tags', function (CacheableDeferrableTagRepository $repository): JsonResponse {
+
+            /** @var string $name */
+            $name = request()->input('name');
+
+            $repository->defer(['name' => $name]);
+
+            return response()->json(['deferred' => $name], 202);
+        });
+
+        Tag::create(['name' => 'php']);
+        Tag::create(['name' => 'laravel']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a deferred write flushed at the request boundary
+     * invalidates the combined repository's own per-query cache, so the
+     * next read re-queries and reflects the freshly persisted row.
+     *
+     * @return void
+     */
+    public function testBoundaryFlushInvalidatesOwnPerQueryCache(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        // Warm the combined repository's per-query cache: an identical repeated
+        // read would now be served from cache without a database round trip.
+        $this->warmCache();
+
+        // Defer a create through the same combined repository inside a route,
+        // then complete the request so RequestHandled flushes the pool.
+        $this->postJson('/api/deferred-tags', ['name' => 'vue'])->assertStatus(202);
+
+        // The boundary flush persisted the deferred row.
+        self::assertSame(3, DB::table('tags')->count());
+
+        DB::enableQueryLog();
+
+        $result = $this->freshRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+        // The stale cached collection is gone: the read re-queried the database
+        // and now reflects the row the boundary flush persisted.
+        self::assertCount(1, DB::getQueryLog());
+        self::assertCount(3, $result);
+    }
+
+    /**
+     * Test that, with invalidation disabled, the boundary flush still persists
+     * the deferred row but leaves the combined repository's cached collection
+     * stale until its TTL expires.
+     *
+     * @return void
+     */
+    public function testBoundaryFlushLeavesCacheStaleWhenInvalidationDisabled(): void
+    {
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', false);
+
+        $this->warmCache();
+
+        $this->postJson('/api/deferred-tags', ['name' => 'vue'])->assertStatus(202);
+
+        DB::enableQueryLog();
+
+        $result = $this->freshRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+        // Invalidation was disabled, so the warmed collection is served
+        // straight from cache without a database round trip and stays
+        // stale until its TTL expires.
+        self::assertCount(0, DB::getQueryLog());
+        self::assertCount(2, $result);
+
+        // The deferred write itself still reached the database; only the
+        // downstream cache invalidation was skipped.
+        self::assertSame(3, DB::table('tags')->count());
+    }
+
+    /**
+     * Warm the combined repository's per-query cache for the tags table.
+     *
+     * @return void
+     */
+    private function warmCache(): void
+    {
+        $this->freshRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
+    }
+
+    /**
+     * Resolve a fresh Cacheable and Deferrable tag repository from the
+     * container.
+     *
+     * @return \Tests\Fixtures\Repositories\CacheableDeferrableTagRepository
+     */
+    private function freshRepository(): CacheableDeferrableTagRepository
+    {
+        assert($this->app !== null);
+
+        return $this->app->make(CacheableDeferrableTagRepository::class);
+    }
+}

--- a/tests/Integration/CollectionEagerLoadRegressionTest.php
+++ b/tests/Integration/CollectionEagerLoadRegressionTest.php
@@ -98,6 +98,40 @@ final class CollectionEagerLoadRegressionTest extends TestCase
     }
 
     /**
+     * Count, sum, and average aggregates fold into the base query, so the
+     * fetch-and-serialise query count stays constant regardless of row count -
+     * a per-row re-load of the pre-loaded aggregates would scale with the rows.
+     *
+     * @return void
+     */
+    public function testAggregatesFoldIntoTheBaseQueryRegardlessOfRowCount(): void
+    {
+        $this->parseUserQuery('name,counts,sums,averages', [
+            'counts'   => ['users' => 'posts'],
+            'sums'     => ['users' => ['posts' => 'id']],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]);
+
+        $small = $this->fetchAndSerialise();
+
+        /** @var \Tests\Fixtures\Models\Organization $organization */
+        $organization = Organization::query()->firstOrFail();
+
+        $this->seedUsers(45, $organization->id, 5);
+
+        $large = $this->fetchAndSerialise();
+
+        self::assertSame($small['queries'], $large['queries']);
+        self::assertSame(1, $large['queries']);
+
+        // Prove the aggregates actually resolved rather than the constant count
+        // reflecting nothing loaded.
+        self::assertSame(2, $large['first']['counts']['posts']);
+        self::assertArrayHasKey('posts_id', $large['first']['sums']);
+        self::assertArrayHasKey('posts_id', $large['first']['averages']);
+    }
+
+    /**
      * Fetch the seeded users through the criteria chain and serialise them
      * under a query log, returning the query count and the decoded record.
      *
@@ -125,15 +159,17 @@ final class CollectionEagerLoadRegressionTest extends TestCase
     }
 
     /**
-     * Parse a user request for the given field set.
+     * Parse a user request for the given field set and optional extra params.
      *
      * @param  string  $fields
+     * @param  array<string, mixed>  $extra
      * @return void
      */
-    private function parseUserQuery(string $fields): void
+    private function parseUserQuery(string $fields, array $extra = []): void
     {
         $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
             'fields' => ['users' => $fields],
+            ...$extra,
         ]);
 
         ApiQuery::parse($request);

--- a/tests/Integration/CollectionEagerLoadRegressionTest.php
+++ b/tests/Integration/CollectionEagerLoadRegressionTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\EagerLoadApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Models\Organization;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Regression guard for N+1 queries when serialising a relation-bearing
+ * collection.
+ *
+ * Drives the eager-load planner through the criteria chain, then serialises
+ * the resulting collection under a query log. The query count must be constant
+ * regardless of how many rows the collection holds: a regression that made a
+ * nested relation resolve per-row would inflate the count in lockstep with the
+ * row count. The serialised relations are asserted to prove the constant count
+ * reflects eager loading rather than nothing loading at all.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiCriteria::class)]
+#[CoversClass(EagerLoadApplier::class)]
+final class CollectionEagerLoadRegressionTest extends TestCase
+{
+    /** @var string The route URI used to exercise the test endpoint. */
+    private const string TEST_URL = '/test';
+
+    /** @var int The upper bound on queries for the whole fetch-and-serialise pass. */
+    private const int EXPECTED_QUERIES = 3;
+
+    /**
+     * Set up each test with the blocklist posture and a seeded organization.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // This test measures eager-load query shape, not the query posture; pin
+        // the blocklist posture so the empty-surface criteria uses the legacy
+        // isSearchable contract.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
+
+        $organization = Organization::create(['name' => 'Acme Corp', 'slug' => 'acme-corp']);
+
+        $this->seedUsers(5, $organization->id);
+    }
+
+    /**
+     * The fetch-and-serialise query count is identical for a small and a large
+     * collection, and stays within the eager-load bound.
+     *
+     * @return void
+     */
+    public function testCollectionQueryCountIsConstantRegardlessOfRowCount(): void
+    {
+        $this->parseUserQuery('name,organization,posts');
+
+        $small = $this->fetchAndSerialise();
+
+        /** @var \Tests\Fixtures\Models\Organization $organization */
+        $organization = Organization::query()->firstOrFail();
+
+        // Grow the result set an order of magnitude; an N+1 regression would
+        // scale the query count with these extra rows.
+        $this->seedUsers(45, $organization->id, 5);
+
+        $large = $this->fetchAndSerialise();
+
+        self::assertSame($small['queries'], $large['queries']);
+        self::assertSame(self::EXPECTED_QUERIES, $large['queries']);
+
+        // Prove the relations actually hydrated, so the constant count reflects
+        // eager loading rather than a firewall returning missing values.
+        self::assertSame('Acme Corp', $large['first']['organization']['name']);
+        self::assertNotEmpty($large['first']['posts']);
+        self::assertArrayHasKey('title', $large['first']['posts'][0]);
+    }
+
+    /**
+     * Fetch the seeded users through the criteria chain and serialise them
+     * under a query log, returning the query count and the decoded record.
+     *
+     * @return array{queries: int, first: array<string, mixed>}
+     */
+    private function fetchAndSerialise(): array
+    {
+        DB::enableQueryLog();
+
+        $users = $this->applyUserCriteria()->get();
+        $data  = UserResource::collection($users)->resolve(Request::create(self::TEST_URL));
+
+        $queries = count(DB::getQueryLog());
+
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+
+        $decoded = json_decode((string) json_encode($data), true);
+
+        /** @var array<int, array<string, mixed>> $decoded */
+        return [
+            'queries' => $queries,
+            'first'   => $decoded[0] ?? [],
+        ];
+    }
+
+    /**
+     * Parse a user request for the given field set.
+     *
+     * @param  string  $fields
+     * @return void
+     */
+    private function parseUserQuery(string $fields): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields' => ['users' => $fields],
+        ]);
+
+        ApiQuery::parse($request);
+    }
+
+    /**
+     * Apply the criteria chain to a user query bound to the user resource.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User>
+     */
+    private function applyUserCriteria(): Builder
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria $criteria */
+        $criteria = $this->app->make(ApiCriteria::class);
+
+        /** @var \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User> */
+        return $criteria->usingResource(UserResource::class)->apply(new User);
+    }
+
+    /**
+     * Seed the given number of users in the organization, each with two posts.
+     *
+     * @param  int  $count
+     * @param  int  $organizationId
+     * @param  int  $offset
+     * @return void
+     */
+    private function seedUsers(int $count, int $organizationId, int $offset = 0): void
+    {
+        for ($index = 1; $index <= $count; $index++) {
+
+            $number = $index + $offset;
+
+            $user = User::create([
+                'name'            => 'User ' . $number,
+                'email'           => 'user' . $number . '@example.com',
+                'status'          => 'active',
+                'organization_id' => $organizationId,
+            ]);
+
+            Post::create(['user_id' => $user->id, 'title' => 'Post ' . $number . 'a', 'body' => 'Content', 'published' => true]);
+            Post::create(['user_id' => $user->id, 'title' => 'Post ' . $number . 'b', 'body' => 'Content', 'published' => false]);
+        }
+    }
+}

--- a/tests/Integration/ConstrainedRelationQueryBoundTest.php
+++ b/tests/Integration/ConstrainedRelationQueryBoundTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
+use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\EagerLoadApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Models\Organization;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\ConstrainedUserResource;
+use Tests\TestCase;
+
+/**
+ * Query-bound guard for a constrained eager-loaded relation.
+ *
+ * The user resource declares a posts relation constrained to published posts.
+ * Serialising a collection under a query log must load that relation through a
+ * single constrained sub-query for the whole set - constant, not one per row -
+ * and the constraint must actually apply so only published posts surface.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiCriteria::class)]
+#[CoversClass(EagerLoadApplier::class)]
+#[CoversClass(EagerLoadPlanner::class)]
+final class ConstrainedRelationQueryBoundTest extends TestCase
+{
+    /** @var string The route URI used to exercise the test endpoint. */
+    private const string TEST_URL = '/test';
+
+    /** @var int The query bound: one query for users, one for constrained posts. */
+    private const int EXPECTED_QUERIES = 2;
+
+    /** @var int The number of published posts seeded per user. */
+    private const int PUBLISHED_PER_USER = 2;
+
+    /**
+     * Set up each test with the blocklist posture and a seeded organization.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // This test measures eager-load query shape, not the query posture; pin
+        // the blocklist posture so the empty-surface criteria uses the legacy
+        // isSearchable contract.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
+
+        $organization = Organization::create(['name' => 'Acme Corp', 'slug' => 'acme-corp']);
+
+        $this->seedUsers(5, $organization->id);
+    }
+
+    /**
+     * The constrained relation loads in one extra query for the whole
+     * collection regardless of row count, and only published posts surface.
+     *
+     * @return void
+     */
+    public function testConstrainedRelationLoadsOnceAndAppliesTheConstraint(): void
+    {
+        $this->parseConstrainedQuery();
+
+        $small = $this->fetchAndSerialise();
+
+        /** @var \Tests\Fixtures\Models\Organization $organization */
+        $organization = Organization::query()->firstOrFail();
+
+        // Grow the result set an order of magnitude; a per-row constrained load
+        // would scale the query count with these extra rows.
+        $this->seedUsers(45, $organization->id, 5);
+
+        $large = $this->fetchAndSerialise();
+
+        self::assertSame($small['queries'], $large['queries']);
+        self::assertSame(self::EXPECTED_QUERIES, $large['queries']);
+
+        // Prove the constraint applied: only the published posts hydrated, so
+        // the constant count reflects a single constrained sub-query rather
+        // than an unconstrained or empty load.
+        /** @var list<array<string, mixed>> $posts */
+        $posts = $large['first']['posts'];
+
+        self::assertCount(self::PUBLISHED_PER_USER, $posts);
+
+        foreach ($posts as $post) {
+            self::assertTrue($post['published'] === true);
+            self::assertIsString($post['title']);
+            self::assertStringStartsWith('Published', $post['title']);
+        }
+    }
+
+    /**
+     * Fetch the seeded users through the criteria chain and serialise them
+     * under a query log, returning the query count and the decoded record.
+     *
+     * @return array{queries: int, first: array<string, mixed>}
+     */
+    private function fetchAndSerialise(): array
+    {
+        DB::enableQueryLog();
+
+        $users = $this->applyUserCriteria()->get();
+        $data  = ConstrainedUserResource::collection($users)->resolve(Request::create(self::TEST_URL));
+
+        $queries = count(DB::getQueryLog());
+
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+
+        $decoded = json_decode((string) json_encode($data), true);
+
+        /** @var array<int, array<string, mixed>> $decoded */
+        return [
+            'queries' => $queries,
+            'first'   => $decoded[0] ?? [],
+        ];
+    }
+
+    /**
+     * Parse a request selecting the constrained posts relation and enough post
+     * fields to observe the applied constraint.
+     *
+     * @return void
+     */
+    private function parseConstrainedQuery(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields' => [
+                'constrained_users' => 'name,posts',
+                'posts'             => 'id,title,published',
+            ],
+        ]);
+
+        ApiQuery::parse($request);
+    }
+
+    /**
+     * Apply the criteria chain to a user query bound to the constrained
+     * resource.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User>
+     */
+    private function applyUserCriteria(): Builder
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria $criteria */
+        $criteria = $this->app->make(ApiCriteria::class);
+
+        /** @var \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User> */
+        return $criteria->usingResource(ConstrainedUserResource::class)->apply(new User);
+    }
+
+    /**
+     * Seed users each with a mix of published and unpublished posts.
+     *
+     * @param  int  $count
+     * @param  int  $organizationId
+     * @param  int  $offset
+     * @return void
+     */
+    private function seedUsers(int $count, int $organizationId, int $offset = 0): void
+    {
+        for ($index = 1; $index <= $count; $index++) {
+
+            $number = $index + $offset;
+
+            $user = User::create([
+                'name'            => 'User ' . $number,
+                'email'           => 'user' . $number . '@example.com',
+                'status'          => 'active',
+                'organization_id' => $organizationId,
+            ]);
+
+            Post::create(['user_id' => $user->id, 'title' => 'Published ' . $number . 'a', 'body' => 'Content', 'published' => true]);
+            Post::create(['user_id' => $user->id, 'title' => 'Published ' . $number . 'b', 'body' => 'Content', 'published' => true]);
+            Post::create(['user_id' => $user->id, 'title' => 'Draft ' . $number, 'body' => 'Content', 'published' => false]);
+        }
+    }
+}

--- a/tests/Integration/DeepNestingQueryBoundTest.php
+++ b/tests/Integration/DeepNestingQueryBoundTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
+use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\EagerLoadApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Models\Organization;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\Tag;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Query-bound guard for a three-level nested field selection.
+ *
+ * Drives the eager-load planner across users -> posts -> tags, then serialises
+ * the collection under a query log. The count must be a small constant (one
+ * query per level, batched) and identical for a small and a large row count:
+ * were the third level loaded per row, the count would scale with the rows.
+ * The tags are asserted to have hydrated so a constant count cannot mean the
+ * deepest level simply never loaded.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiCriteria::class)]
+#[CoversClass(EagerLoadApplier::class)]
+#[CoversClass(EagerLoadPlanner::class)]
+final class DeepNestingQueryBoundTest extends TestCase
+{
+    /** @var string The route URI used to exercise the test endpoint. */
+    private const string TEST_URL = '/test';
+
+    /** @var int The query bound: one query per level for users, posts, tags. */
+    private const int EXPECTED_QUERIES = 3;
+
+    /** @var array<int, int> The tag ids attached to every seeded post. */
+    private array $tagIds = [];
+
+    /**
+     * Set up each test with the blocklist posture and a tag pool.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // This test measures eager-load query shape, not the query posture; pin
+        // the blocklist posture so the empty-surface criteria uses the legacy
+        // isSearchable contract.
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
+
+        $this->tagIds = [
+            Tag::create(['name' => 'php'])->id,
+            Tag::create(['name' => 'laravel'])->id,
+        ];
+
+        $organization = Organization::create(['name' => 'Acme Corp', 'slug' => 'acme-corp']);
+
+        $this->seedUsers(5, $organization->id);
+    }
+
+    /**
+     * The three-level fetch-and-serialise count is constant regardless of row
+     * count, proving the tag level is batched rather than loaded per row.
+     *
+     * @return void
+     */
+    public function testDeepNestingQueryCountIsConstantRegardlessOfRowCount(): void
+    {
+        $this->parseNestedQuery();
+
+        $small = $this->fetchAndSerialise();
+
+        /** @var \Tests\Fixtures\Models\Organization $organization */
+        $organization = Organization::query()->firstOrFail();
+
+        // Grow the result set an order of magnitude; a per-row load of the
+        // deepest level would scale the query count with these extra rows.
+        $this->seedUsers(45, $organization->id, 5);
+
+        $large = $this->fetchAndSerialise();
+
+        self::assertSame($small['queries'], $large['queries']);
+        self::assertSame(self::EXPECTED_QUERIES, $large['queries']);
+
+        // Prove every level hydrated, so the constant count reflects batched
+        // eager loading rather than the deepest relation never loading.
+        self::assertNotEmpty($large['first']['posts']);
+
+        $firstPost = $large['first']['posts'][0];
+
+        self::assertArrayHasKey('tags', $firstPost);
+        self::assertNotEmpty($firstPost['tags']);
+        self::assertArrayHasKey('name', $firstPost['tags'][0]);
+    }
+
+    /**
+     * Fetch the seeded users through the criteria chain and serialise them
+     * under a query log, returning the query count and the decoded record.
+     *
+     * @return array{queries: int, first: array<string, mixed>}
+     */
+    private function fetchAndSerialise(): array
+    {
+        DB::enableQueryLog();
+
+        $users = $this->applyUserCriteria()->get();
+        $data  = UserResource::collection($users)->resolve(Request::create(self::TEST_URL));
+
+        $queries = count(DB::getQueryLog());
+
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+
+        $decoded = json_decode((string) json_encode($data), true);
+
+        /** @var array<int, array<string, mixed>> $decoded */
+        return [
+            'queries' => $queries,
+            'first'   => $decoded[0] ?? [],
+        ];
+    }
+
+    /**
+     * Parse a user request declaring the nested users -> posts -> tags field
+     * selection so the planner recurses all three levels.
+     *
+     * @return void
+     */
+    private function parseNestedQuery(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'fields' => [
+                'users' => 'name,posts',
+                'posts' => 'title,tags',
+                'tags'  => 'name',
+            ],
+        ]);
+
+        ApiQuery::parse($request);
+    }
+
+    /**
+     * Apply the criteria chain to a user query bound to the user resource.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User>
+     */
+    private function applyUserCriteria(): Builder
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria $criteria */
+        $criteria = $this->app->make(ApiCriteria::class);
+
+        /** @var \Illuminate\Database\Eloquent\Builder<\Tests\Fixtures\Models\User> */
+        return $criteria->usingResource(UserResource::class)->apply(new User);
+    }
+
+    /**
+     * Seed the given number of users, each with two posts, each post carrying
+     * the shared tag pool.
+     *
+     * @param  int  $count
+     * @param  int  $organizationId
+     * @param  int  $offset
+     * @return void
+     */
+    private function seedUsers(int $count, int $organizationId, int $offset = 0): void
+    {
+        for ($index = 1; $index <= $count; $index++) {
+
+            $number = $index + $offset;
+
+            $user = User::create([
+                'name'            => 'User ' . $number,
+                'email'           => 'user' . $number . '@example.com',
+                'status'          => 'active',
+                'organization_id' => $organizationId,
+            ]);
+
+            $postA = Post::create(['user_id' => $user->id, 'title' => 'Post ' . $number . 'a', 'body' => 'Content', 'published' => true]);
+            $postB = Post::create(['user_id' => $user->id, 'title' => 'Post ' . $number . 'b', 'body' => 'Content', 'published' => false]);
+
+            $postA->tags()->attach($this->tagIds);
+            $postB->tags()->attach($this->tagIds);
+        }
+    }
+}

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -8,10 +8,12 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\Facades\Log;
+use Laravel\Octane\Events\OperationTerminated;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
 use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
+use Tests\Fixtures\Support\FunctionOverrides;
 use Tests\TestCase;
 
 /**
@@ -81,6 +83,33 @@ final class LifecycleRegistrarTest extends TestCase
 
         self::assertTrue($this->hasSubscriberListener(RequestHandled::class, WritePoolFlushSubscriber::class));
         self::assertTrue($this->hasSubscriberListener(JobProcessed::class, QueueFlushSubscriber::class));
+    }
+
+    /**
+     * Test that the Octane flush listener is wired when the lifecycle Octane
+     * flush is enabled and the Octane event class is available.
+     *
+     * @return void
+     */
+    public function testOctaneFlushListenerRegisteredWhenClassPresentAndEnabled(): void
+    {
+        unset($_SERVER['LARAVEL_OCTANE']);
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->getApplication()->make('config');
+        $config->set('api-toolkit.lifecycle.octane', true);
+        $config->set('api-toolkit.lifecycle.queue', false);
+
+        // Simulate laravel/octane being installed so the class_exists guard
+        // passes and the listener binds to the event class name.
+        FunctionOverrides::set('class_exists', static fn (string $class): bool => $class === OperationTerminated::class || \class_exists($class)); // @phpstan-ignore class.notFound
+
+        (new LifecycleRegistrar)->register();
+
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $this->getApplication()->make('events');
+
+        self::assertTrue($events->hasListeners(OperationTerminated::class)); // @phpstan-ignore class.notFound
     }
 
     /**

--- a/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LoggingRegistrarTest.php
@@ -10,6 +10,7 @@ use Illuminate\Notifications\Events\NotificationSent;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Listeners\NotificationListener;
 use SineMacula\ApiToolkit\Providers\Registrars\LoggingRegistrar;
+use Tests\Fixtures\Support\FunctionOverrides;
 use Tests\TestCase;
 
 /**
@@ -72,6 +73,36 @@ final class LoggingRegistrarTest extends TestCase
         $config = $app->make('config');
 
         $config->set('api-toolkit.notifications.enable_logging', false);
+
+        (new LoggingRegistrar)->register();
+
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $app->make('events');
+
+        $raw = $events->getRawListeners();
+
+        self::assertNotContains([NotificationListener::class, 'sending'], $raw[NotificationSending::class] ?? []);
+        self::assertNotContains([NotificationListener::class, 'sent'], $raw[NotificationSent::class] ?? []);
+    }
+
+    /**
+     * Test that no notification logging listeners are registered when logging
+     * is enabled but illuminate/notifications is not installed.
+     *
+     * @return void
+     */
+    public function testRegisterSkipsNotificationLoggingWhenPackageAbsent(): void
+    {
+        $app = $this->getApplication();
+
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $app->make('config');
+
+        $config->set('api-toolkit.notifications.enable_logging', true);
+
+        // Simulate illuminate/notifications being absent so the class_exists
+        // guard short-circuits before any listener is wired.
+        FunctionOverrides::set('class_exists', static fn (string $class): bool => $class !== NotificationSending::class && \class_exists($class));
 
         (new LoggingRegistrar)->register();
 

--- a/tests/Integration/Providers/Registrars/MiddlewareRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/MiddlewareRegistrarTest.php
@@ -6,6 +6,7 @@ namespace Tests\Integration\Providers\Registrars;
 
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance as FrameworkMaintenance;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Http\Middleware\DetectsCapabilities;
@@ -59,6 +60,10 @@ final class MiddlewareRegistrarTest extends TestCase
         self::assertContains(PreventRequestsDuringMaintenance::class, $middleware);
         self::assertContains(DetectsCapabilities::class, $middleware);
         self::assertContains(JsonPrettyPrint::class, $middleware);
+
+        // The maintenance swap removes the framework middleware so the toolkit
+        // middleware is the sole gate and its except list is authoritative.
+        self::assertNotContains(FrameworkMaintenance::class, $middleware);
 
         /** @var \Illuminate\Routing\Router $router */
         $router = $app->make(Router::class);

--- a/tests/Integration/ServiceAfterCommitTest.php
+++ b/tests/Integration/ServiceAfterCommitTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Service;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
+use Tests\TestCase;
+
+/**
+ * Integration test for a throwing afterCommit hook over a real transaction.
+ *
+ * Proves that when the core write commits and the afterCommit hook then throws,
+ * the committed row survives and the failure is captured as a side-effect error
+ * on a still-successful result rather than rolling back or escaping the runner.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ServiceRunner::class)]
+final class ServiceAfterCommitTest extends TestCase
+{
+    /**
+     * Set up each test with a silent log channel for the captured error.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Log::spy();
+    }
+
+    /**
+     * Test that a throwing afterCommit captures while the write survives.
+     *
+     * @return void
+     */
+    public function testAfterCommitThrowIsCapturedAndWritePersists(): void
+    {
+        $service = new class (new ArrayInput([])) extends Service {
+            /**
+             * Insert a row inside the committed transaction.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function handle(): mixed
+            {
+                DB::table('users')->insert([
+                    'name'  => 'after_commit',
+                    'email' => 'after-commit@service.test',
+                ]);
+
+                return 'written';
+            }
+
+            /**
+             * Throw after the transaction has already committed.
+             *
+             * The output is required by the hook signature but not used here.
+             *
+             * @SuppressWarnings("php:S1172")
+             *
+             * @param  mixed  $output
+             * @return never
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function afterCommit(mixed $output): never
+            {
+                throw new \RuntimeException('after commit failed');
+            }
+        };
+
+        $result = $service->run();
+
+        // The run still succeeds: the committed write is intact and the
+        // afterCommit failure is captured rather than rethrown or rolled back.
+        self::assertTrue($result->succeeded());
+        self::assertSame('written', $result->output());
+
+        $errors = $result->sideEffectErrors();
+
+        self::assertCount(1, $errors);
+        self::assertInstanceOf(\RuntimeException::class, $errors[0]);
+        self::assertSame('after commit failed', $errors[0]->getMessage());
+
+        $this->assertDatabaseHas('users', ['email' => 'after-commit@service.test']);
+    }
+}

--- a/tests/Integration/ServiceConcernOrderTest.php
+++ b/tests/Integration/ServiceConcernOrderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Service;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
+use Tests\Fixtures\Services\Concerns\InnerRecordingConcern;
+use Tests\Fixtures\Services\Concerns\OuterRecordingConcern;
+use Tests\Fixtures\Services\Concerns\RecordingConcern;
+use Tests\TestCase;
+
+/**
+ * Integration test for synchronous concern composition over a real transaction.
+ *
+ * Proves that multiple synchronous concerns wrap the core in declaration order
+ * (the first-declared concern being the outermost) and that every concern and
+ * the core execute inside the one shared database transaction rather than each
+ * opening its own.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ServiceRunner::class)]
+final class ServiceConcernOrderTest extends TestCase
+{
+    /**
+     * Reset the shared concern capture before each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RecordingConcern::reset();
+    }
+
+    /**
+     * Test that concerns wrap the core in order within one transaction.
+     *
+     * @return void
+     */
+    public function testConcernsWrapCoreInOrderWithinOneTransaction(): void
+    {
+        $baseLevel = DB::transactionLevel();
+
+        $service = new class (new ArrayInput([])) extends Service {
+            /**
+             * Return the concerns in declaration order.
+             *
+             * @return array<int, class-string<\SineMacula\ApiToolkit\Services\Contracts\ServiceConcern>>
+             */
+            #[\Override]
+            protected function concerns(): array
+            {
+                return [OuterRecordingConcern::class, InnerRecordingConcern::class];
+            }
+
+            /**
+             * Record the core marker and its transaction level.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function handle(): mixed
+            {
+                RecordingConcern::push('core');
+                RecordingConcern::recordLevel('core', DB::transactionLevel());
+
+                return 'done';
+            }
+        };
+
+        $result = $service->run();
+
+        self::assertTrue($result->succeeded());
+        self::assertSame('done', $result->output());
+
+        // The first-declared concern is outermost and the core runs innermost.
+        self::assertSame(
+            ['outer:before', 'inner:before', 'core', 'inner:after', 'outer:after'],
+            RecordingConcern::$trace,
+        );
+
+        // The runner opens exactly one transaction for the whole pipeline, so
+        // every concern and the core observe the same single level one deeper
+        // than the ambient level.
+        $expected = $baseLevel + 1;
+
+        self::assertSame($expected, RecordingConcern::$levels['outer']);
+        self::assertSame($expected, RecordingConcern::$levels['inner']);
+        self::assertSame($expected, RecordingConcern::$levels['core']);
+    }
+}

--- a/tests/Integration/ServiceHttpAndDispatchTest.php
+++ b/tests/Integration/ServiceHttpAndDispatchTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Services\Enums\ServiceSource;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Jobs\ServiceJob;
+use SineMacula\ApiToolkit\Services\Service;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\Fixtures\Services\SimpleService;
+use Tests\Fixtures\Services\StubActor;
+use Tests\TestCase;
+
+/**
+ * Integration tests for the service lifecycle driven over the wire.
+ *
+ * Proves the two edge invocations of a service: an HTTP route action runs a
+ * service inside the real request lifecycle and returns the created subject
+ * through the toolkit resource response, and Service::dispatch() pushes a
+ * ServiceJob carrying the service class and the explicit actor context onto a
+ * faked queue. The queue re-hydration path itself is covered elsewhere; this
+ * suite proves only the HTTP and dispatch entry points.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(Service::class)]
+#[CoversClass(ServiceRunner::class)]
+#[CoversClass(ServiceJob::class)]
+final class ServiceHttpAndDispatchTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with the toolkit handler and a service-backed route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::post('/api/service-user', static function (Request $request): UserResource {
+
+            $service = new class (new ArrayInput($request->all())) extends Service {
+                /**
+                 * Create a user from the input and return it as the output.
+                 *
+                 * @return \Tests\Fixtures\Models\User
+                 */
+                #[\Override]
+                protected function handle(): mixed
+                {
+                    $data = $this->input->toArray();
+                    $name = isset($data['name']) && is_string($data['name']) ? $data['name'] : 'anonymous';
+
+                    return User::create([
+                        'name'  => $name,
+                        'email' => strtolower($name) . '@service.test',
+                    ]);
+                }
+            };
+
+            $user = $service->run()->throw()->output();
+
+            assert($user instanceof User);
+
+            return UserResource::make($user);
+        });
+    }
+
+    /**
+     * Test that an HTTP action runs a service and returns its output.
+     *
+     * The route action runs the full service lifecycle in-process, so the
+     * created user is reflected in the toolkit resource body (including the
+     * service-derived email) and as a committed row in the database.
+     *
+     * @return void
+     */
+    public function testHttpActionRunsServiceAndReturnsOutput(): void
+    {
+        $response = $this->postJson('/api/service-user', ['name' => 'Fabricated']);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('data._type', 'users');
+        $response->assertJsonPath('data.name', 'Fabricated');
+        $response->assertJsonPath('data.email', 'fabricated@service.test');
+
+        $this->assertDatabaseHas('users', ['email' => 'fabricated@service.test']);
+    }
+
+    /**
+     * Test that Service::dispatch() pushes a ServiceJob to the queue.
+     *
+     * The real dispatch path is exercised under a faked queue: the pushed job
+     * carries the concrete service class-string and the explicit actor context,
+     * with the source defaulting to INTERNAL for a synchronous dispatch.
+     *
+     * @return void
+     */
+    public function testDispatchPushesServiceJobWithActorContext(): void
+    {
+        Queue::fake();
+
+        (new SimpleService)->by(new StubActor)->dispatch();
+
+        Queue::assertPushed(ServiceJob::class, static fn (ServiceJob $job): bool => is_a($job->service, SimpleService::class, true)
+                && $job->context->actor instanceof StubActor
+                && $job->context->actor->actorIdentifier() === 'stub-id'
+                && $job->context->source                   === ServiceSource::INTERNAL);
+    }
+}

--- a/tests/Integration/ServiceInputValidationTest.php
+++ b/tests/Integration/ServiceInputValidationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Input\InputData;
+use SineMacula\ApiToolkit\Services\Service;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
+use Tests\Fixtures\Services\ValidatingUserService;
+use Tests\TestCase;
+
+/**
+ * Integration tests for typed input validation on the real service path.
+ *
+ * Proves the headline contract: a typed InputData is validated inside the
+ * lifecycle, and a validation failure is captured in the total result without
+ * ever throwing out of run(). The failed run opens no transaction and writes no
+ * row, while a valid run reaches handle() and commits.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(Service::class)]
+#[CoversClass(ServiceRunner::class)]
+#[CoversClass(InputData::class)]
+final class ServiceInputValidationTest extends TestCase
+{
+    /**
+     * Test that a failed typed-input validation is captured without throwing.
+     *
+     * The service declares SampleInput as its input and receives a raw snapshot
+     * missing the required city. run() must not throw; the result reports
+     * failure carrying the ValidationException, and no users row is written
+     * because handle() never ran.
+     *
+     * @return void
+     */
+    public function testInvalidTypedInputIsCapturedWithoutThrowing(): void
+    {
+        $service = new ValidatingUserService(new ArrayInput(['age' => 30]));
+
+        $result = $service->run();
+
+        self::assertTrue($result->failed());
+
+        $exception = $result->exception;
+
+        self::assertInstanceOf(ValidationException::class, $exception);
+        self::assertArrayHasKey('city', $exception->errors());
+        self::assertDatabaseCount('users', 0);
+    }
+
+    /**
+     * Test that a valid typed input reaches handle() and commits its write.
+     *
+     * Proves the same path succeeds when the input satisfies the rules: the
+     * validated city threads through to the output and the row is committed.
+     *
+     * @return void
+     */
+    public function testValidTypedInputReachesHandleAndCommits(): void
+    {
+        $service = new ValidatingUserService(new ArrayInput(['city' => 'London', 'age' => 30]));
+
+        $result = $service->run();
+
+        self::assertTrue($result->succeeded());
+        self::assertSame('London', $result->output());
+        self::assertDatabaseCount('users', 1);
+        self::assertDatabaseHas('users', ['name' => 'London']);
+    }
+}

--- a/tests/Integration/ServiceLockReleaseTest.php
+++ b/tests/Integration/ServiceLockReleaseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Pipeline\LockStage;
+use SineMacula\ApiToolkit\Services\Service;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
+use Tests\TestCase;
+
+/**
+ * Integration test for lock release when the core throws.
+ *
+ * Proves that a lockable service whose handle() throws still releases its cache
+ * lock: after the failed run the same lock is free for a second acquisition and
+ * the result reports failure carrying the thrown exception.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ServiceRunner::class)]
+#[CoversClass(LockStage::class)]
+final class ServiceLockReleaseTest extends TestCase
+{
+    /**
+     * Test that a throwing handle() releases the lock and fails the result.
+     *
+     * @return void
+     */
+    public function testThrowingHandleReleasesLock(): void
+    {
+        $service = new class (new ArrayInput([])) extends Service {
+            /** @var bool Whether this service acquires a cache lock */
+            protected bool $lockable = true;
+
+            /**
+             * Throw from the core to force the lock to release under failure.
+             *
+             * @return never
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function handle(): never
+            {
+                throw new \RuntimeException('handle failed under lock');
+            }
+
+            /**
+             * Return the unique lock identity for this invocation.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function lockId(): string
+            {
+                return 'lock-release-on-throw';
+            }
+        };
+
+        $result = $service->run();
+
+        self::assertTrue($result->failed());
+        self::assertInstanceOf(\RuntimeException::class, $result->exception);
+
+        // The lock must be free after the failed run, so a fresh acquisition of
+        // the same key succeeds.
+        $lock = Cache::lock($service->getLockKey(), 60);
+
+        self::assertTrue($lock->get());
+
+        $lock->release();
+    }
+}

--- a/tests/Unit/ApiQueryParserTest.php
+++ b/tests/Unit/ApiQueryParserTest.php
@@ -760,4 +760,21 @@ final class ApiQueryParserTest extends TestCase
         $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['fields' => 123]);
         $this->parser->parse($request);
     }
+
+    /**
+     * Test that reset clears all previously parsed parameters.
+     *
+     * @return void
+     */
+    public function testResetClearsAllParsedParameters(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), ['fields' => self::FIELDS_NAME_EMAIL]);
+        $this->parser->parse($request);
+
+        self::assertSame(['name', 'email'], $this->parser->getFields());
+
+        $this->parser->reset();
+
+        self::assertNull($this->parser->getFields());
+    }
 }

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -239,6 +239,31 @@ final class CacheManagerTest extends TestCase
     }
 
     /**
+     * Test that flush skips the query parser reset when the configured alias is
+     * not bound in the container.
+     *
+     * @return void
+     */
+    public function testFlushSkipsQueryParserResetWhenAliasNotBound(): void
+    {
+        // Arrange
+        Event::fake();
+
+        config()->set('api-toolkit.parser.alias', 'api.query.unbound');
+
+        assert($this->app !== null);
+        self::assertFalse($this->app->bound('api.query.unbound'));
+
+        // Act
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $manager */
+        $manager = $this->app->make(CacheManager::class); // @phpstan-ignore method.nonObject
+        $manager->flush();
+
+        // Assert
+        Event::assertDispatched(CacheFlushed::class);
+    }
+
+    /**
      * Test that flush on empty state does not throw an exception.
      *
      * @return void

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -436,6 +436,57 @@ final class ApiExceptionTest extends TestCase
     }
 
     /**
+     * Test that an exception whose status has no enum case falls back to the
+     * generic literal title when no unknown-status translation is registered
+     * under its namespace.
+     *
+     * @return void
+     */
+    public function testGetCustomTitleFallsBackToGenericLiteralWhenNoTranslationExists(): void
+    {
+        $exception = new class extends ApiException {
+            /** The internal error code for the test exception. */
+            public const \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface CODE = ErrorCode::HTTP_ERROR;
+
+            /**
+             * Get the HTTP status code for this exception instance.
+             *
+             * @return int
+             */
+            #[\Override]
+            public function getStatusCode(): int
+            {
+                return 419;
+            }
+
+            /**
+             * Get the HTTP status for this exception instance.
+             *
+             * @return \SineMacula\Http\Enums\HttpStatus|null
+             */
+            #[\Override]
+            public function getStatus(): ?HttpStatus
+            {
+                return null;
+            }
+
+            /**
+             * Resolve from a namespace with no registered translations so the
+             * unknown-status key is absent.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function getNamespace(): string
+            {
+                return 'missing-namespace-for-title';
+            }
+        };
+
+        self::assertSame('Unknown Error', $exception->getCustomTitle());
+    }
+
+    /**
      * Test that a non-string per-status translation yields an empty title
      * rather than an error, matching the code-keyed title guard.
      *

--- a/tests/Unit/Http/Middleware/JsonPrettyPrintTest.php
+++ b/tests/Unit/Http/Middleware/JsonPrettyPrintTest.php
@@ -221,6 +221,32 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
+     * Test that a non-streamed response whose content is not a string (its
+     * body is served from a file) is left untouched even when it declares a
+     * JSON content type.
+     *
+     * @return void
+     */
+    public function testSkipsPlainResponseWhoseContentIsNotAString(): void
+    {
+        $request    = Request::create(self::TEST_URI, HttpMethod::GET->getVerb(), ['pretty' => 'true']);
+        $middleware = new JsonPrettyPrint;
+        $tempFile   = tempnam(sys_get_temp_dir(), 'test');
+
+        self::assertIsString($tempFile);
+
+        $binaryFileResponse = new BinaryFileResponse($tempFile);
+        $binaryFileResponse->headers->set('Content-Type', self::CONTENT_TYPE_JSON);
+
+        $response = $middleware->handle($request, fn () => $binaryFileResponse);
+
+        self::assertSame($binaryFileResponse, $response);
+        self::assertFalse($response->getContent());
+
+        unlink($tempFile);
+    }
+
+    /**
      * Test that plain Response with JSON content-type preserves malformed JSON.
      *
      * @return void

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -2682,6 +2682,59 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
+     * Test that an aggregate is recognised as loaded by matching the aliased
+     * attribute name, so a pre-loaded aggregate is not re-queried per row.
+     *
+     * @return void
+     */
+    public function testIsAggregateLoadedMatchesTheAliasedAttribute(): void
+    {
+        $user = new User;
+        $user->setAttribute('posts_sum_id', 10);
+        $user->setAttribute('plain', 1);
+
+        $resource = new UserResource($user);
+        $method   = new \ReflectionMethod(UserResource::class, 'isAggregateLoaded');
+
+        // The alias after ' as ' is matched against the loaded attributes.
+        self::assertTrue($method->invoke($resource, $user, 'posts as posts_sum_id'));
+        self::assertFalse($method->invoke($resource, $user, 'comments as comments_sum_id'));
+
+        // The constrained (array-keyed) form reads the key.
+        self::assertTrue($method->invoke($resource, $user, ['posts as posts_sum_id' => static fn (): null => null]));
+
+        // A specification without an alias is matched verbatim.
+        self::assertTrue($method->invoke($resource, $user, 'plain'));
+        self::assertFalse($method->invoke($resource, $user, 'missing'));
+    }
+
+    /**
+     * Test that already-loaded aggregate specifications are dropped while
+     * unloaded ones are retained.
+     *
+     * @return void
+     */
+    public function testRejectLoadedAggregatesDropsPreloadedSpecifications(): void
+    {
+        $user = new User;
+        $user->setAttribute('posts_count', 2);
+
+        $resource = new UserResource($user);
+        $method   = new \ReflectionMethod(UserResource::class, 'rejectLoadedAggregates');
+
+        /** @var array<int|string, mixed> $result */
+        $result = $method->invoke($resource, $user, [
+            'posts as posts_count',
+            'comments as comments_count',
+            'tags as tags_count' => static fn (): null => null,
+        ]);
+
+        self::assertContains('comments as comments_count', $result);
+        self::assertArrayHasKey('tags as tags_count', $result);
+        self::assertNotContains('posts as posts_count', $result);
+    }
+
+    /**
      * Clear the static schema cache between tests.
      *
      * @return void

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -2682,35 +2682,8 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
-     * Test that an aggregate is recognised as loaded by matching the aliased
-     * attribute name, so a pre-loaded aggregate is not re-queried per row.
-     *
-     * @return void
-     */
-    public function testIsAggregateLoadedMatchesTheAliasedAttribute(): void
-    {
-        $user = new User;
-        $user->setAttribute('posts_sum_id', 10);
-        $user->setAttribute('plain', 1);
-
-        $resource = new UserResource($user);
-        $method   = new \ReflectionMethod(UserResource::class, 'isAggregateLoaded');
-
-        // The alias after ' as ' is matched against the loaded attributes.
-        self::assertTrue($method->invoke($resource, $user, 'posts as posts_sum_id'));
-        self::assertFalse($method->invoke($resource, $user, 'comments as comments_sum_id'));
-
-        // The constrained (array-keyed) form reads the key.
-        self::assertTrue($method->invoke($resource, $user, ['posts as posts_sum_id' => static fn (): null => null]));
-
-        // A specification without an alias is matched verbatim.
-        self::assertTrue($method->invoke($resource, $user, 'plain'));
-        self::assertFalse($method->invoke($resource, $user, 'missing'));
-    }
-
-    /**
      * Test that already-loaded aggregate specifications are dropped while
-     * unloaded ones are retained.
+     * unloaded ones are retained, for both count specs and aggregate entries.
      *
      * @return void
      */
@@ -2718,6 +2691,7 @@ final class ApiResourceTest extends TestCase
     {
         $user = new User;
         $user->setAttribute('posts_count', 2);
+        $user->setAttribute('posts_sum_id', 10);
 
         $resource = new UserResource($user);
         $method   = new \ReflectionMethod(UserResource::class, 'rejectLoadedAggregates');
@@ -2727,11 +2701,17 @@ final class ApiResourceTest extends TestCase
             'posts as posts_count',
             'comments as comments_count',
             'tags as tags_count' => static fn (): null => null,
+            ['relation'          => 'posts as posts_sum_id', 'column' => 'id'],
+            ['relation'          => 'authors as authors_sum_id', 'column' => 'id'],
         ]);
 
-        self::assertContains('comments as comments_count', $result);
+        $values = array_values($result);
+
+        self::assertContains('comments as comments_count', $values);
         self::assertArrayHasKey('tags as tags_count', $result);
-        self::assertNotContains('posts as posts_count', $result);
+        self::assertContains(['relation' => 'authors as authors_sum_id', 'column' => 'id'], $values);
+        self::assertNotContains('posts as posts_count', $values);
+        self::assertNotContains(['relation' => 'posts as posts_sum_id', 'column' => 'id'], $values);
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/DerivedTabularSchemaTest.php
+++ b/tests/Unit/Http/Resources/Concerns/DerivedTabularSchemaTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Concerns;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivedTabularSchema;
+use SineMacula\Exporter\Schema\Column;
+use Tests\TestCase;
+
+/**
+ * Tests for the DerivedTabularSchema column carrier.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(DerivedTabularSchema::class)]
+final class DerivedTabularSchemaTest extends TestCase
+{
+    /**
+     * Test that the schema returns the ordered columns it was built with.
+     *
+     * @return void
+     */
+    public function testColumnsReturnsTheProvidedColumnsInOrder(): void
+    {
+        $columns = [Column::make('id'), Column::make('name')];
+
+        $schema = new DerivedTabularSchema(Request::create('/'), $columns);
+
+        self::assertSame($columns, $schema->columns());
+    }
+
+    /**
+     * Test that an empty column list is returned unchanged.
+     *
+     * @return void
+     */
+    public function testColumnsReturnsEmptyListWhenNoColumnsProvided(): void
+    {
+        $schema = new DerivedTabularSchema(Request::create('/'), []);
+
+        self::assertSame([], $schema->columns());
+    }
+}

--- a/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
+++ b/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
@@ -9,9 +9,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\RowGuardProbe;
+use SineMacula\ApiToolkit\Schema\Field;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\Exporter\Contracts\ProvidesTabularExport;
 use SineMacula\Exporter\Schema\CastRegistry;
 use SineMacula\Exporter\Schema\Column;
 use Tests\Fixtures\Models\User;
@@ -153,6 +156,98 @@ final class DerivesTabularSchemaTest extends TestCase
         $this->expectException(PerItemGuardedFieldException::class);
 
         (new ThrowingGuardExportResource($user))->tabular($request);
+    }
+
+    /**
+     * Test that a plain string-accessor field maps to a model-sourced column
+     * that reads the accessor path rather than the exposed key.
+     *
+     * @return void
+     */
+    public function testStringAccessorFieldMapsToModelSourcedColumn(): void
+    {
+        $resource = new class (null) extends ApiResource implements ProvidesTabularExport {
+            use DerivesTabularSchema;
+
+            /** @var string */
+            public const string RESOURCE_TYPE = 'string_accessor_export';
+
+            /** @var array<int, string> */
+            protected static array $default = ['contact'];
+
+            /**
+             * Return the resource schema.
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            #[\Override]
+            public static function schema(): array
+            {
+                return Field::set(
+                    Field::accessor('contact', 'email'),
+                );
+            }
+        };
+
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $columns = $resource->tabular($request)->columns();
+
+        self::assertCount(1, $columns);
+        self::assertSame('contact', $columns[0]->getKey());
+        self::assertTrue($columns[0]->usesModelSource());
+        self::assertSame('email', $columns[0]->getModelPath());
+    }
+
+    /**
+     * Test that a non-callable guard entry is skipped during the column
+     * visibility check while a relation field is dropped from the schema,
+     * leaving a permitting callable guard to decide the remaining column.
+     *
+     * @return void
+     */
+    public function testNonCallableGuardIsSkippedDuringVisibilityCheck(): void
+    {
+        $resource = new class (null) extends ApiResource implements ProvidesTabularExport {
+            use DerivesTabularSchema;
+
+            /** @var string */
+            public const string RESOURCE_TYPE = 'non_callable_guard_export';
+
+            /** @var array<int, string> */
+            protected static array $default = ['flagged', 'related'];
+
+            /**
+             * Return a raw schema whose guard list holds a non-callable entry
+             * alongside a relation field that must be skipped.
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            #[\Override]
+            public static function schema(): array
+            {
+                return [
+                    'flagged' => [
+                        'guards' => [123, static fn ($resource, $request): bool => true],
+                    ],
+                    'related' => [
+                        'relation' => 'related',
+                    ],
+                ];
+            }
+        };
+
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $columns = $resource->tabular($request)->columns();
+
+        self::assertCount(1, $columns);
+        self::assertSame('flagged', $columns[0]->getKey());
+        self::assertTrue($columns[0]->isVisible($request));
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -10,6 +10,7 @@ use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use Tests\Concerns\InteractsWithNonPublicMembers;
+use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Resources\OrganizationResource;
 use Tests\Fixtures\Resources\PostResource;
 use Tests\Fixtures\Resources\TagResource;
@@ -976,5 +977,36 @@ final class EagerLoadPlannerTest extends TestCase
 
         self::assertContains('rel', $result);
         self::assertContains('rel.organization', $result);
+    }
+
+    /**
+     * Test that an aggregate is recognised as loaded by matching the aliased
+     * attribute against the model, so a pre-loaded aggregate is not re-queried
+     * per row.
+     *
+     * @return void
+     */
+    public function testIsAggregateAttributeLoadedMatchesTheAliasedAttribute(): void
+    {
+        $user = new User;
+        $user->setAttribute('posts_sum_id', 10);
+        $user->setAttribute('plain', 1);
+
+        // The alias after ' as ' is matched against the loaded attributes.
+        self::assertTrue(EagerLoadPlanner::isAggregateAttributeLoaded($user, 'posts as posts_sum_id'));
+        self::assertFalse(EagerLoadPlanner::isAggregateAttributeLoaded($user, 'comments as comments_sum_id'));
+
+        // The constrained (array-keyed) form reads the key.
+        self::assertTrue(EagerLoadPlanner::isAggregateAttributeLoaded($user, ['posts as posts_sum_id' => static fn (): null => null]));
+
+        // A specification without an alias is matched verbatim.
+        self::assertTrue(EagerLoadPlanner::isAggregateAttributeLoaded($user, 'plain'));
+        self::assertFalse(EagerLoadPlanner::isAggregateAttributeLoaded($user, 'missing'));
+
+        // A non-string, non-array specification is never loaded.
+        self::assertFalse(EagerLoadPlanner::isAggregateAttributeLoaded($user, 123));
+
+        // An object without getAttributes() is never loaded.
+        self::assertFalse(EagerLoadPlanner::isAggregateAttributeLoaded(new \stdClass, 'plain'));
     }
 }

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\Http\Resources\Concerns;
 
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
@@ -1008,5 +1009,142 @@ final class EagerLoadPlannerTest extends TestCase
 
         // An object without getAttributes() is never loaded.
         self::assertFalse(EagerLoadPlanner::isAggregateAttributeLoaded(new \stdClass, 'plain'));
+    }
+
+    /**
+     * Test that a blank extra path is skipped while a real extra path is still
+     * collected.
+     *
+     * @return void
+     */
+    public function testBuildEagerLoadMapSkipsBlankExtraPaths(): void
+    {
+
+        $blankExtraResource = new class {
+            /** @var string The resource type identifier. */
+            public const string RESOURCE_TYPE = 'blank_extra_test';
+
+            /**
+             * @return array<string, array<string, mixed>>
+             */
+            public static function schema(): array
+            {
+                return [
+                    'avatar' => [
+                        'extras' => ['', 'media'],
+                    ],
+                ];
+            }
+        };
+
+        $result = EagerLoadPlanner::buildEagerLoadMap($blankExtraResource::class, ['avatar']);
+
+        self::assertContains('media', $result);
+        self::assertNotContains('', $result);
+    }
+
+    /**
+     * Test that a wrapped constraint runs against a MorphTo query verbatim, is
+     * applied to a resolved builder, and is skipped for a query that resolves
+     * to no builder.
+     *
+     * @return void
+     */
+    public function testWrappedConstraintHandlesMorphToBuilderAndNonBuilderQueries(): void
+    {
+
+        /** @var list<mixed> $calls */
+        $calls = [];
+
+        $constrainedResource = new class {
+            /** @var string The resource type identifier. */
+            public const string RESOURCE_TYPE = 'wrap_constraint_test';
+
+            /** @var (\Closure(mixed): void)|null */
+            public static ?\Closure $constraint = null;
+
+            /**
+             * @return array<string, array<string, mixed>>
+             */
+            public static function schema(): array
+            {
+                return [
+                    'items' => [
+                        'relation'   => 'items',
+                        'constraint' => self::$constraint,
+                    ],
+                ];
+            }
+        };
+
+        $constrainedResource::$constraint = static function ($query) use (&$calls): void {
+            $calls[] = $query;
+        };
+
+        $map     = EagerLoadPlanner::buildEagerLoadMap($constrainedResource::class, ['items']);
+        $wrapped = $map['items'];
+
+        self::assertInstanceOf(\Closure::class, $wrapped);
+
+        // A MorphTo query and a plain builder are each handed to the constraint
+        // verbatim, while a query that is neither a relation nor a builder is
+        // skipped.
+        $morphTo = \Mockery::mock(MorphTo::class);
+        $builder = User::query();
+
+        $wrapped($morphTo);
+        $wrapped($builder);
+        $wrapped(new \stdClass);
+
+        self::assertCount(2, $calls);
+        self::assertSame($morphTo, $calls[0]);
+        self::assertSame($builder, $calls[1]);
+    }
+
+    /**
+     * Test that recursion halts when a child field projection resolves to an
+     * empty set, so the parent relation is loaded without any child paths.
+     *
+     * @return void
+     */
+    public function testBuildEagerLoadMapStopsRecursionWhenChildFieldsResolveEmpty(): void
+    {
+
+        $emptyChildFieldsResource = new class {
+            /** @var string The resource type identifier. */
+            public const string RESOURCE_TYPE = 'empty_child_fields_test';
+
+            /**
+             * @return array<string, array<string, mixed>>
+             */
+            public static function schema(): array
+            {
+                return [
+                    'posts' => [
+                        'relation' => 'posts',
+                        'resource' => PostResource::class,
+                        'fields'   => [''],
+                    ],
+                ];
+            }
+        };
+
+        $result = EagerLoadPlanner::buildEagerLoadMap($emptyChildFieldsResource::class, ['posts']);
+
+        self::assertContains('posts', $result);
+        self::assertNotContains('posts.tags', $result);
+    }
+
+    /**
+     * Test that the requested-child-field lookup returns an empty set for a
+     * class that is not an ApiResource.
+     *
+     * @return void
+     */
+    public function testGetRequestedChildFieldsReturnsEmptyForNonResourceClass(): void
+    {
+        $result = $this->invokeStaticMethod(EagerLoadPlanner::class, 'getRequestedChildFields', \stdClass::class);
+
+        self::assertSame([], $result);
     }
 }

--- a/tests/Unit/Http/Resources/Concerns/RowGuardProbeTest.php
+++ b/tests/Unit/Http/Resources/Concerns/RowGuardProbeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Concerns;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\RowGuardProbe;
+use Tests\TestCase;
+
+/**
+ * Tests for the RowGuardProbe stand-in resource.
+ *
+ * Every modelled access - property read, isset check, method call, string
+ * coercion, and iteration - must flip the internal touched flag and return a
+ * value that lets a chained guard keep running.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(RowGuardProbe::class)]
+final class RowGuardProbeTest extends TestCase
+{
+    /**
+     * Test that a fresh probe reports no interaction.
+     *
+     * @return void
+     */
+    public function testUntouchedProbeReportsNoInteraction(): void
+    {
+        self::assertFalse((new RowGuardProbe)->wasTouched());
+    }
+
+    /**
+     * Test that a property read records a touch and returns the probe so a
+     * chained read keeps running.
+     *
+     * @return void
+     */
+    public function testPropertyReadRecordsTouchAndReturnsProbe(): void
+    {
+        $probe = new RowGuardProbe;
+
+        self::assertSame($probe, $probe->__get('name'));
+        self::assertTrue($probe->wasTouched());
+    }
+
+    /**
+     * Test that an isset check records a touch and reports it present.
+     *
+     * @return void
+     */
+    public function testIssetCheckRecordsTouchAndReportsPresent(): void
+    {
+        $probe = new RowGuardProbe;
+
+        self::assertTrue($probe->__isset('name'));
+        self::assertTrue($probe->wasTouched());
+    }
+
+    /**
+     * Test that a method call records a touch and returns the probe.
+     *
+     * @return void
+     */
+    public function testMethodCallRecordsTouchAndReturnsProbe(): void
+    {
+        $probe = new RowGuardProbe;
+
+        self::assertSame($probe, $probe->__call('someMethod', ['argument']));
+        self::assertTrue($probe->wasTouched());
+    }
+
+    /**
+     * Test that a string coercion records a touch and yields an empty string.
+     *
+     * @return void
+     */
+    public function testStringCoercionRecordsTouchAndReturnsEmptyString(): void
+    {
+        $probe = new RowGuardProbe;
+
+        self::assertSame('', (string) $probe);
+        self::assertTrue($probe->wasTouched());
+    }
+
+    /**
+     * Test that iterating the probe records a touch and yields no items.
+     *
+     * @return void
+     */
+    public function testIterationRecordsTouchAndYieldsNoItems(): void
+    {
+        $probe = new RowGuardProbe;
+
+        self::assertSame([], iterator_to_array($probe));
+        self::assertTrue($probe->wasTouched());
+    }
+}

--- a/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
@@ -1597,6 +1597,312 @@ final class ValueResolverTest extends TestCase
     }
 
     /**
+     * Test that a field listed in the model's appended attributes resolves
+     * through the magic getter.
+     *
+     * @return void
+     */
+    public function testResolveFieldValueResolvesAppendedAttribute(): void
+    {
+
+        $model = new class {
+            /** @var array<int, string> */
+            public array $appends = ['full_name'];
+
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+
+            /**
+             * Resolve the appended attribute.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return 'Appended Value';
+            }
+        };
+
+        $result = $this->resolver->resolveFieldValue('full_name', $this->makeFieldDefinition(), new JsonResource($model), null);
+
+        self::assertSame('Appended Value', $result);
+    }
+
+    /**
+     * Test that a field with no property, attribute, appended entry, cast
+     * accessor method, or magic isset resolves to a MissingValue.
+     *
+     * @return void
+     */
+    public function testResolveFieldValueReturnsMissingValueWhenNoAccessiblePathExists(): void
+    {
+
+        $model = new class {
+            /**
+             * Return the attributes array.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+        };
+
+        $result = $this->resolver->resolveFieldValue('ghost_field', $this->makeFieldDefinition(), new JsonResource($model), null);
+
+        self::assertInstanceOf(MissingValue::class, $result);
+    }
+
+    /**
+     * Test that a relation field carrying a string accessor reads the accessor
+     * path from the loaded related model.
+     *
+     * @return void
+     */
+    public function testResolveFieldValueReadsStringAccessorFromLoadedRelation(): void
+    {
+
+        $resource   = new JsonResource($this->makeRelationOwner((object) ['label' => 'RelatedLabel']));
+        $definition = $this->makeFieldDefinition(accessor: 'label', relation: 'thing');
+
+        $result = $this->resolver->resolveFieldValue('thing', $definition, $resource, null);
+
+        self::assertSame('RelatedLabel', $result);
+    }
+
+    /**
+     * Test that a relation field carrying a callable accessor invokes the
+     * callable with the resource.
+     *
+     * @return void
+     */
+    public function testResolveFieldValueInvokesCallableAccessorForLoadedRelation(): void
+    {
+
+        $resource   = new JsonResource($this->makeRelationOwner((object) ['label' => 'ignored']));
+        $definition = new CompiledFieldDefinition(
+            accessor: static fn ($resource, $request): string => 'from-relation-callable',
+            compute: null,
+            relation: 'thing',
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: [],
+            transformers: [],
+        );
+
+        $result = $this->resolver->resolveFieldValue('thing', $definition, $resource, null);
+
+        self::assertSame('from-relation-callable', $result);
+    }
+
+    /**
+     * Test that a relation field carrying a non-string, non-callable accessor
+     * resolves to null rather than erroring.
+     *
+     * @return void
+     */
+    public function testResolveFieldValueReturnsNullForUnresolvableRelationAccessor(): void
+    {
+
+        $resource   = new JsonResource($this->makeRelationOwner((object) ['label' => 'ignored']));
+        $definition = new CompiledFieldDefinition(
+            accessor: 123,
+            compute: null,
+            relation: 'thing',
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: [],
+            transformers: [],
+        );
+
+        $result = $this->resolver->resolveFieldValue('thing', $definition, $resource, null);
+
+        self::assertNull($result);
+    }
+
+    /**
+     * Test that a count attribute exposed only through magic isset and get is
+     * read and included in the payload.
+     *
+     * @return void
+     */
+    public function testResolveCountsPayloadReadsAttributeViaMagicIsset(): void
+    {
+
+        ApiQuery::shouldReceive('getCounts')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /**
+             * Return the attributes array without the count attribute.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+
+            /**
+             * Report the count attribute present through magic isset.
+             *
+             * @param  string  $key
+             * @return bool
+             */
+            public function __isset(string $key): bool
+            {
+                return $key === 'posts_count';
+            }
+
+            /**
+             * Resolve the count attribute through the magic getter.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $key === 'posts_count' ? 8 : null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [
+            'posts' => new CompiledCountDefinition('posts', 'posts', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveCountsPayload($resource, $schema, 'users', null);
+
+        self::assertSame(['posts' => 8], $result);
+    }
+
+    /**
+     * Test that a count whose attribute is not loaded at all is skipped.
+     *
+     * @return void
+     */
+    public function testResolveCountsPayloadSkipsCountWhenAttributeAbsent(): void
+    {
+
+        ApiQuery::shouldReceive('getCounts')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /**
+             * Return the attributes array without the count attribute.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [
+            'posts' => new CompiledCountDefinition('posts', 'posts', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveCountsPayload($resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Test that an aggregate whose attribute is not loaded at all is skipped.
+     *
+     * @return void
+     */
+    public function testResolveAggregatesPayloadSkipsAggregateWhenAttributeAbsent(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /**
+             * Return the attributes array without the aggregate attribute.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'posts_id' => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Build an owner exposing a single already-loaded relation.
+     *
+     * @param  object  $related
+     * @return object
+     */
+    private function makeRelationOwner(object $related): object
+    {
+        return new class ($related) {
+            /**
+             * @param  object  $related
+             */
+            public function __construct(
+
+                /** The related value returned for the loaded relation. */
+                private readonly object $related,
+            ) {}
+
+            /**
+             * Report the relation as loaded.
+             *
+             * @param  string  $name
+             * @return bool
+             */
+            public function relationLoaded(string $name): bool // phpcs:ignore SineMacula.NamingConventions.BooleanMethodName.NotPredicate
+            {
+                return true;
+            }
+
+            /**
+             * Return the loaded relation value.
+             *
+             * @param  string  $name
+             * @return object
+             */
+            public function getRelation(string $name): object
+            {
+                return $this->related;
+            }
+        };
+    }
+
+    /**
      * Create a compiled field definition with the given overrides.
      *
      * @param  string|null  $accessor

--- a/tests/Unit/Http/Resources/PolymorphicResourceTest.php
+++ b/tests/Unit/Http/Resources/PolymorphicResourceTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ResourceMappingException;
 use SineMacula\ApiToolkit\Http\Resources\PolymorphicResource;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
@@ -292,6 +293,75 @@ final class PolymorphicResourceTest extends TestCase
         self::assertIsArray($result);
         self::assertFalse($user->relationLoaded('organization'));
         self::assertArrayNotHasKey('organization', $result);
+    }
+
+    /**
+     * Test that excluded fields set through withoutFields propagate to the
+     * mapped resource and drop the field from the response.
+     *
+     * @return void
+     */
+    public function testToArrayPropagatesExcludedFieldsToMappedResource(): void
+    {
+        $user = User::create([
+            'name'   => 'ExcludePoly',
+            'email'  => 'excludepoly@example.com',
+            'status' => 'active',
+        ]);
+
+        $resource = new PolymorphicResource($user);
+        $resource->withoutFields(['email']);
+
+        $result = $resource->toArray(request());
+
+        self::assertArrayHasKey('_type', $result);
+        self::assertArrayHasKey('name', $result);
+        self::assertArrayNotHasKey('email', $result);
+    }
+
+    /**
+     * Test that a non-object resource is refused with the dedicated mapping
+     * exception.
+     *
+     * @return void
+     */
+    public function testToArrayThrowsWhenResourceIsNotAnObject(): void
+    {
+        $resource = new PolymorphicResource('not-an-object');
+
+        $this->expectException(ResourceMappingException::class);
+        $this->expectExceptionMessage('Resource must be an object to be mapped');
+
+        $resource->toArray(request());
+    }
+
+    /**
+     * Test that a mapped class not implementing the resource interface is
+     * refused with the dedicated mapping exception.
+     *
+     * @return void
+     */
+    public function testToArrayThrowsWhenMappedClassDoesNotImplementInterface(): void
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $this->app['config'];
+        $config->set('api-toolkit.resources.resource_map', [
+            User::class => \stdClass::class,
+        ]);
+
+        $user = User::create([
+            'name'  => 'BadMap',
+            'email' => 'badmap@example.com',
+        ]);
+
+        $resource = new PolymorphicResource($user);
+
+        $this->expectException(ResourceMappingException::class);
+        $this->expectExceptionMessage('must implement');
+
+        $resource->toArray(request());
     }
 
     /**

--- a/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
+++ b/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
@@ -408,6 +408,22 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
+     * Test that a file removed between enumeration and read yields no classes
+     * rather than aborting discovery, so a concurrent scan or a hot deploy
+     * swapping resources mid-scan cannot break resolution.
+     *
+     * @return void
+     */
+    public function testVanishedFileYieldsNoClasses(): void
+    {
+        $method = new \ReflectionMethod(ResourceDiscovery::class, 'classesFromFile');
+
+        $result = $method->invoke($this->discovery(), $this->fixturePath('Primary') . '/DoesNotExist.php');
+
+        self::assertSame([], $result);
+    }
+
+    /**
      * Test that every declared class in a multi-class, multi-namespace file
      * is considered: both attributed resources bind, and a trailing
      * unloadable class is skipped without disturbing the bindings already

--- a/tests/Unit/Http/Resources/Schema/CompiledSchemaTest.php
+++ b/tests/Unit/Http/Resources/Schema/CompiledSchemaTest.php
@@ -210,4 +210,135 @@ final class CompiledSchemaTest extends TestCase
         self::assertSame('sum', $aggregates['posts_id']->metric);
         self::assertSame('avg', $aggregates['posts_id_avg']->metric);
     }
+
+    /**
+     * Test that getAggregateDefinitionsByMetric returns only the definitions
+     * whose metric matches the requested value.
+     *
+     * @return void
+     */
+    public function testGetAggregateDefinitionsByMetricReturnsMatchingDefinitions(): void
+    {
+        $sum = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: null,
+            isDefault: true,
+            guards: [],
+        );
+
+        $avg = new CompiledAggregateDefinition(
+            presentKey: 'posts_id_avg',
+            relation: 'posts',
+            column: 'id',
+            metric: 'avg',
+            constraint: null,
+            isDefault: false,
+            guards: [],
+        );
+
+        $schema = new CompiledSchema([], [], ['posts_id' => $sum, 'posts_id_avg' => $avg]);
+
+        $matches = $schema->getAggregateDefinitionsByMetric('sum');
+
+        self::assertSame(['posts_id' => $sum], $matches);
+    }
+
+    /**
+     * Test that getAggregateDefinitionsByMetric returns an empty array when no
+     * definition matches the requested metric.
+     *
+     * @return void
+     */
+    public function testGetAggregateDefinitionsByMetricReturnsEmptyWhenNoMatch(): void
+    {
+        $sum = new CompiledAggregateDefinition(
+            presentKey: 'posts_id',
+            relation: 'posts',
+            column: 'id',
+            metric: 'sum',
+            constraint: null,
+            isDefault: true,
+            guards: [],
+        );
+
+        $schema = new CompiledSchema([], [], ['posts_id' => $sum]);
+
+        self::assertSame([], $schema->getAggregateDefinitionsByMetric('avg'));
+    }
+
+    /**
+     * Test that getFilterableColumns returns the declared filterable columns.
+     *
+     * @return void
+     */
+    public function testGetFilterableColumnsReturnsDeclaredColumns(): void
+    {
+        $schema = new CompiledSchema([], [], [], ['email', 'status']);
+
+        self::assertSame(['email', 'status'], $schema->getFilterableColumns());
+    }
+
+    /**
+     * Test that getFilterableColumns defaults to an empty array.
+     *
+     * @return void
+     */
+    public function testGetFilterableColumnsDefaultsToEmpty(): void
+    {
+        $schema = new CompiledSchema([], []);
+
+        self::assertSame([], $schema->getFilterableColumns());
+    }
+
+    /**
+     * Test that getSortableColumns returns the declared sortable columns.
+     *
+     * @return void
+     */
+    public function testGetSortableColumnsReturnsDeclaredColumns(): void
+    {
+        $schema = new CompiledSchema([], [], [], [], ['created_at', 'name']);
+
+        self::assertSame(['created_at', 'name'], $schema->getSortableColumns());
+    }
+
+    /**
+     * Test that getSortableColumns defaults to an empty array.
+     *
+     * @return void
+     */
+    public function testGetSortableColumnsDefaultsToEmpty(): void
+    {
+        $schema = new CompiledSchema([], []);
+
+        self::assertSame([], $schema->getSortableColumns());
+    }
+
+    /**
+     * Test that getTraversableRelations returns the declared traversable
+     * relation names.
+     *
+     * @return void
+     */
+    public function testGetTraversableRelationsReturnsDeclaredRelations(): void
+    {
+        $schema = new CompiledSchema([], [], [], [], [], ['posts', 'organization']);
+
+        self::assertSame(['posts', 'organization'], $schema->getTraversableRelations());
+    }
+
+    /**
+     * Test that getTraversableRelations defaults to an empty array.
+     *
+     * @return void
+     */
+    public function testGetTraversableRelationsDefaultsToEmpty(): void
+    {
+        $schema = new CompiledSchema([], []);
+
+        self::assertSame([], $schema->getTraversableRelations());
+    }
 }

--- a/tests/Unit/Http/Resources/Schema/FieldTest.php
+++ b/tests/Unit/Http/Resources/Schema/FieldTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\Http\Resources\Schema;
 
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -138,6 +139,37 @@ final class FieldTest extends TestCase
     }
 
     /**
+     * Test that the timestamp accessor formats a Carbon value as an ISO-8601
+     * string.
+     *
+     * @return void
+     */
+    public function testTimestampAccessorFormatsCarbonValueAsIso8601(): void
+    {
+        $accessor = Field::timestamp('created_at')->toArray()['created_at']['accessor'];
+
+        self::assertIsCallable($accessor);
+
+        $carbon = Carbon::parse('2026-07-15T09:30:00+00:00');
+
+        self::assertSame($carbon->toIso8601String(), $accessor(['created_at' => $carbon]));
+    }
+
+    /**
+     * Test that the timestamp accessor returns null for a non-Carbon value.
+     *
+     * @return void
+     */
+    public function testTimestampAccessorReturnsNullForNonCarbonValue(): void
+    {
+        $accessor = Field::timestamp('created_at')->toArray()['created_at']['accessor'];
+
+        self::assertIsCallable($accessor);
+
+        self::assertNull($accessor(['created_at' => null]));
+    }
+
+    /**
      * Test that date creates a field with an accessor callable.
      *
      * @return void
@@ -151,6 +183,36 @@ final class FieldTest extends TestCase
         self::assertArrayHasKey('birth_date', $array);
         self::assertArrayHasKey('accessor', $array['birth_date']);
         self::assertIsCallable($array['birth_date']['accessor']);
+    }
+
+    /**
+     * Test that the date accessor formats a Carbon value as a date string.
+     *
+     * @return void
+     */
+    public function testDateAccessorFormatsCarbonValueAsDateString(): void
+    {
+        $accessor = Field::date('birth_date')->toArray()['birth_date']['accessor'];
+
+        self::assertIsCallable($accessor);
+
+        $carbon = Carbon::parse('2026-07-15T09:30:00+00:00');
+
+        self::assertSame('2026-07-15', $accessor(['birth_date' => $carbon]));
+    }
+
+    /**
+     * Test that the date accessor returns null for a non-Carbon value.
+     *
+     * @return void
+     */
+    public function testDateAccessorReturnsNullForNonCarbonValue(): void
+    {
+        $accessor = Field::date('birth_date')->toArray()['birth_date']['accessor'];
+
+        self::assertIsCallable($accessor);
+
+        self::assertNull($accessor(['birth_date' => 'not-a-carbon']));
     }
 
     /**

--- a/tests/Unit/Http/Routing/AuthorizedControllerTest.php
+++ b/tests/Unit/Http/Routing/AuthorizedControllerTest.php
@@ -175,4 +175,20 @@ final class AuthorizedControllerTest extends TestCase
 
         self::assertSame(['index', 'show'], $result);
     }
+
+    /**
+     * Test that getGuardExclusions returns null when the GUARD_EXCLUSIONS
+     * constant is not defined on the controller.
+     *
+     * @return void
+     */
+    public function testGetGuardExclusionsReturnsNullWhenNotDefined(): void
+    {
+        $reflection = new \ReflectionClass(TestingMinimalAuthorizedController::class);
+        $controller = $reflection->newInstanceWithoutConstructor(); // qlty-ignore: radarlint-php:php:S3011
+
+        $result = $this->invokeMethod($controller, 'getGuardExclusions');
+
+        self::assertNull($result);
+    }
 }

--- a/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
@@ -21,7 +21,6 @@ use SineMacula\ApiToolkit\Enums\FlushStrategy;
 use SineMacula\ApiToolkit\Events\WritePoolFlushFailed;
 use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
-use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -41,10 +40,9 @@ final class WritePoolFlushSubscriberTest extends TestCase
     /**
      * Set up the test environment.
      *
-     * The per-query cache invalidation path is covered by its own dedicated
-     * tests below; disable it here so the flush and escalation assertions
-     * observe the subscriber in isolation without the container being asked for
-     * the invalidator.
+     * The write pool flush now invalidates the per-query cache itself; disable
+     * that here so the subscriber's flush and escalation assertions observe it
+     * in isolation, without a cache side effect.
      *
      * @return void
      */
@@ -442,114 +440,6 @@ final class WritePoolFlushSubscriberTest extends TestCase
         $this->expectException(WritePoolFlushException::class);
 
         $subscriber->handleFlush();
-    }
-
-    /**
-     * Test that, when invalidation is enabled, the subscriber invalidates the
-     * per-query cache for every table the flush persisted.
-     *
-     * @return void
-     */
-    public function testHandleFlushInvalidatesQueryCacheForFlushedTables(): void
-    {
-        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
-
-        $pool = new WritePool(500, 10000);
-        $pool->add('users', ['name' => 'Alice', 'email' => 'alice@example.com', 'password' => 'secret']);
-
-        $invalidator = new class {
-            /** @var list<array<int, string>> The arguments of each invalidate() call. */
-            public array $calls = [];
-
-            /**
-             * @param  array<int, string>  $tables
-             * @return void
-             */
-            public function invalidate(array $tables): void
-            {
-                $this->calls[] = $tables;
-            }
-        };
-
-        $container = \Mockery::mock(Container::class);
-        $container->shouldReceive('make')->with(WritePool::class)->andReturn($pool);
-        $container->shouldReceive('make')->with(DeferredWriteCacheInvalidator::class)->andReturn($invalidator);
-
-        $subscriber = new WritePoolFlushSubscriber($container);
-
-        $subscriber->handleFlush();
-
-        self::assertTrue($pool->isEmpty());
-        self::assertSame([['users']], $invalidator->calls);
-    }
-
-    /**
-     * Test that, when invalidation is disabled, the subscriber never resolves
-     * the invalidator from the container.
-     *
-     * @return void
-     */
-    public function testHandleFlushDoesNotInvalidateQueryCacheWhenDisabled(): void
-    {
-        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', false);
-
-        $pool = new WritePool(500, 10000);
-        $pool->add('users', ['name' => 'Bob', 'email' => 'bob@example.com', 'password' => 'secret']);
-
-        $container = \Mockery::mock(Container::class);
-        $container->shouldReceive('make')->with(WritePool::class)->andReturn($pool);
-        $container->shouldReceive('make')->with(DeferredWriteCacheInvalidator::class)->never();
-
-        $subscriber = new WritePoolFlushSubscriber($container);
-
-        $subscriber->handleFlush();
-
-        self::assertTrue($pool->isEmpty());
-    }
-
-    /**
-     * Test that a throw-strategy failure still invalidates the per-query cache
-     * for every attempted table before the failure is escalated.
-     *
-     * @return void
-     */
-    public function testHandleFlushInvalidatesQueryCacheOnFlushException(): void
-    {
-        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
-        Config::set('api-toolkit.deferred_writes.rethrow_at_boundary', false);
-
-        $pool = new WritePool(500, 10000, FlushStrategy::THROW);
-        $pool->add('users', ['name' => 'Carol', 'email' => 'carol@example.com', 'password' => 'secret']);
-        $pool->add('nonexistent_table', ['col' => 'val']);
-
-        $invalidator = new class {
-            /** @var list<array<int, string>> The arguments of each invalidate() call. */
-            public array $calls = [];
-
-            /**
-             * @param  array<int, string>  $tables
-             * @return void
-             */
-            public function invalidate(array $tables): void
-            {
-                $this->calls[] = $tables;
-            }
-        };
-
-        $container = \Mockery::mock(Container::class);
-        $container->shouldReceive('make')->with(WritePool::class)->andReturn($pool);
-        $container->shouldReceive('make')->with(DeferredWriteCacheInvalidator::class)->andReturn($invalidator);
-
-        Log::shouldReceive('warning')->once();
-
-        Event::fake([WritePoolFlushFailed::class]);
-
-        $subscriber = new WritePoolFlushSubscriber($container);
-
-        $subscriber->handleFlush();
-
-        Event::assertDispatched(WritePoolFlushFailed::class);
-        self::assertSame([['users', 'nonexistent_table']], $invalidator->calls);
     }
 
     /**

--- a/tests/Unit/OpenApi/Builder/ResourceSchemaBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/ResourceSchemaBuilderTest.php
@@ -9,7 +9,10 @@ use SineMacula\ApiToolkit\OpenApi\Builder\ResourceSchemaBuilder;
 use SineMacula\ApiToolkit\OpenApi\Contracts\MetadataCatalogue;
 use SineMacula\ApiToolkit\OpenApi\Resolution\ColumnTypeMapper;
 use SineMacula\ApiToolkit\OpenApi\Resolution\FieldTypeResolver;
+use SineMacula\ApiToolkit\Schema\CompiledSchema;
 use SineMacula\ApiToolkit\Schema\Introspection\SchemaIntrospector;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\Tag;
@@ -31,6 +34,43 @@ use Tests\TestCase;
 #[CoversClass(ResourceSchemaBuilder::class)]
 final class ResourceSchemaBuilderTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
+    /**
+     * Tear down the test environment.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        SchemaCompiler::clearCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a compiled field key that resolves to no field definition is
+     * skipped when building the schema, emitting an empty-property object.
+     *
+     * @return void
+     */
+    public function testSkipsFieldKeyWithoutADefinition(): void
+    {
+        // A compiled schema whose only field key maps to a null definition -
+        // the builder must skip it rather than resolve a property.
+        $schema = new CompiledSchema(['ghost' => null], []); // @phpstan-ignore argument.type
+
+        $this->setStaticProperty(SchemaCompiler::class, 'cache', ['GhostResource' => $schema]);
+
+        $catalogue = self::createStub(MetadataCatalogue::class);
+        $catalogue->method('getResourceMap')->willReturn(['GhostModel' => 'GhostResource']);
+
+        $schemas = (new ResourceSchemaBuilder($catalogue, $this->resolver()))->build();
+
+        self::assertSame(['type' => 'object', 'properties' => []], $schemas['Ghost']);
+    }
+
     /**
      * Test that exactly one schema is emitted per registered resource, keyed by
      * its PascalCase component name.

--- a/tests/Unit/OpenApi/ExportOpenApiComponentsTest.php
+++ b/tests/Unit/OpenApi/ExportOpenApiComponentsTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Tests\Unit\OpenApi;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SineMacula\ApiToolkit\OpenApi\Builder\ErrorResponseBuilder;
 use SineMacula\ApiToolkit\OpenApi\Builder\QueryParameterBuilder;
 use SineMacula\ApiToolkit\OpenApi\Builder\ResourceSchemaBuilder;
@@ -17,6 +18,7 @@ use SineMacula\ApiToolkit\OpenApi\Resolution\ColumnTypeMapper;
 use SineMacula\ApiToolkit\OpenApi\Resolution\FieldTypeResolver;
 use SineMacula\ApiToolkit\Schema\Introspection\SchemaIntrospector;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\User;
 use Tests\Fixtures\Resources\OrganizationResource;
@@ -35,6 +37,8 @@ use Tests\TestCase;
 #[CoversClass(ExportResult::class)]
 final class ExportOpenApiComponentsTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /**
      * Set up each test.
      *
@@ -93,6 +97,34 @@ final class ExportOpenApiComponentsTest extends TestCase
             $result->responseCount,
         );
         self::assertSame(1, $result->responseCount);
+    }
+
+    /**
+     * Provide documents whose components section is absent, non-array, or holds
+     * a non-array section value.
+     *
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function malformedComponentsProvider(): iterable
+    {
+        yield 'components is not an array' => [['components' => 'nope']];
+        yield 'section is absent' => [['components' => []]];
+        yield 'section is not an array' => [['components' => ['parameters' => 'nope']]];
+    }
+
+    /**
+     * Test that a components section that is missing or not an array counts as
+     * zero rather than raising a type error.
+     *
+     * @param  array<string, mixed>  $document
+     * @return void
+     */
+    #[DataProvider('malformedComponentsProvider')]
+    public function testCountComponentsToleratesMalformedSections(array $document): void
+    {
+        $useCase = (new \ReflectionClass(ExportOpenApiComponents::class))->newInstanceWithoutConstructor();
+
+        self::assertSame(0, $this->invokeMethod($useCase, 'countComponents', $document, 'parameters'));
     }
 
     /**

--- a/tests/Unit/OpenApi/Metadata/ErrorCatalogueReaderTest.php
+++ b/tests/Unit/OpenApi/Metadata/ErrorCatalogueReaderTest.php
@@ -7,8 +7,11 @@ namespace Tests\Unit\OpenApi\Metadata;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SineMacula\ApiToolkit\Enums\ErrorCode;
+use SineMacula\ApiToolkit\Exceptions\NotFoundException;
+use SineMacula\ApiToolkit\OpenApi\Exceptions\MetadataReadException;
 use SineMacula\ApiToolkit\OpenApi\Metadata\ErrorCatalogueReader;
 use SineMacula\ApiToolkit\OpenApi\Metadata\ErrorDescriptor;
+use Tests\Fixtures\Support\FunctionOverrides;
 use Tests\TestCase;
 
 /**
@@ -176,6 +179,80 @@ final class ErrorCatalogueReaderTest extends TestCase
         foreach ($reader->read() as $descriptor) {
             self::assertNotSame('', $descriptor->detail, "Empty detail for code {$descriptor->code}");
         }
+    }
+
+    /**
+     * Test that the exception map is memoised so a second read does not
+     * re-scan the filesystem.
+     *
+     * @return void
+     */
+    public function testExceptionMapIsMemoisedAcrossReads(): void
+    {
+        $reader = new ErrorCatalogueReader;
+        $first  = $reader->read();
+
+        // Force the directory scan to fail; a re-scan would now throw, so a
+        // successful second read proves the map was memoised.
+        FunctionOverrides::set('glob', static fn (): false => false);
+
+        self::assertEquals($first, $reader->read());
+    }
+
+    /**
+     * Test that a failed exceptions-directory scan raises a metadata read
+     * exception naming the directory.
+     *
+     * @return void
+     */
+    public function testThrowsWhenExceptionsDirectoryScanFails(): void
+    {
+        FunctionOverrides::set('glob', static fn (): false => false);
+
+        $this->expectException(MetadataReadException::class);
+        $this->expectExceptionMessage('Unable to scan the exceptions directory');
+
+        (new ErrorCatalogueReader)->read();
+    }
+
+    /**
+     * Test that an error code with no owning exception subclass falls back to
+     * HTTP 500, matching the unhandled-exception default.
+     *
+     * @return void
+     */
+    public function testUnmappedErrorCodeFallsBackToStatus500(): void
+    {
+        // No exception files are discovered, so every code is unmapped.
+        FunctionOverrides::set('glob', static fn (): array => []);
+
+        $descriptor = $this->findDescriptor((new ErrorCatalogueReader)->read(), ErrorCode::NOT_FOUND->getCode());
+
+        self::assertNotNull($descriptor);
+        self::assertSame(500, $descriptor->httpStatus);
+    }
+
+    /**
+     * Test that a discovered exception subclass declaring no CODE constant is
+     * skipped, so its error code remains unmapped and falls back to HTTP 500.
+     *
+     * @return void
+     */
+    public function testSkipsExceptionSubclassWithoutCodeConstant(): void
+    {
+        $file = (new \ReflectionClass(NotFoundException::class))->getFileName();
+
+        self::assertIsString($file);
+
+        // The NotFoundException file is discovered, but its CODE constant is
+        // reported absent, so the scan skips it and NOT_FOUND stays unmapped.
+        FunctionOverrides::set('glob', static fn (): array => [$file]);
+        FunctionOverrides::set('defined', static fn (string $constant): bool => !str_ends_with($constant, '::CODE') && \defined($constant));
+
+        $descriptor = $this->findDescriptor((new ErrorCatalogueReader)->read(), ErrorCode::NOT_FOUND->getCode());
+
+        self::assertNotNull($descriptor);
+        self::assertSame(500, $descriptor->httpStatus);
     }
 
     /**

--- a/tests/Unit/Repositories/ApiRepositoryTest.php
+++ b/tests/Unit/Repositories/ApiRepositoryTest.php
@@ -14,6 +14,7 @@ use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
 use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
 use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
 use SineMacula\Http\Enums\HttpMethod;
+use SineMacula\Repositories\Contracts\CriteriaInterface;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Enums\UserStatus;
 use Tests\Fixtures\Models\Organization;
@@ -108,6 +109,27 @@ final class ApiRepositoryTest extends TestCase
         self::assertTrue(
             $criteria->contains(fn ($c) => $c instanceof ApiCriteria),
         );
+    }
+
+    /**
+     * Test that usingResource skips registered criteria that are not
+     * ApiCriteria instances while still propagating to the ApiCriteria ones.
+     *
+     * @return void
+     */
+    public function testUsingResourceSkipsNonApiCriteria(): void
+    {
+        $this->repository->withApiCriteria();
+        $this->repository->pushCriteria(self::createStub(CriteriaInterface::class));
+
+        $result = $this->repository->usingResource(UserResource::class);
+
+        self::assertSame($this->repository, $result);
+
+        $criteria = $this->repository->getCriteria()->first(fn ($c) => $c instanceof ApiCriteria);
+
+        self::assertInstanceOf(ApiCriteria::class, $criteria);
+        self::assertSame(UserResource::class, $this->getProperty($criteria, 'customResourceClass'));
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
+++ b/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
@@ -720,6 +720,38 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
+     * Test that an associate cast whose attribute does not resolve to a
+     * BelongsTo relation raises a LogicException.
+     *
+     * @return void
+     */
+    public function testSetAssociateAttributeThrowsWhenRelationIsNotBelongsTo(): void
+    {
+        $user = User::create(['name' => 'Alice', 'email' => self::ALICE_EMAIL]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('does not resolve to a BelongsTo relation');
+
+        $this->invokeMethod($this->attributeSetter, 'setAttribute', $user, 'posts', 1, 'associate');
+    }
+
+    /**
+     * Test that a sync cast whose attribute does not resolve to a BelongsToMany
+     * relation raises a LogicException.
+     *
+     * @return void
+     */
+    public function testSetSyncAttributeThrowsWhenRelationIsNotBelongsToMany(): void
+    {
+        $user = User::create(['name' => 'Alice', 'email' => self::ALICE_EMAIL]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('does not resolve to a BelongsToMany relation');
+
+        $this->invokeMethod($this->attributeSetter, 'setAttribute', $user, 'organization', 1, 'sync');
+    }
+
+    /**
      * Test that persist registers the REPOSITORY_MODEL_CASTS key in the
      * metadata key registry.
      *

--- a/tests/Unit/Repositories/Concerns/WritePoolFlushAccumulatorTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolFlushAccumulatorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Repositories\Concerns;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Enums\FlushStrategy;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushAccumulator;
+
+/**
+ * Tests for the WritePoolFlushAccumulator collaborator.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePoolFlushAccumulator::class)]
+final class WritePoolFlushAccumulatorTest extends TestCase
+{
+    /**
+     * Test that recordSuccess tallies both the chunk count and the record
+     * count.
+     *
+     * @return void
+     */
+    public function testRecordSuccessTalliesChunkAndRecordCounts(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        $accumulator->recordSuccess([['a' => 1], ['a' => 2]]);
+        $accumulator->recordSuccess([['a' => 3]]);
+
+        $result = $accumulator->toResult(FlushStrategy::COLLECT);
+
+        self::assertSame(2, $result->successCount());
+        self::assertSame(3, $result->flushedRecordCount());
+        self::assertSame(0, $result->failureCount());
+    }
+
+    /**
+     * Test that recordFailure tallies the failure count and captures the
+     * failure detail keyed by table name.
+     *
+     * @return void
+     */
+    public function testRecordFailureCapturesDetailKeyedByTable(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+        $exception   = new \RuntimeException('insert failed');
+
+        $accumulator->recordFailure('orders', [['id' => 1], ['id' => 2]], $exception);
+
+        $result   = $accumulator->toResult(FlushStrategy::COLLECT);
+        $failures = $result->failures();
+
+        self::assertSame(1, $result->failureCount());
+        self::assertSame(2, $result->failedRecordCount());
+        self::assertArrayHasKey('orders', $failures);
+        self::assertSame([['id' => 1], ['id' => 2]], $failures['orders'][0]['records']);
+        self::assertSame('insert failed', $failures['orders'][0]['exception']);
+        self::assertSame(\RuntimeException::class, $failures['orders'][0]['exception_class']);
+    }
+
+    /**
+     * Test that retain merges retained records per table and that failedRecords
+     * exposes them for retry.
+     *
+     * @return void
+     */
+    public function testRetainMergesRecordsPerTable(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        $accumulator->retain('orders', [['id' => 1]]);
+        $accumulator->retain('orders', [['id' => 2]]);
+        $accumulator->retain('payments', [['id' => 9]]);
+
+        self::assertSame([
+            'orders'   => [['id' => 1], ['id' => 2]],
+            'payments' => [['id' => 9]],
+        ], $accumulator->failedRecords());
+    }
+
+    /**
+     * Test that failedRecords returns an empty array when nothing was retained.
+     *
+     * @return void
+     */
+    public function testFailedRecordsIsEmptyByDefault(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        self::assertSame([], $accumulator->failedRecords());
+    }
+
+    /**
+     * Test that toResult retains failed records under the collect strategy,
+     * dropping none, and reports the attempted tables.
+     *
+     * @return void
+     */
+    public function testToResultRetainsFailedRecordsForCollectStrategy(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        $accumulator->recordFailure('orders', [['id' => 1], ['id' => 2]], new \RuntimeException);
+
+        $result = $accumulator->toResult(FlushStrategy::COLLECT, ['orders', 'payments']);
+
+        self::assertSame(2, $result->retainedRecordCount());
+        self::assertSame(0, $result->droppedRecordCount());
+        self::assertSame(['orders', 'payments'], $result->flushedTables());
+    }
+
+    /**
+     * Test that toResult drops failed records under the log strategy, retaining
+     * none.
+     *
+     * @return void
+     */
+    public function testToResultDropsFailedRecordsForLogStrategy(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        $accumulator->recordFailure('orders', [['id' => 1], ['id' => 2]], new \RuntimeException);
+
+        $result = $accumulator->toResult(FlushStrategy::LOG);
+
+        self::assertSame(0, $result->retainedRecordCount());
+        self::assertSame(2, $result->droppedRecordCount());
+        self::assertSame([], $result->flushedTables());
+    }
+
+    /**
+     * Test that toThrowResult carries the explicit retained record count and
+     * drops nothing.
+     *
+     * @return void
+     */
+    public function testToThrowResultUsesExplicitRetainedCount(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        $accumulator->recordSuccess([['id' => 1]]);
+        $accumulator->recordFailure('orders', [['id' => 2]], new \RuntimeException);
+
+        $result = $accumulator->toThrowResult(5, ['orders', 'payments']);
+
+        self::assertSame(1, $result->successCount());
+        self::assertSame(1, $result->failureCount());
+        self::assertSame(1, $result->flushedRecordCount());
+        self::assertSame(1, $result->failedRecordCount());
+        self::assertSame(5, $result->retainedRecordCount());
+        self::assertSame(0, $result->droppedRecordCount());
+        self::assertSame(['orders', 'payments'], $result->flushedTables());
+    }
+}

--- a/tests/Unit/Repositories/Concerns/WritePoolFlushContextTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolFlushContextTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Repositories\Concerns;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Enums\FlushStrategy;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushContext;
+
+/**
+ * Tests for the WritePoolFlushContext value object.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePoolFlushContext::class)]
+final class WritePoolFlushContextTest extends TestCase
+{
+    /**
+     * Test that the accessors return the values supplied to the constructor.
+     *
+     * @return void
+     */
+    public function testAccessorsReturnConstructorValues(): void
+    {
+        $chunks  = [[['id' => 1]], [['id' => 2]]];
+        $context = new WritePoolFlushContext(FlushStrategy::COLLECT, 'orders', $chunks, ['orders', 'payments'], 0);
+
+        self::assertSame(FlushStrategy::COLLECT, $context->strategy());
+        self::assertSame('orders', $context->table());
+        self::assertSame($chunks, $context->chunks());
+        self::assertSame(['orders', 'payments'], $context->tables());
+        self::assertSame(0, $context->tableIndex());
+    }
+
+    /**
+     * Test that chunkIndex defaults to null when omitted from the constructor.
+     *
+     * @return void
+     */
+    public function testChunkIndexDefaultsToNull(): void
+    {
+        $context = new WritePoolFlushContext(FlushStrategy::THROW, 'orders', [], [], 0);
+
+        self::assertNull($context->chunkIndex());
+    }
+
+    /**
+     * Test that a chunk index provided to the constructor is exposed by the
+     * accessor.
+     *
+     * @return void
+     */
+    public function testChunkIndexReturnsConstructorValue(): void
+    {
+        $context = new WritePoolFlushContext(FlushStrategy::LOG, 'orders', [], ['orders'], 2, 7);
+
+        self::assertSame(7, $context->chunkIndex());
+        self::assertSame(2, $context->tableIndex());
+    }
+
+    /**
+     * Test that withChunkIndex returns a new instance carrying the given chunk
+     * index while preserving every other field and leaving the original
+     * untouched.
+     *
+     * @return void
+     */
+    public function testWithChunkIndexReturnsNewInstancePreservingOtherFields(): void
+    {
+        $chunks   = [[['id' => 1]], [['id' => 2]]];
+        $original = new WritePoolFlushContext(FlushStrategy::THROW, 'orders', $chunks, ['orders', 'payments'], 1);
+
+        $derived = $original->withChunkIndex(3);
+
+        self::assertNotSame($original, $derived);
+        self::assertNull($original->chunkIndex());
+        self::assertSame(3, $derived->chunkIndex());
+        self::assertSame(FlushStrategy::THROW, $derived->strategy());
+        self::assertSame('orders', $derived->table());
+        self::assertSame($chunks, $derived->chunks());
+        self::assertSame(['orders', 'payments'], $derived->tables());
+        self::assertSame(1, $derived->tableIndex());
+    }
+}

--- a/tests/Unit/Repositories/Concerns/WritePoolTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Repositories\Concerns;
 
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
@@ -14,6 +16,9 @@ use SineMacula\ApiToolkit\Enums\FlushStrategy;
 use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
+use SineMacula\Repositories\Concerns\CacheSizeGuard;
+use SineMacula\Repositories\Concerns\CacheStore;
+use SineMacula\Repositories\Concerns\CacheStoreOptions;
 use Tests\TestCase;
 
 /**
@@ -968,6 +973,124 @@ final class WritePoolTest extends TestCase
     }
 
     /**
+     * Test that a successful flush invalidates the per-query cache for each
+     * table it persisted, so a Cacheable repository re-reads the committed rows
+     * rather than serving a stale collection.
+     *
+     * @return void
+     */
+    public function testFlushInvalidatesTheQueryCacheForFlushedTables(): void
+    {
+        Config::set('cache.default', 'array');
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        $warm = $this->cacheStore('test_records');
+        $warm->put('stale-query-hash', collect(['stale']), 60);
+
+        self::assertNotNull($warm->fetch('stale-query-hash'));
+
+        $this->pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $this->pool->flush();
+
+        self::assertNull($this->cacheStore('test_records')->fetch('stale-query-hash'));
+    }
+
+    /**
+     * Test that the auto-flush triggered when the pool limit is reached
+     * invalidates the per-query cache, so a buffer that drains mid-request does
+     * not leave a Cacheable repository serving stale rows.
+     *
+     * @return void
+     */
+    public function testAutoFlushAtPoolLimitInvalidatesTheQueryCache(): void
+    {
+        Config::set('cache.default', 'array');
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        $warm = $this->cacheStore('test_records');
+        $warm->put('stale-query-hash', collect(['stale']), 60);
+
+        $pool = new WritePool(chunkSize: 500, poolLimit: 1);
+        $pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+
+        self::assertSame(1, DB::table('test_records')->count());
+        self::assertNull($this->cacheStore('test_records')->fetch('stale-query-hash'));
+    }
+
+    /**
+     * Test that a flush invalidates the per-query cache by default when the
+     * config key is absent, so the safe default keeps cached collections in
+     * step with the committed rows.
+     *
+     * @return void
+     */
+    public function testFlushInvalidatesTheQueryCacheByDefaultWhenConfigKeyAbsent(): void
+    {
+        Config::set('cache.default', 'array');
+
+        $deferred = (array) Config::get('api-toolkit.deferred_writes');
+        unset($deferred['invalidate_query_cache']);
+        Config::set('api-toolkit.deferred_writes', $deferred);
+
+        $warm = $this->cacheStore('test_records');
+        $warm->put('stale-query-hash', collect(['stale']), 60);
+
+        $this->pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $this->pool->flush();
+
+        self::assertNull($this->cacheStore('test_records')->fetch('stale-query-hash'));
+    }
+
+    /**
+     * Test that a flush leaves the per-query cache untouched when invalidation
+     * is disabled by config.
+     *
+     * @return void
+     */
+    public function testFlushDoesNotInvalidateTheQueryCacheWhenDisabled(): void
+    {
+        Config::set('cache.default', 'array');
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', false);
+
+        $warm = $this->cacheStore('test_records');
+        $warm->put('stale-query-hash', collect(['stale']), 60);
+
+        $this->pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $this->pool->flush();
+
+        self::assertNotNull($this->cacheStore('test_records')->fetch('stale-query-hash'));
+    }
+
+    /**
+     * Test that a flush that throws still invalidates the per-query cache for
+     * the tables it persisted before the failing table, so a partial commit
+     * does not leave stale cached collections behind.
+     *
+     * @return void
+     */
+    public function testFlushInvalidatesTheQueryCacheForTablesPersistedBeforeAThrow(): void
+    {
+        Config::set('cache.default', 'array');
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        $warm = $this->cacheStore('test_records');
+        $warm->put('stale-query-hash', collect(['stale']), 60);
+
+        $pool = new WritePool(chunkSize: 1, poolLimit: 10000, strategy: FlushStrategy::THROW);
+        $pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $pool->add('nonexistent_table', ['col' => 'val']);
+
+        try {
+            $pool->flush();
+            self::fail('Expected WritePoolFlushException was not thrown');
+        } catch (WritePoolFlushException) {
+            // Expected: the second table fails under the throw strategy.
+        }
+
+        self::assertNull($this->cacheStore('test_records')->fetch('stale-query-hash'));
+    }
+
+    /**
      * Define the database migrations.
      *
      * @return void
@@ -992,5 +1115,16 @@ final class WritePoolTest extends TestCase
             $table->id();
             $table->string('name')->unique();
         });
+    }
+
+    /**
+     * Build a CacheStore on the array driver for the given table.
+     *
+     * @param  string  $table
+     * @return \SineMacula\Repositories\Concerns\CacheStore
+     */
+    private function cacheStore(string $table): CacheStore
+    {
+        return new CacheStore(Cache::store('array'), $table, new CacheStoreOptions(3600, new CacheSizeGuard(null, null), true, 0));
     }
 }

--- a/tests/Unit/Repositories/Concerns/WritePoolTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolTest.php
@@ -922,6 +922,52 @@ final class WritePoolTest extends TestCase
     }
 
     /**
+     * Test that a transactional flush commits every chunk of a table and counts
+     * each chunk and record as successfully flushed.
+     *
+     * @return void
+     */
+    public function testTransactionalFlushCommitsAndRecordsTableSuccess(): void
+    {
+        $pool = new WritePool(chunkSize: 1, poolLimit: 10000, strategy: FlushStrategy::COLLECT, transactional: true);
+
+        $pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $pool->add('test_records', ['name' => 'baz', 'value' => 'qux']);
+
+        $flushResult = $pool->flush();
+
+        self::assertTrue($flushResult->isSuccessful());
+        self::assertSame(2, $flushResult->successCount());
+        self::assertSame(2, $flushResult->flushedRecordCount());
+        self::assertSame(2, DB::table('test_records')->count());
+        self::assertSame(0, $pool->count());
+    }
+
+    /**
+     * Test that a transactional log flush logs the rolled-back table and drops
+     * its records rather than retaining them.
+     *
+     * @return void
+     */
+    public function testTransactionalLogFlushLogsAndDropsRolledBackTable(): void
+    {
+        $pool = new WritePool(chunkSize: 1, poolLimit: 10000, strategy: FlushStrategy::LOG, transactional: true);
+
+        Log::shouldReceive('error')->once()->withAnyArgs();
+
+        $pool->add('test_unique', ['name' => 'alpha']);
+        $pool->add('test_unique', ['name' => 'alpha']);
+
+        $flushResult = $pool->flush();
+
+        self::assertFalse($flushResult->isSuccessful());
+        self::assertSame(0, DB::table('test_unique')->count());
+        self::assertTrue($pool->isEmpty());
+        self::assertSame(2, $flushResult->droppedRecordCount());
+        self::assertSame(0, $flushResult->retainedRecordCount());
+    }
+
+    /**
      * Define the database migrations.
      *
      * @return void

--- a/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
@@ -328,6 +328,37 @@ final class ColumnProjectionApplierTest extends TestCase
     }
 
     /**
+     * Test that an eager-load map entry whose relation path is not a string is
+     * skipped when deriving base-model relation names, so narrowing still
+     * proceeds over the remaining resolvable fields.
+     *
+     * @return void
+     */
+    public function testSkipsNonStringRelationPathInEagerLoadMap(): void
+    {
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $this->parseRequest(new Request);
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(self::USER_DEFAULT_FIELDS);
+        // Int-keyed entry carrying a non-string relation path (a nested array
+        // rather than a dot-path string).
+        $provider->method('eagerLoadMapFor')->willReturn([['nested', 'array']]);
+
+        $query  = (new User)->newQuery();
+        $result = $this->makeApplier()->apply($query, $provider, UserResource::class, []);
+
+        $columns = $result->getQuery()->columns;
+
+        self::assertNotNull($columns);
+        self::assertContains('id', $columns);
+        self::assertContains('name', $columns);
+        self::assertContains('email', $columns);
+    }
+
+    /**
      * Build a column projection applier over a stubbed introspection provider
      * reporting the fixture user columns.
      *

--- a/tests/Unit/Repositories/Criteria/Concerns/FilterApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/FilterApplierTest.php
@@ -23,6 +23,7 @@ use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\User;
 use Tests\TestCase;
 
@@ -40,6 +41,8 @@ use Tests\TestCase;
 #[CoversClass(FilterApplier::class)]
 final class FilterApplierTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
     /** @var string */
     private const string OPERATOR_CONTAINS = '$contains';
 
@@ -676,6 +679,38 @@ final class FilterApplierTest extends TestCase
         ]);
 
         self::assertNotEmpty($result->getQuery()->wheres);
+    }
+
+    /**
+     * Test that a condition operator applied to a column that fails the query
+     * surface guard is skipped, leaving the query untouched.
+     *
+     * @return void
+     */
+    public function testConditionOperatorOnGuardedColumnIsSkipped(): void
+    {
+        $result = $this->applyFilters(['forbidden_column' => ['$eq' => 'Alice']]);
+
+        self::assertEmpty($result->getQuery()->wheres);
+    }
+
+    /**
+     * Test that a condition operator whose token is reported as registered but
+     * resolves to no handler is skipped, leaving the query untouched.
+     *
+     * @return void
+     */
+    public function testConditionOperatorWithNullHandlerIsSkipped(): void
+    {
+        // Force a token that the registry reports present but resolves to null,
+        // so has() and resolve() disagree - the guard must drop it silently.
+        $operators             = $this->getProperty($this->operatorRegistry, 'operators');
+        $operators['$phantom'] = null;
+        $this->setProperty($this->operatorRegistry, 'operators', $operators);
+
+        $result = $this->applyFilters(['name' => ['$phantom' => 'Alice']]);
+
+        self::assertEmpty($result->getQuery()->wheres);
     }
 
     /**

--- a/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
+++ b/tests/Unit/Repositories/Criteria/QuerySurfaceTest.php
@@ -229,6 +229,24 @@ final class QuerySurfaceTest extends TestCase
     }
 
     /**
+     * Test that the blocklist posture delegates sort-column checks to the
+     * schema introspector and drops (rather than rejects) an unsortable key.
+     *
+     * @return void
+     */
+    public function testBlocklistDelegatesSortToIntrospectorAndDropsUnsearchable(): void
+    {
+        $introspector = \Mockery::mock(SchemaIntrospectionProvider::class);
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'created_at')->andReturnTrue(); // @phpstan-ignore method.notFound
+        $introspector->shouldReceive('isSearchable')->with(\Mockery::any(), 'secret')->andReturnFalse(); // @phpstan-ignore method.notFound
+
+        $surface = $this->make(posture: QuerySurface::POSTURE_BLOCKLIST, introspector: $introspector);
+
+        self::assertTrue($surface->guardSort('created_at', new User));
+        self::assertFalse($surface->guardSort('secret', new User));
+    }
+
+    /**
      * Test that under the allowlist posture a relation declared traversable in
      * the related model's mapped resource is permitted at a non-root hop.
      *

--- a/tests/Unit/Schema/Introspection/SchemaIntrospectorTest.php
+++ b/tests/Unit/Schema/Introspection/SchemaIntrospectorTest.php
@@ -230,6 +230,28 @@ final class SchemaIntrospectorTest extends TestCase
     }
 
     /**
+     * Test that a fresh introspector serves column definitions from the memo
+     * cache populated by an earlier instance, without re-querying the schema.
+     *
+     * @return void
+     */
+    public function testGetColumnDefinitionsServesMemoCacheOnFreshInstance(): void
+    {
+        $model = new User;
+
+        $first = ($this->makeIntrospector())->getColumnDefinitions($model);
+
+        self::assertNotEmpty($first);
+
+        Schema::shouldReceive('getColumns')
+            ->never();
+
+        $second = ($this->makeIntrospector())->getColumnDefinitions($model);
+
+        self::assertEquals($first, $second);
+    }
+
+    /**
      * Test that getColumnDefinitions stores the result in the memo cache under
      * a key scoped to the model class.
      *
@@ -336,6 +358,24 @@ final class SchemaIntrospectorTest extends TestCase
         $model        = new User;
 
         self::assertContains('name', $introspector->getSearchableColumns($model));
+    }
+
+    /**
+     * Test that a second getSearchableColumns call on the same instance is
+     * served from the instance cache without recomputing.
+     *
+     * @return void
+     */
+    public function testGetSearchableColumnsServesInstanceCacheOnSecondCall(): void
+    {
+        $introspector = $this->makeIntrospector();
+        $model        = new User;
+
+        $first  = $introspector->getSearchableColumns($model);
+        $second = $introspector->getSearchableColumns($model);
+
+        self::assertSame($first, $second);
+        self::assertArrayHasKey(User::class, $this->getProperty($introspector, 'searchable'));
     }
 
     /**

--- a/tests/Unit/Schema/Validation/Rules/ValidateRelationMethodsTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidateRelationMethodsTest.php
@@ -252,6 +252,33 @@ final class ValidateRelationMethodsTest extends TestCase
     }
 
     /**
+     * Test that a count definition whose relation method is valid produces no
+     * error, so the loop advances past it.
+     *
+     * @return void
+     */
+    public function testNoErrorForCountDefinitionWithValidRelation(): void
+    {
+        $schema = new CompiledSchema(
+            fields: [],
+            counts: [
+                'posts_count' => new CompiledCountDefinition(
+                    presentKey: 'posts_count',
+                    relation: 'posts',
+                    constraint: null,
+                    isDefault: false,
+                    guards: [],
+                ),
+            ],
+        );
+
+        $rule   = new ValidateRelationMethods;
+        $errors = $rule->validate(UserResource::class, User::class, $schema);
+
+        self::assertSame([], $errors);
+    }
+
+    /**
      * Test reports relation method missing on model for count definition.
      *
      * @return void

--- a/tests/Unit/Schema/Validation/Rules/ValidatesCallableListsTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidatesCallableListsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Schema\Validation\Rules;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
+use SineMacula\ApiToolkit\Schema\CompiledSchema;
+use SineMacula\ApiToolkit\Schema\Validation\Rules\ValidatesCallableLists;
+
+/**
+ * Tests for the ValidatesCallableLists base validation rule.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ValidatesCallableLists::class)]
+final class ValidatesCallableListsTest extends TestCase
+{
+    /**
+     * Test that a field whose callable list is fully callable produces no
+     * errors.
+     *
+     * @return void
+     */
+    public function testNoErrorsWhenEveryEntryIsCallable(): void
+    {
+        $field = new CompiledFieldDefinition(
+            accessor: 'name',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: [fn ($value, $model) => true],
+            transformers: [],
+        );
+
+        $schema = new CompiledSchema(fields: ['name' => $field], counts: []);
+
+        self::assertSame([], $this->makeRule()->validate('App\Http\Resources\UserResource', null, $schema));
+    }
+
+    /**
+     * Test that a non-callable entry is reported using the concrete label.
+     *
+     * @return void
+     */
+    public function testReportsNonCallableEntry(): void
+    {
+        $field = new CompiledFieldDefinition(
+            accessor: 'name',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: ['not_a_function'],
+            transformers: [],
+        );
+
+        $schema = new CompiledSchema(fields: ['name' => $field], counts: []);
+
+        $errors = $this->makeRule()->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('name', $errors[0]->fieldKey);
+        self::assertSame('Item at index 0 is not callable', $errors[0]->defect);
+    }
+
+    /**
+     * Test that a null field definition present under a declared key is skipped
+     * without error.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public function testSkipsNullFieldDefinition(): void
+    {
+        $reflection = new \ReflectionClass(CompiledSchema::class);
+        $schema     = $reflection->newInstanceWithoutConstructor();
+
+        $reflection->getProperty('fields')->setValue($schema, ['ghost' => null]);
+        $reflection->getProperty('counts')->setValue($schema, []);
+
+        self::assertSame([], $this->makeRule()->validate('App\Http\Resources\UserResource', null, $schema));
+    }
+
+    /**
+     * Build a concrete rule that validates each field's guard list.
+     *
+     * @return \SineMacula\ApiToolkit\Schema\Validation\Rules\ValidatesCallableLists
+     */
+    private function makeRule(): ValidatesCallableLists
+    {
+        return new class extends ValidatesCallableLists {
+            /**
+             * Return the callable list to validate for the given field.
+             *
+             * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $field
+             * @return array<int, callable(mixed, mixed): mixed>
+             */
+            #[\Override]
+            protected function getCallables(CompiledFieldDefinition $field): array
+            {
+                return $field->guards;
+            }
+
+            /**
+             * Return the human-readable label used in defect messages.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function getLabel(): string
+            {
+                return 'Item';
+            }
+        };
+    }
+}

--- a/tests/Unit/Services/Actors/EloquentActorTest.php
+++ b/tests/Unit/Services/Actors/EloquentActorTest.php
@@ -4,6 +4,9 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\Services\Actors;
 
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Services\Actors\EloquentActor;
@@ -194,5 +197,87 @@ final class EloquentActorTest extends TestCase
         $second = $restored->toAuthenticatable();
 
         self::assertSame($first, $second);
+    }
+
+    /**
+     * Test that a string primary key is captured verbatim as the actor
+     * identifier.
+     *
+     * @return void
+     */
+    public function testCapturesStringPrimaryKeyAsIdentifier(): void
+    {
+        $model = $this->makeStringKeyedModel();
+
+        $model->setAttribute('code', 'GB');
+        $model->setAttribute('name', 'Great Britain');
+
+        $actor = new EloquentActor($model);
+
+        self::assertSame('GB', $actor->actorIdentifier());
+    }
+
+    /**
+     * Test that a model with an unset (null) primary key falls back to an empty
+     * string identifier.
+     *
+     * @return void
+     */
+    public function testFallsBackToEmptyIdentifierForNullKey(): void
+    {
+        $model = $this->makeStringKeyedModel();
+
+        $model->setAttribute('name', 'Keyless');
+
+        $actor = new EloquentActor($model);
+
+        self::assertSame('', $actor->actorIdentifier());
+    }
+
+    /**
+     * Test that the label falls back to the model's class basename when neither
+     * a name nor an email attribute is present.
+     *
+     * @return void
+     */
+    public function testLabelFallsBackToClassBasename(): void
+    {
+        $model = new class extends Model implements AuthenticatableContract {
+            use Authenticatable;
+
+            /** @var string|null */
+            protected $table = 'users';
+        };
+
+        $model->setAttribute('id', 5);
+
+        $actor = new EloquentActor($model);
+
+        self::assertSame(class_basename($model), $actor->actorLabel());
+    }
+
+    /**
+     * Build an Authenticatable model whose primary key is a non-incrementing
+     * string column.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Database\Eloquent\Model
+     */
+    private function makeStringKeyedModel(): AuthenticatableContract&Model
+    {
+        return new class extends Model implements AuthenticatableContract {
+            use Authenticatable;
+
+            /** @var string|null */
+            protected $table = 'countries';
+
+            /** @var string */
+            protected $primaryKey = 'code';
+
+            /** @var string */
+            protected $keyType = 'string';
+
+            /** @var bool */
+            public $incrementing = false;
+        };
     }
 }

--- a/tests/Unit/Services/Input/InputDataTest.php
+++ b/tests/Unit/Services/Input/InputDataTest.php
@@ -188,4 +188,128 @@ final class InputDataTest extends TestCase
             $input->toArray(),
         );
     }
+
+    /**
+     * Test that from() skips constructor parameters that are not promoted, so
+     * such parameters are never hydrated from the validated input.
+     *
+     * @return void
+     */
+    public function testFromSkipsNonPromotedConstructorParameters(): void
+    {
+        $definition = new class extends InputData {
+            /** @var string The city, from a non-promoted parameter. */
+            public readonly string $city;
+
+            /**
+             * Create a new instance from a non-promoted and a promoted param.
+             *
+             * @param  string  $cityInput
+             * @param  int|null  $age
+             */
+            public function __construct(
+
+                // The city name from a non-promoted parameter.
+                string $cityInput = 'default',
+
+                /** The age, hydrated from validated input. */
+                public readonly ?int $age = null,
+            ) {
+                $this->city = $cityInput;
+            }
+
+            /**
+             * Validate both the promoted and the non-promoted parameter names.
+             *
+             * @return array<string, mixed>
+             */
+            #[\Override]
+            public static function rules(): array
+            {
+                return [
+                    'age'       => ['nullable', 'integer'],
+                    'cityInput' => ['nullable', 'string'],
+                ];
+            }
+        };
+
+        $result = $definition::from(['age' => 42, 'cityInput' => 'from-input']);
+
+        self::assertSame(42, $result->age);
+        self::assertSame('default', $result->city);
+    }
+
+    /**
+     * Test that toArray() skips public properties that are not promoted.
+     *
+     * @return void
+     */
+    public function testToArraySkipsNonPromotedPublicProperties(): void
+    {
+        $input = new class extends InputData {
+            /** @var string A public property that is not promoted. */
+            public string $manual = 'manual-value';
+
+            /**
+             * Create a new instance with a single promoted property.
+             *
+             * @param  string  $city
+             */
+            public function __construct(
+
+                /** The promoted city property. */
+                public readonly string $city = 'Y',
+            ) {}
+        };
+
+        self::assertSame(['city' => 'Y'], $input->toArray());
+    }
+
+    /**
+     * Test that toArray() skips promoted properties that are uninitialised.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public function testToArraySkipsUninitialisedPromotedProperties(): void
+    {
+        $reflection = new \ReflectionClass(SampleInput::class);
+
+        /** @var \Tests\Fixtures\Input\SampleInput $input */
+        $input = $reflection->newInstanceWithoutConstructor();
+
+        $reflection->getProperty('city')->setValue($input, 'OnlyCity');
+
+        self::assertSame(['city' => 'OnlyCity'], $input->toArray());
+    }
+
+    /**
+     * Test that the base rules() returns an empty rule set when a subclass does
+     * not override it, permitting construction from an empty source.
+     *
+     * @return void
+     */
+    public function testBaseRulesReturnEmptyArrayWhenNotOverridden(): void
+    {
+        $definition = new class extends InputData {
+            /**
+             * Create a new instance with a defaulted promoted property.
+             *
+             * @param  string  $city
+             */
+            public function __construct(
+
+                /** The promoted city property. */
+                public readonly string $city = 'base',
+            ) {}
+        };
+
+        self::assertSame([], $definition::rules());
+
+        $result = $definition::from([]);
+
+        self::assertInstanceOf(InputData::class, $result);
+        self::assertSame('base', $result->city);
+    }
 }

--- a/tests/Unit/Traits/OrdersFieldsTest.php
+++ b/tests/Unit/Traits/OrdersFieldsTest.php
@@ -145,6 +145,15 @@ final class OrdersFieldsTest extends TestCase
             ],
             ['id', 'name'],
         ];
+
+        yield 'requested field absent from data is skipped' => [
+            ['name', 'missing', 'id'],
+            [
+                'id'   => 1,
+                'name' => 'Alice',
+            ],
+            ['name', 'id'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Closes the highest-priority gaps from the test-suite readiness review: the seams where a silent regression would pass the entire existing suite, and the two axes the review flagged - realistic HTTP coverage and proven collection efficiency.

## What's added

A new `tests/Feature/` suite driving the package through the real HTTP kernel, plus a collection query-count guard in `tests/Integration/`:

- **Collection N+1 guard** - the fetch-and-serialise query count is a constant (3) regardless of row count, with the nested relations asserted so a constant count cannot silently mean nothing loaded.
- **Allowlist rejection** - under the default allowlist posture, a declared filter narrows; an undeclared filter/sort key renders the 422 envelope keyed on the offending field. (The one existing lifecycle HTTP test pins *blocklist*, so allowlist had zero full-stack coverage.)
- **Authorization** - a denied ability renders the 403 envelope while a guard-excluded action bypasses it (first policy fixture in the suite).
- **Throttle** - an exhausted bucket renders the 429 envelope with a `Retry-After` header.
- **Maintenance mode** - a guarded route renders the 503 envelope; a bypass-list route is served as normal.
- **Sensitive-key redaction** - proven reaching a real record on the `api-exceptions` channel, not just via reflection.

## Bug found and fixed

The maintenance test surfaced a real defect. The swap prepended the toolkit middleware but left the framework's built-in maintenance middleware in the global stack, so `maintenance_mode.except` never bypassed anything - the framework middleware (empty except list) re-threw a raw 503 for any excepted path. Fixed by removing the framework middleware from the global stack when swapping, so the toolkit middleware is the sole gate and its except list is authoritative. Pinned by an HTTP bypass test and the registrar test.

Note: a consuming app that previously configured maintenance exceptions on the framework middleware directly should move them to `api-toolkit.maintenance_mode.except`.

## Verification

- Full suite green (1906 tests).
- `qlty check` / `qlty smells` clean.
- Diff-scoped mutation gate passes (100% on the changed middleware logic).