### PR TITLE
fix: Octane flush listener registration, plus coding-standards v1.14.0 conformance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "suggest": {
         "illuminate/notifications": "Required only for notification-event logging",
+        "laravel/octane": "Flushes toolkit caches between requests when serving under Laravel Octane",
         "sinemacula/laravel-log-cloudwatch": "CloudWatch log driver (Monolog), extracted from this package",
         "sinemacula/laravel-log-database": "Database log driver (Monolog), extracted from this package",
         "sinemacula/laravel-resource-exporter": "Content-negotiated exports (CSV/TSV/XLSX/XML/JSON/NDJSON) for resources and collections; wires into resource responses automatically when installed",
@@ -37,6 +38,7 @@
         "brianium/paratest": "^7.20",
         "friendsofphp/php-cs-fixer": "3.89.0",
         "infection/infection": "0.33.2",
+        "laravel/octane": "^2.0",
         "mockery/mockery": "^1.6",
         "opis/json-schema": "^2.4",
         "orchestra/testbench": "^9.0 || ^10.0",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
             "@php vendor/bin/paratest --coverage-clover=clover.xml"
         ],
         "test:mutation": [
-            "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90"
+            "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90 --ignore-msi-with-no-mutations"
         ],
         "test:mutation:full": [
             "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.full.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --threads=max"

--- a/src/Concerns/OrdersFields.php
+++ b/src/Concerns/OrdersFields.php
@@ -14,11 +14,7 @@ use SineMacula\ApiToolkit\Enums\FieldOrderingStrategy;
  */
 trait OrdersFields
 {
-    /**
-     * The field-ordering strategy to use.
-     *
-     * @var \SineMacula\ApiToolkit\Enums\FieldOrderingStrategy
-     */
+    /** @var \SineMacula\ApiToolkit\Enums\FieldOrderingStrategy */
     protected FieldOrderingStrategy $fieldOrderingStrategy = FieldOrderingStrategy::DEFAULT;
 
     /**

--- a/src/Enums/FieldOrderingStrategy.php
+++ b/src/Enums/FieldOrderingStrategy.php
@@ -12,19 +12,9 @@ namespace SineMacula\ApiToolkit\Enums;
  */
 enum FieldOrderingStrategy: string
 {
-    /**
-     * Order resolved fields into a predictable output structure.
-     *
-     * Rules:
-     *  - "_type" always first
-     *  - "id" always second
-     *  - any timestamps (*_at) always last
-     *  - everything else alphabetized in between
-     */
+    /** "_type" first, "id" second, others alphabetised, timestamps last. */
     case DEFAULT = 'default';
 
-    /**
-     * Order resolved fields in the order they were requested.
-     */
+    /** Order resolved fields in the order they were requested. */
     case BY_REQUESTED_FIELDS = 'by_requested_fields';
 }

--- a/src/Enums/FlushStrategy.php
+++ b/src/Enums/FlushStrategy.php
@@ -12,27 +12,12 @@ namespace SineMacula\ApiToolkit\Enums;
  */
 enum FlushStrategy: string
 {
-    /**
-     * Opt-in best-effort: catch the exception, log at error level, continue to
-     * the next chunk, and clear the entire buffer after processing. Failed
-     * records are dropped, so this strategy is only appropriate for genuinely
-     * disposable writes such as audit, analytics, or telemetry.
-     */
+    /** Best-effort: log failures, continue, and drop the whole buffer. */
     case LOG = 'log';
 
-    /**
-     * Safe explicit: on the first chunk failure, throw the exception carrying
-     * the partial result and preserve the failed and unprocessed records in the
-     * buffer. No record is dropped. Intended for callers that own an explicit
-     * flush site and want to be told loudly when a write fails.
-     */
+    /** Throw on first failure; retain failed and unprocessed records. */
     case THROW = 'throw';
 
-    /**
-     * Safe default: catch all failures, accumulate them in the result, and
-     * retain the failed records in the buffer for the next flush attempt. No
-     * record is dropped and no exception escapes, so a boundary flush surfaces
-     * failures loudly without disrupting the lifecycle.
-     */
+    /** Safe default: accumulate failures and retain records for retry. */
     case COLLECT = 'collect';
 }

--- a/src/OpenApi/Metadata/ErrorCatalogueReader.php
+++ b/src/OpenApi/Metadata/ErrorCatalogueReader.php
@@ -29,11 +29,7 @@ final class ErrorCatalogueReader
     /** @var string The filesystem path to the Exceptions directory */
     private const string EXCEPTIONS_DIR = __DIR__ . '/../../Exceptions';
 
-    /**
-     * Memoised map from integer error-code value to owning exception class.
-     *
-     * @var array<int, class-string<\SineMacula\ApiToolkit\Exceptions\ApiException>>
-     */
+    /** @var array<int, class-string<\SineMacula\ApiToolkit\Exceptions\ApiException>> Memoised code-to-class map. */
     private array $exceptionMap = [];
 
     /**

--- a/src/Providers/Registrars/LifecycleRegistrar.php
+++ b/src/Providers/Registrars/LifecycleRegistrar.php
@@ -7,7 +7,7 @@ namespace SineMacula\ApiToolkit\Providers\Registrars;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
-use Laravel\Octane\Events\OperationTerminated;
+use Laravel\Octane\Contracts\OperationTerminated;
 use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
@@ -59,7 +59,7 @@ final class LifecycleRegistrar
             return;
         }
 
-        if (!class_exists(OperationTerminated::class)) {
+        if (!interface_exists(OperationTerminated::class)) {
             return;
         }
 

--- a/src/Services/Actors/EloquentActor.php
+++ b/src/Services/Actors/EloquentActor.php
@@ -38,23 +38,10 @@ final class EloquentActor implements Actor
     /** @var string Human-readable label snapshotted at construction time. */
     private string $label;
 
-    /**
-     * The live model instance.
-     *
-     * Null after unserialisation until the first call to toAuthenticatable().
-     * Also null when the underlying record has been deleted and re-resolution
-     * returned nothing.
-     *
-     * @var (\Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Database\Eloquent\Model)|null
-     */
+    /** @var (\Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Database\Eloquent\Model)|null The live model, or null when unresolved or gone. */
     private (Authenticatable&Model)|null $model = null;
 
-    /**
-     * Whether the model has been resolved (or attempted) after unserialisation.
-     * False only between __unserialize and the first toAuthenticatable() call.
-     *
-     * @var bool
-     */
+    /** @var bool Whether resolution has run since unserialisation. */
     private bool $resolved = false;
 
     /**

--- a/tests/Fixtures/Overrides/functions.php
+++ b/tests/Fixtures/Overrides/functions.php
@@ -149,3 +149,31 @@ function class_exists(string $class, bool $autoload = true): bool
 
     return \class_exists($class, $autoload);
 }
+
+/**
+ * Override interface_exists() within the Providers\Registrars namespace.
+ *
+ * Lets tests simulate the presence or absence of an optional integration's
+ * marker interface (Octane's OperationTerminated) so both branches of the
+ * interface_exists guard are observable without changing the installed
+ * dependency set.
+ *
+ * @SuppressWarnings("php:S100")
+ * @SuppressWarnings("php:S4144")
+ *
+ * @param  string  $interface
+ * @param  bool  $autoload
+ * @return bool
+ *
+ * @imperative
+ */
+function interface_exists(string $interface, bool $autoload = true): bool
+{
+    $override = FunctionOverrides::get('interface_exists');
+
+    if ($override !== null) {
+        return (bool) $override($interface, $autoload);
+    }
+
+    return \interface_exists($interface, $autoload);
+}

--- a/tests/Integration/ApiServiceProviderTest.php
+++ b/tests/Integration/ApiServiceProviderTest.php
@@ -19,7 +19,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Octane\Events\OperationTerminated;
+use Laravel\Octane\Contracts\OperationTerminated;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\ApiQueryParser;
 use SineMacula\ApiToolkit\ApiServiceProvider;
@@ -595,13 +595,13 @@ final class ApiServiceProviderTest extends TestCase
      */
     public function testOctaneFlushListenerRegisteredWhenConfigEnabled(): void
     {
-        if (!class_exists(OperationTerminated::class)) {
-            self::markTestSkipped('Laravel Octane is not installed.');
-        }
-
         $app = $this->getApplication();
 
         $this->getConfig()->set('api-toolkit.lifecycle.octane', true);
+
+        // Reset the dispatcher so Octane's own OperationTerminated listeners do
+        // not mask whether the provider wires the toolkit's listener.
+        Event::swap(new Dispatcher($app));
 
         $provider = new ApiServiceProvider($app);
         $provider->boot();
@@ -624,13 +624,17 @@ final class ApiServiceProviderTest extends TestCase
 
         $this->getConfig()->set('api-toolkit.lifecycle.octane', false);
 
+        // Reset the dispatcher so Octane's own OperationTerminated listeners do
+        // not mask that the provider leaves the toolkit's listener unwired.
+        Event::swap(new Dispatcher($app));
+
         $provider = new ApiServiceProvider($app);
         $provider->boot();
 
         /** @var \Illuminate\Contracts\Events\Dispatcher $events */
         $events = $app->make('events');
 
-        self::assertFalse($events->hasListeners(OperationTerminated::class)); // @phpstan-ignore class.notFound
+        self::assertFalse($events->hasListeners(OperationTerminated::class));
     }
 
     /**

--- a/tests/Integration/LifecycleFlushDefaultsTest.php
+++ b/tests/Integration/LifecycleFlushDefaultsTest.php
@@ -180,10 +180,9 @@ final class LifecycleFlushDefaultsTest extends TestCase
      * With the lifecycle flag off, LifecycleRegistrar does not subscribe the
      * flush, so no boundary can fire it. The queue path is the representative
      * opt-out oracle - the Octane path additionally gates on
-     * class_exists(OperationTerminated), which is always false here because
-     * laravel/octane is not installed, so the queue gate is the one that can be
-     * isolated. The enabled control proves the assertion tracks the flag rather
-     * than passing vacuously.
+     * interface_exists(OperationTerminated), so the queue gate is the one that
+     * can be isolated cleanly. The enabled control proves the assertion tracks
+     * the flag rather than passing vacuously.
      *
      * @return void
      */

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -4,11 +4,13 @@ declare(strict_types = 1);
 
 namespace Tests\Integration\Providers\Registrars;
 
+use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
-use Laravel\Octane\Events\OperationTerminated;
+use Laravel\Octane\Contracts\OperationTerminated;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Listeners\QueueFlushSubscriber;
 use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
@@ -87,11 +89,11 @@ final class LifecycleRegistrarTest extends TestCase
 
     /**
      * Test that the Octane flush listener is wired when the lifecycle Octane
-     * flush is enabled and the Octane event class is available.
+     * flush is enabled and the Octane marker interface is available.
      *
      * @return void
      */
-    public function testOctaneFlushListenerRegisteredWhenClassPresentAndEnabled(): void
+    public function testOctaneFlushListenerRegisteredWhenInterfacePresentAndEnabled(): void
     {
         unset($_SERVER['LARAVEL_OCTANE']);
 
@@ -100,16 +102,47 @@ final class LifecycleRegistrarTest extends TestCase
         $config->set('api-toolkit.lifecycle.octane', true);
         $config->set('api-toolkit.lifecycle.queue', false);
 
-        // Simulate laravel/octane being installed so the class_exists guard
-        // passes and the listener binds to the event class name.
-        FunctionOverrides::set('class_exists', static fn (string $class): bool => $class === OperationTerminated::class || \class_exists($class)); // @phpstan-ignore class.notFound
+        // Reset the dispatcher so Octane's own OperationTerminated listeners do
+        // not mask whether the registrar wires the toolkit's listener.
+        Event::swap(new Dispatcher($this->getApplication()));
 
         (new LifecycleRegistrar)->register();
 
         /** @var \Illuminate\Events\Dispatcher $events */
         $events = $this->getApplication()->make('events');
 
-        self::assertTrue($events->hasListeners(OperationTerminated::class)); // @phpstan-ignore class.notFound
+        self::assertTrue($events->hasListeners(OperationTerminated::class));
+    }
+
+    /**
+     * Test that the Octane flush listener is not wired when the Octane marker
+     * interface is absent, even with the lifecycle Octane flush enabled.
+     *
+     * @return void
+     */
+    public function testOctaneFlushListenerNotRegisteredWhenInterfaceAbsent(): void
+    {
+        unset($_SERVER['LARAVEL_OCTANE']);
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->getApplication()->make('config');
+        $config->set('api-toolkit.lifecycle.octane', true);
+        $config->set('api-toolkit.lifecycle.queue', false);
+
+        // Simulate laravel/octane being absent so the interface_exists guard
+        // short-circuits before the listener binds.
+        FunctionOverrides::set('interface_exists', static fn (string $interface): bool => $interface !== OperationTerminated::class && \interface_exists($interface));
+
+        // Reset the dispatcher so Octane's own OperationTerminated listeners do
+        // not mask the registrar short-circuiting.
+        Event::swap(new Dispatcher($this->getApplication()));
+
+        (new LifecycleRegistrar)->register();
+
+        /** @var \Illuminate\Events\Dispatcher $events */
+        $events = $this->getApplication()->make('events');
+
+        self::assertFalse($events->hasListeners(OperationTerminated::class));
     }
 
     /**


### PR DESCRIPTION
Started as coding-standards v1.14.0 conformance and grew to cover a real Octane bug that installing the optional dep surfaced. Three logically-separate commits:

### 1. `style:` collapse data-member doc comments to a single line
v1.14.0 added a `SingleLineMemberComment` sniff requiring property/constant/enum-case doc comments on one line (no auto-fixer). Collapsed nine multi-line member docblocks across five files, keeping the house form (`/** @var Type Description */`, `/** Description */`). Enum-case prose trimmed within the 80-char comment limit; a few `@var` lines stay longer only because of long union/generic type strings (exempt from the length sniff).

### 2. `ci:` tolerate zero-mutation diffs in the scoped mutation gate
The diff-scoped Infection gate reports MSI 0% when a diff has no mutable lines (comments/docs/formatting), failing `--min-msi`. Added `--ignore-msi-with-no-mutations` so the threshold only applies when there is something to mutate - any diff with real code still enforces the 90% floor.

### 3. `fix:` register the Octane flush listener against the real contract
Installing `laravel/octane` locally to test the code surfaced a latent bug: `LifecycleRegistrar` imported `Laravel\Octane\Events\OperationTerminated` and guarded on `class_exists()`. That symbol does not exist - Octane's `OperationTerminated` lives in `Contracts` and is an **interface**, so `class_exists()` returns false even with Octane installed. The guard always short-circuited, so **the cache-flush listener was never wired and toolkit caches went unflushed between Octane operations**. The tests passed only because they stubbed `class_exists` on the same wrong symbol.

Fix: import `Laravel\Octane\Contracts\OperationTerminated` and guard with `interface_exists()`. Added `laravel/octane` to `require-dev` (so the guard, listener registration, and static analysis run against the real interface - previously the only optional integration nothing in the dev tree pulled in) and to `suggest` (so consumers know). Reworked the Octane tests to exercise the real interface, isolated the registrar from Octane's own `OperationTerminated` listeners with a fresh dispatcher, and added an interface-absent branch test.

### Verification
- Full suite green (2027 tests), 100% line coverage, mutation 100% MSI on the diff
- phpstan / phpcs / php-cs-fixer clean on all touched files
- A previously-skipped Octane registration test now runs for real
