### PR TITLE
test: comprehensive coverage - e2e/feature gaps and mutation hardening

### DIFF
--- a/tests/Feature/BlocklistPostureHttpTest.php
+++ b/tests/Feature/BlocklistPostureHttpTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the blocklist query-surface posture through the kernel.
+ *
+ * Under the opt-out blocklist posture a real request is gated by the legacy
+ * shape-derived searchable predicate rather than the resource's declared
+ * allowlist. An undeclared column that is a real, non-excluded table column is
+ * therefore applied and narrows the envelope, while a column named in
+ * searchable_exclusions is silently dropped and the full unfiltered set is
+ * returned - proving the exclusion set stays honoured even when the resource
+ * never declared the column filterable.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class BlocklistPostureHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test under the blocklist posture with seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.repositories.query_posture', QuerySurface::POSTURE_BLOCKLIST);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'password' => 'secret', 'status' => 'active']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'password' => 'secret', 'status' => 'active']);
+        User::create(['name' => 'Charlie', 'email' => 'charlie@example.com', 'password' => 'secret', 'status' => 'inactive']);
+    }
+
+    /**
+     * Test that an undeclared but real, non-excluded column is applied under
+     * the blocklist posture and narrows the envelope.
+     *
+     * @return void
+     */
+    public function testUndeclaredColumnIsAppliedUnderBlocklist(): void
+    {
+        $filters = json_encode(['status' => 'active']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('meta.total', 2);
+    }
+
+    /**
+     * Test that a column named in searchable_exclusions is never filterable:
+     * the filter is dropped and the full unfiltered set is returned.
+     *
+     * @return void
+     */
+    public function testExcludedColumnIsNeverFilterableUnderBlocklist(): void
+    {
+        $filters = json_encode(['password' => 'no-such-value']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('meta.total', 3);
+    }
+}

--- a/tests/Feature/CacheInvalidationRoundTripTest.php
+++ b/tests/Feature/CacheInvalidationRoundTripTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use SineMacula\ApiToolkit\Repositories\Concerns\DeferredWriteCacheInvalidator;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\CacheableUserRepository;
+use Tests\Fixtures\Repositories\DeferrableUserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving an HTTP write invalidates the per-query cache so the
+ * next HTTP read envelope is fresh.
+ *
+ * A read warms the cached collection, a deferred create is buffered through a
+ * route and flushed at the request boundary, and the boundary flush invalidates
+ * the users-table cache. The second read re-queries and the client-visible
+ * envelope reports the new total, joining the read and write halves over the
+ * real response body rather than direct repository calls.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+#[CoversClass(DeferredWriteCacheInvalidator::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+#[CoversTrait(Deferrable::class)]
+final class CacheInvalidationRoundTripTest extends TestCase
+{
+    /**
+     * Set up each test with cacheable read and deferrable write routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+        Config::set('api-toolkit.deferred_writes.invalidate_query_cache', true);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/cached-users', function (CacheableUserRepository $repository): ApiResourceCollection {
+
+            /** @var \Illuminate\Support\Collection<int, \Tests\Fixtures\Models\User> $users */
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            $paginator = new LengthAwarePaginator($users, $users->count(), max($users->count(), 1));
+
+            return new ApiResourceCollection($paginator, FilterableUserResource::class);
+        });
+
+        Route::post('/api/deferred-users', function (DeferrableUserRepository $repository): JsonResponse {
+
+            /** @var string $email */
+            $email = request()->input('email');
+
+            $repository->defer(['name' => 'Deferred', 'email' => $email]);
+
+            return response()->json(['deferred' => $email], 202);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a deferred create flushed at the boundary invalidates the cache
+     * so the next read envelope reports the new total.
+     *
+     * @return void
+     */
+    public function testBoundaryFlushMakesNextReadEnvelopeFresh(): void
+    {
+        // Warm the cached collection: two rows.
+        $this->getJson('/api/cached-users')
+            ->assertOk()
+            ->assertJsonPath('meta.total', 2)
+            ->assertJsonCount(2, 'data');
+
+        // Defer a create; completing the request flushes the pool at the
+        // boundary and invalidates the users-table cache.
+        $this->postJson('/api/deferred-users', ['email' => 'carol@example.com'])->assertStatus(202);
+
+        self::assertSame(3, DB::table('users')->count());
+
+        // The stale cached collection is gone: the read re-queried and the
+        // envelope now reflects the freshly persisted row.
+        $fresh = $this->getJson('/api/cached-users');
+
+        $fresh->assertOk();
+        $fresh->assertJsonPath('meta.total', 3);
+        $fresh->assertJsonCount(3, 'data');
+        self::assertContains('carol@example.com', $fresh->json('data.*.email'));
+    }
+}

--- a/tests/Feature/ColumnNarrowingHttpTest.php
+++ b/tests/Feature/ColumnNarrowingHttpTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\ColumnProjectionApplier;
+use SineMacula\ApiToolkit\Schema\ColumnNarrower;
+use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests proving column narrowing over the real HTTP pipeline.
+ *
+ * Drives the middleware plus repository pagination path so the narrowing
+ * decision is observed on the wire: with the flag on, the base users SELECT is
+ * a strict column subset that never leaks the password column, while the
+ * rendered envelope stays byte-identical to the flag-off baseline; an opaque
+ * unmapped field forces the query to fall back to the full column set while the
+ * computed value still renders.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ColumnProjectionApplier::class)]
+#[CoversClass(ColumnNarrower::class)]
+#[CoversClass(ApiCriteria::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class ColumnNarrowingHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        FieldColumnMapper::clearCache();
+        SchemaCompiler::clearCache();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(UserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, UserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'password' => 'secret', 'status' => 'active']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'password' => 'secret', 'status' => 'active']);
+    }
+
+    /**
+     * Tear down each test, clearing the static schema and map caches.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        FieldColumnMapper::clearCache();
+        SchemaCompiler::clearCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a narrowed request emits a strict-subset base SELECT while the
+     * rendered envelope stays byte-identical to the flag-off baseline.
+     *
+     * @return void
+     */
+    public function testNarrowedRequestEmitsSubsetSelectWithByteIdenticalEnvelope(): void
+    {
+        $query = http_build_query(['fields' => ['users' => 'name,email,status,display_label']]);
+
+        Config::set('api-toolkit.resources.narrow_columns', false);
+
+        DB::enableQueryLog();
+        $off = $this->getJson('/api/users?' . $query);
+        $off->assertOk();
+        $offSql = $this->baseUsersSelect();
+
+        FieldColumnMapper::clearCache();
+        SchemaCompiler::clearCache();
+
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        DB::enableQueryLog();
+        $on = $this->getJson('/api/users?' . $query);
+        $on->assertOk();
+        $onSql = $this->baseUsersSelect();
+
+        // Flag-off selects the whole table; flag-on selects a strict subset
+        // that never leaks the password column.
+        self::assertStringContainsString('users.*', $this->unquote($offSql));
+        self::assertStringNotContainsString('users.*', $this->unquote($onSql));
+        self::assertStringContainsString('name', $this->unquote($onSql));
+        self::assertStringContainsString('email', $this->unquote($onSql));
+        self::assertStringNotContainsString('password', $this->unquote($onSql));
+
+        // The rendered envelope is unchanged by the SQL narrowing.
+        self::assertSame($off->baseResponse->getContent(), $on->baseResponse->getContent());
+    }
+
+    /**
+     * Test that an opaque unmapped field forces a fallback to the full SELECT
+     * while the computed value still renders.
+     *
+     * @return void
+     */
+    public function testOpaqueFieldFallsBackToFullSelect(): void
+    {
+        $query = http_build_query(['fields' => ['users' => 'name,email,full_label']]);
+
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        DB::enableQueryLog();
+        $response = $this->getJson('/api/users?' . $query);
+        $sql      = $this->baseUsersSelect();
+
+        $response->assertOk();
+
+        // The un-annotated compute is opaque, so the narrower falls back to the
+        // full column set rather than risk dropping a column the closure reads.
+        self::assertStringContainsString('users.*', $this->unquote($sql));
+
+        // The computed field still resolves from the fully-hydrated model.
+        $response->assertJsonPath('data.0.full_label', 'Alice <alice@example.com>');
+    }
+
+    /**
+     * Get the base users SELECT statement from the recorded query log.
+     *
+     * @return string
+     */
+    private function baseUsersSelect(): string
+    {
+        $log = DB::getQueryLog();
+
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+
+        foreach ($log as $entry) {
+            $sql      = (string) $entry['query'];
+            $unquoted = $this->unquote($sql);
+
+            if (!str_starts_with($sql, 'select') || !str_contains($unquoted, 'from users')) {
+                continue;
+            }
+
+            // Skip the paginator's row-count query and the schema introspection
+            // statements so only the hydrating base select is returned.
+            if (str_contains($sql, 'as aggregate') || str_contains($sql, 'pragma') || str_contains($sql, 'sqlite_master')) {
+                continue;
+            }
+
+            return $sql;
+        }
+
+        return '';
+    }
+
+    /**
+     * Strip identifier quote characters so SQL assertions are driver-agnostic.
+     *
+     * @param  string  $sql
+     * @return string
+     */
+    private function unquote(string $sql): string
+    {
+        return str_replace(['`', '"'], '', $sql);
+    }
+}

--- a/tests/Feature/ContainsFilterHttpTest.php
+++ b/tests/Feature/ContainsFilterHttpTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\ContainsOperator;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Log;
+use Tests\Fixtures\Repositories\LogRepository;
+use Tests\Fixtures\Resources\LogResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests exercising JSON containment filtering over real HTTP requests.
+ *
+ * Drives the containment operator against a filterable JSON column: an array
+ * payload resolves via a JSON-contains constraint, while a comma-separated
+ * string resolves to an OR-combined containment group returning the union of
+ * matches rather than their intersection. SQLite's grammar rejects the
+ * underlying JSON-containment clause, so each scenario is skipped on that
+ * driver and only runs under MySQL or PostgreSQL.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(ContainsOperator::class)]
+final class ContainsFilterHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up a repository-backed logs route and seed rows with JSON contexts.
+     *
+     * Each row carries a top-level JSON array in its context column so a
+     * containment constraint can match against the array members directly.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/logs', function (LogRepository $repository): ApiResourceCollection {
+
+            $logs = $repository->usingResource(LogResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($logs, LogResource::class);
+        });
+
+        Log::create(['level' => 'info', 'message' => 'first', 'context' => ['php', 'laravel']]);
+        Log::create(['level' => 'info', 'message' => 'second', 'context' => ['rust']]);
+        Log::create(['level' => 'info', 'message' => 'third', 'context' => ['go']]);
+    }
+
+    /**
+     * Test that an array payload resolves via a JSON containment constraint.
+     *
+     * @return void
+     */
+    public function testArrayPayloadResolvesViaJsonContainment(): void
+    {
+        $this->skipOnSqlite();
+
+        $response = $this->query(['context' => ['$contains' => ['php']]]);
+
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('meta.total', 1);
+        $response->assertJsonPath('data.0.message', 'first');
+    }
+
+    /**
+     * Test that a comma-separated string resolves to the union of containment
+     * matches rather than their intersection.
+     *
+     * @return void
+     */
+    public function testCommaSeparatedStringResolvesToTheUnion(): void
+    {
+        $this->skipOnSqlite();
+
+        $response = $this->query(['context' => ['$contains' => 'php,rust']]);
+
+        $messages = array_column((array) $response->json('data'), 'message');
+
+        $response->assertJsonPath('meta.total', 2);
+        self::assertEqualsCanonicalizing(['first', 'second'], $messages);
+    }
+
+    /**
+     * Test that a scalar payload resolves via a JSON containment constraint.
+     *
+     * @return void
+     */
+    public function testScalarPayloadResolvesViaJsonContainment(): void
+    {
+        $this->skipOnSqlite();
+
+        $response = $this->query(['context' => ['$contains' => 'go']]);
+
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.message', 'third');
+    }
+
+    /**
+     * Issue a filtered request against the logs route and return the response.
+     *
+     * @param  array<string, mixed>  $filters
+     * @return \Illuminate\Testing\TestResponse<\Illuminate\Http\JsonResponse>
+     */
+    private function query(array $filters): TestResponse
+    {
+        $response = $this->getJson('/api/logs?filters=' . urlencode((string) json_encode($filters)));
+
+        $response->assertOk();
+
+        return $response;
+    }
+
+    /**
+     * Skip the current test on the SQLite driver, whose grammar rejects the
+     * JSON-containment clause the containment operator emits.
+     *
+     * @return void
+     */
+    private function skipOnSqlite(): void
+    {
+        if (DB::connection()->getDriverName() !== 'sqlite') {
+            return;
+        }
+
+        self::markTestSkipped('JSON containment is unsupported on the SQLite driver.');
+    }
+}

--- a/tests/Feature/CursorPaginationTest.php
+++ b/tests/Feature/CursorPaginationTest.php
@@ -120,4 +120,59 @@ final class CursorPaginationTest extends TestCase
         // The prev cursor is populated once past the first page.
         self::assertIsString($second->json('links.prev'));
     }
+
+    /**
+     * Test that following the next cursors to the terminal page returns the
+     * single trailing row with no further cursor.
+     *
+     * @return void
+     */
+    public function testLastCursorPageHasNoNextCursor(): void
+    {
+        $response = $this->getJson('/api/users?pagination=cursor&limit=2');
+
+        $response->assertOk();
+
+        // Walk the next cursors until the terminal page is reached.
+        while (is_string($next = $response->json('links.next'))) {
+
+            $parts = parse_url($next);
+
+            self::assertIsArray($parts);
+            self::assertArrayHasKey('query', $parts);
+
+            $response = $this->getJson('/api/users?' . $parts['query']);
+
+            $response->assertOk();
+        }
+
+        // Five rows over pages of two leaves a single trailing row with no
+        // further pages and a null next cursor.
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Evan');
+
+        self::assertFalse($response->json('meta.continue'));
+        self::assertNull($response->json('links.next'));
+        self::assertIsString($response->json('links.prev'));
+    }
+
+    /**
+     * Test that a cursor request matching no rows returns the terminal envelope
+     * with empty data and null cursors on both sides.
+     *
+     * @return void
+     */
+    public function testEmptyCursorPageReturnsTerminalEnvelope(): void
+    {
+        $filters = json_encode(['id' => ['$gt' => 9999]]);
+
+        $response = $this->getJson('/api/users?pagination=cursor&limit=2&filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(0, 'data');
+
+        self::assertFalse($response->json('meta.continue'));
+        self::assertNull($response->json('links.next'));
+        self::assertNull($response->json('links.prev'));
+    }
 }

--- a/tests/Feature/CustomOperatorHttpTest.php
+++ b/tests/Feature/CustomOperatorHttpTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a provider-registered custom operator applies over HTTP.
+ *
+ * A closure-backed operator token is registered on the resolved registry before
+ * the request, then driven through the query string, confirming the advertised
+ * extension point reaches the filter handler and narrows the result set end to
+ * end without any core change.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(OperatorRegistry::class)]
+final class CustomOperatorHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up a repository-backed users route, register a custom operator, and
+     * seed rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        app(OperatorRegistry::class)->override('$starts', static function (Builder $query, string $column, mixed $value): void {
+
+            $term = is_scalar($value) ? (string) $value : '';
+
+            $query->where($column, 'like', $term . '%');
+        });
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        User::create(['name' => 'Alan', 'email' => 'alan@example.com']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+    }
+
+    /**
+     * Test that the registered custom operator narrows the result set by a name
+     * prefix over HTTP.
+     *
+     * @return void
+     */
+    public function testCustomOperatorNarrowsByNamePrefix(): void
+    {
+        $filters = json_encode(['name' => ['$starts' => 'Al']]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('meta.total', 2);
+
+        $names = array_column((array) $response->json('data'), 'name');
+
+        self::assertEqualsCanonicalizing(['Alice', 'Alan'], $names);
+    }
+}

--- a/tests/Feature/DeepTraversalHttpTest.php
+++ b/tests/Feature/DeepTraversalHttpTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\DeepTraversalPostResource;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test for a multi-hop relation chain applied over HTTP.
+ *
+ * When the related resource declares an onward traversable relation the chain
+ * users -> posts -> user is permitted at every hop and compiles to nested
+ * whereHas constraints. A real request proves the per-hop gating and the
+ * nested existence constraint survive the HTTP layer: only the user owning a
+ * post whose onward user matches the nested predicate is returned.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class DeepTraversalHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a users route, the deep-traversal Post resource
+     * map, and seeded users and posts.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.resources.resource_map', [
+            Post::class => DeepTraversalPostResource::class,
+        ]);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        $alice = User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        $bob   = User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'Alice Post', 'body' => 'Content']);
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob Post', 'body' => 'Content']);
+    }
+
+    /**
+     * Test that a users -> posts -> user chain narrows the envelope to the
+     * single matching user.
+     *
+     * @return void
+     */
+    public function testMultiHopRelationChainNarrowsTheEnvelope(): void
+    {
+        $filters = json_encode(['posts' => ['nested' => ['user' => ['name' => 'Alice']]]]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Alice');
+        $response->assertJsonPath('meta.total', 1);
+    }
+}

--- a/tests/Feature/DeferredWriteAutoFlushRequestTest.php
+++ b/tests/Feature/DeferredWriteAutoFlushRequestTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use Tests\Fixtures\Repositories\DeferrableUserRepository;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a config-wired pool limit auto-flushes mid-request.
+ *
+ * With the deferred-writes pool limit bound from config to two, a route that
+ * defers three rows through the config-bound repository sees the first two
+ * persisted while the request is still in flight (the auto-flush fired when the
+ * buffer reached the limit) and the trailing row persisted only once the
+ * request lifecycle boundary flush runs.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePool::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+#[CoversTrait(Deferrable::class)]
+final class DeferredWriteAutoFlushRequestTest extends TestCase
+{
+    /**
+     * Set up each test with a config-bound pool limit and a deferring route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('api-toolkit.deferred_writes.pool_limit', 2);
+
+        Route::post('/api/auto-flush-users', function (DeferrableUserRepository $repository): JsonResponse {
+
+            $repository->defer(['name' => 'Alice', 'email' => 'alice@example.com', 'password' => 'secret']);
+            $repository->defer(['name' => 'Bob', 'email' => 'bob@example.com', 'password' => 'secret']);
+            $repository->defer(['name' => 'Carol', 'email' => 'carol@example.com', 'password' => 'secret']);
+
+            return response()->json([
+                'persisted_during_request' => DB::table('users')->count(),
+            ], 202);
+        });
+    }
+
+    /**
+     * Test that reaching the config-bound pool limit auto-flushes mid-request
+     * while the trailing row waits for the boundary flush.
+     *
+     * @return void
+     */
+    public function testPoolLimitAutoFlushesMidRequest(): void
+    {
+        $response = $this->postJson('/api/auto-flush-users');
+
+        $response->assertStatus(202);
+
+        // Two rows crossed the pool limit and were auto-flushed while the
+        // request was still executing; the third stayed buffered.
+        $response->assertJsonPath('persisted_during_request', 2);
+
+        self::assertSame(3, DB::table('users')->count());
+        self::assertSame(1, DB::table('users')->where('name', 'Carol')->count());
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePool $pool */
+        $pool = $this->app->make(WritePool::class); // @phpstan-ignore method.nonObject
+
+        self::assertTrue($pool->isEmpty());
+    }
+}

--- a/tests/Feature/DeferredWriteConsoleBoundaryTest.php
+++ b/tests/Feature/DeferredWriteConsoleBoundaryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Contracts\Console\Kernel as KernelContract;
+use Illuminate\Foundation\Console\Kernel;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use Tests\Fixtures\Console\DeferUsersCommand;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a real Artisan run flushes deferred writes at its
+ * command-finished boundary.
+ *
+ * A fixture command defers user rows through the deferrable repository during
+ * its handler. The rows remain buffered in the scoped pool until the framework
+ * fires the command-finished lifecycle event, so a genuine Artisan run proves
+ * the subscriber flushes the buffer once the command completes rather than
+ * during the handler.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePool::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+#[CoversTrait(Deferrable::class)]
+final class DeferredWriteConsoleBoundaryTest extends TestCase
+{
+    /**
+     * Set up each test by registering the deferring fixture command.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $kernel = $this->app->make(KernelContract::class); // @phpstan-ignore method.nonObject
+
+        assert($kernel instanceof Kernel);
+
+        // The framework suppresses the Symfony command lifecycle events while
+        // running the test suite, so reroute them before Artisan is resolved to
+        // prove the real command-finished boundary flush fires.
+        $kernel->rerouteSymfonyCommandEvents();
+        $kernel->registerCommand(new DeferUsersCommand);
+    }
+
+    /**
+     * Test that deferred rows persist only after the command-finished boundary
+     * flush completes.
+     *
+     * @return void
+     */
+    public function testDeferredRowsFlushAtCommandBoundary(): void
+    {
+        self::assertSame(0, DB::table('users')->count());
+
+        $this->artisan('fixtures:defer-users', ['--count' => 3])->assertSuccessful(); // @phpstan-ignore method.nonObject
+
+        self::assertSame(3, DB::table('users')->count());
+        self::assertSame(1, DB::table('users')->where('email', 'deferred-1@console.test')->count());
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePool $pool */
+        $pool = $this->app->make(WritePool::class); // @phpstan-ignore method.nonObject
+
+        self::assertTrue($pool->isEmpty());
+    }
+}

--- a/tests/Feature/DeferredWriteFailureStrategyRequestTest.php
+++ b/tests/Feature/DeferredWriteFailureStrategyRequestTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Enums\FlushStrategy;
+use SineMacula\ApiToolkit\Events\WritePoolFlushFailed;
+use SineMacula\ApiToolkit\Exceptions\WritePoolFlushException;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\TestCase;
+
+/**
+ * Feature test covering the deferred-write failure strategies over live
+ * requests.
+ *
+ * Proves each config-wired on_failure posture behaves as documented when a
+ * flush fails: throw escalates a boundary flush failure loudly (and surfaces
+ * the exception only when rethrow_at_boundary is set), log drops the failed
+ * records after logging, and an in-handler auto-flush failure under throw
+ * reaches the client as a server error rather than the accepted response.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePool::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+#[CoversClass(WritePoolFlushException::class)]
+#[CoversClass(FlushStrategy::class)]
+final class DeferredWriteFailureStrategyRequestTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with the toolkit exception handler and deferring routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        // Buffers a record for a table that does not exist so the flush fails.
+        Route::post('/api/deferred-invalid-boundary', function (): JsonResponse {
+
+            app(WritePool::class)->add('nonexistent_table', ['col' => 'val']);
+
+            return response()->json(['accepted' => true], 202);
+        });
+
+        // Buffers a record for a missing table with the pool limit at one, so
+        // the auto-flush fires (and may throw) inside the handler itself.
+        Route::post('/api/deferred-invalid-handler', function (): JsonResponse {
+
+            app(WritePool::class)->add('nonexistent_table', ['col' => 'val']);
+
+            return response()->json(['accepted' => true], 202);
+        });
+    }
+
+    /**
+     * Test that the throw strategy escalates a boundary flush failure while the
+     * request still returns its accepted response.
+     *
+     * @return void
+     */
+    public function testThrowStrategyEscalatesBoundaryFailureWithoutRethrow(): void
+    {
+        Config::set('api-toolkit.deferred_writes.on_failure', 'throw');
+
+        Event::fake([WritePoolFlushFailed::class]);
+
+        Log::spy();
+
+        $this->postJson('/api/deferred-invalid-boundary')->assertStatus(202);
+
+        Event::assertDispatched(WritePoolFlushFailed::class, fn (WritePoolFlushFailed $event): bool => $event->flushResult->failureCount() === 1);
+    }
+
+    /**
+     * Test that the throw strategy surfaces the flush exception at the boundary
+     * when rethrow_at_boundary is enabled.
+     *
+     * @return void
+     */
+    public function testThrowStrategyRethrowsAtBoundaryWhenConfigured(): void
+    {
+        Config::set('api-toolkit.deferred_writes.on_failure', 'throw');
+        Config::set('api-toolkit.deferred_writes.rethrow_at_boundary', true);
+
+        Log::spy();
+
+        // The boundary flush runs after the response is produced, so the
+        // re-thrown exception surfaces out of the test kernel rather than as a
+        // rendered response.
+        $this->expectException(WritePoolFlushException::class);
+
+        $this->postJson('/api/deferred-invalid-boundary');
+    }
+
+    /**
+     * Test that the log strategy drops the failed records after logging while
+     * the request returns its accepted response.
+     *
+     * @return void
+     */
+    public function testLogStrategyDropsAndLogsFailedRecords(): void
+    {
+        Config::set('api-toolkit.deferred_writes.on_failure', 'log');
+
+        Log::spy();
+
+        $this->postJson('/api/deferred-invalid-boundary')->assertStatus(202);
+
+        Log::shouldHaveReceived('error')->once(); // @phpstan-ignore staticMethod.notFound
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePool $pool */
+        $pool = $this->app->make(WritePool::class); // @phpstan-ignore method.nonObject
+
+        self::assertTrue($pool->isEmpty());
+    }
+
+    /**
+     * Test that an in-handler auto-flush failure under the throw strategy
+     * reaches the client as a server error rather than the accepted response.
+     *
+     * @return void
+     */
+    public function testThrowStrategyRaisesServerErrorFromHandlerAtPoolLimit(): void
+    {
+        Config::set('api-toolkit.deferred_writes.on_failure', 'throw');
+        Config::set('api-toolkit.deferred_writes.pool_limit', 1);
+
+        Log::spy();
+
+        $this->postJson('/api/deferred-invalid-handler')->assertStatus(500);
+    }
+}

--- a/tests/Feature/DeferredWriteObservabilityRequestTest.php
+++ b/tests/Feature/DeferredWriteObservabilityRequestTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePoolFlushResult;
+use Tests\TestCase;
+
+/**
+ * Feature test proving lastAutoFlushResult surfaces a non-throwing mid-request
+ * auto-flush failure.
+ *
+ * Under the collect strategy an auto-flush that fails when the pool limit is
+ * reached returns without raising, so the retained result is the only
+ * in-process signal that it failed. A route reads the scoped pool's
+ * lastAutoFlushResult failure count into the response body, proving the
+ * accessor reports the failure and that the resolved singleton is the same
+ * instance the request wrote to.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePool::class)]
+#[CoversClass(WritePoolFlushResult::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+final class DeferredWriteObservabilityRequestTest extends TestCase
+{
+    /**
+     * Set up each test with a single-record pool limit and a deferring route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('api-toolkit.deferred_writes.on_failure', 'collect');
+        Config::set('api-toolkit.deferred_writes.pool_limit', 1);
+
+        Route::post('/api/observable-flush', function (): JsonResponse {
+
+            $pool = app(WritePool::class);
+
+            // Reaching the pool limit of one triggers a non-throwing auto-flush
+            // that fails because the table does not exist.
+            $pool->add('nonexistent_table', ['col' => 'val']);
+
+            return response()->json([
+                'failure_count' => $pool->lastAutoFlushResult()?->failureCount(),
+            ], 202);
+        });
+    }
+
+    /**
+     * Test that the scoped pool's lastAutoFlushResult reports the failed
+     * auto-flush count observed during the request.
+     *
+     * @return void
+     */
+    public function testLastAutoFlushResultReportsFailureCount(): void
+    {
+        Log::spy();
+
+        $response = $this->postJson('/api/observable-flush');
+
+        $response->assertStatus(202);
+        $response->assertJsonPath('failure_count', 1);
+    }
+}

--- a/tests/Feature/DeferredWriteTransactionalRequestTest.php
+++ b/tests/Feature/DeferredWriteTransactionalRequestTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Events\WritePoolFlushFailed;
+use SineMacula\ApiToolkit\Listeners\WritePoolFlushSubscriber;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use Tests\Fixtures\Repositories\DeferrableUserRepository;
+use Tests\TestCase;
+
+/**
+ * Feature test proving transactional deferred writes roll back all-or-nothing.
+ *
+ * With the transactional flag config-wired on and a chunk size of one, a route
+ * defers two rows whose second entry violates the unique email constraint. When
+ * the boundary flush runs the whole table's inserts are applied inside a single
+ * transaction, so the constraint violation rolls the entire table back to zero
+ * rows and the failure is escalated through the dispatched event.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(WritePool::class)]
+#[CoversClass(WritePoolFlushSubscriber::class)]
+#[CoversTrait(Deferrable::class)]
+final class DeferredWriteTransactionalRequestTest extends TestCase
+{
+    /**
+     * Set up each test with transactional deferred writes and a deferring
+     * route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('api-toolkit.deferred_writes.transactional', true);
+        Config::set('api-toolkit.deferred_writes.chunk_size', 1);
+
+        Route::post('/api/transactional-users', function (DeferrableUserRepository $repository): JsonResponse {
+
+            $repository->defer(['name' => 'Alice', 'email' => 'clash@example.com', 'password' => 'secret']);
+            $repository->defer(['name' => 'Bob', 'email' => 'clash@example.com', 'password' => 'secret']);
+
+            return response()->json(['accepted' => true], 202);
+        });
+    }
+
+    /**
+     * Test that a unique-constraint violation inside a transactional flush
+     * rolls the whole table back and escalates the failure.
+     *
+     * @return void
+     */
+    public function testTransactionalFlushRollsBackWholeTable(): void
+    {
+        Event::fake([WritePoolFlushFailed::class]);
+
+        Log::spy();
+
+        $this->postJson('/api/transactional-users')->assertStatus(202);
+
+        self::assertSame(0, DB::table('users')->count());
+
+        Event::assertDispatched(WritePoolFlushFailed::class);
+    }
+}

--- a/tests/Feature/DetectsCapabilitiesTest.php
+++ b/tests/Feature/DetectsCapabilitiesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\DetectsCapabilities;
+use SineMacula\ApiToolkit\Http\RequestCapabilities;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the capability-detection middleware over the HTTP kernel.
+ *
+ * Dispatches real requests carrying the trashed-record query parameters and
+ * proves the flags the middleware resolves are visible to a downstream
+ * handler via RequestCapabilities::fromRequest, so the query string
+ * round-trips through the live request into the typed capabilities object.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(DetectsCapabilities::class)]
+#[CoversClass(RequestCapabilities::class)]
+final class DetectsCapabilitiesTest extends TestCase
+{
+    /**
+     * Set up each test with a route that echoes the resolved capabilities.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(DetectsCapabilities::class)->get('/api/capabilities', static function (Request $request): array {
+
+            $capabilities = RequestCapabilities::fromRequest($request);
+
+            return [
+                'include_trashed' => $capabilities->includeTrashed(),
+                'only_trashed'    => $capabilities->onlyTrashed(),
+            ];
+        });
+    }
+
+    /**
+     * Test that the include-trashed parameter surfaces downstream.
+     *
+     * @return void
+     */
+    public function testIncludeTrashedParameterSurfacesDownstream(): void
+    {
+        $response = $this->getJson('/api/capabilities?include_trashed=true');
+
+        $response->assertOk();
+        $response->assertJsonPath('include_trashed', true);
+        $response->assertJsonPath('only_trashed', false);
+    }
+
+    /**
+     * Test that the only-trashed parameter surfaces downstream.
+     *
+     * @return void
+     */
+    public function testOnlyTrashedParameterSurfacesDownstream(): void
+    {
+        $response = $this->getJson('/api/capabilities?only_trashed=true');
+
+        $response->assertOk();
+        $response->assertJsonPath('include_trashed', false);
+        $response->assertJsonPath('only_trashed', true);
+    }
+
+    /**
+     * Test that both capability flags default to false when unrequested.
+     *
+     * @return void
+     */
+    public function testCapabilitiesDefaultToFalseWhenUnrequested(): void
+    {
+        $response = $this->getJson('/api/capabilities');
+
+        $response->assertOk();
+        $response->assertJsonPath('include_trashed', false);
+        $response->assertJsonPath('only_trashed', false);
+    }
+}

--- a/tests/Feature/ExceptionRenderStrategyTest.php
+++ b/tests/Feature/ExceptionRenderStrategyTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the exception render-strategy matrix through the kernel.
+ *
+ * These prove the strategy switch and the debug controls that govern the
+ * rendered error body: always_json forces the JSON envelope even for an
+ * HTML-accepting client, include_debug_info surfaces the underlying throwable
+ * internals, auto defers to the framework HTML page for a non-JSON request in
+ * debug, and the pretty flag indents the rendered error body.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiExceptionHandler::class)]
+final class ExceptionRenderStrategyTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with the toolkit handler wired and failing routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::get('/api/abort-conflict', static function (): never {
+            abort(409);
+        });
+
+        Route::get('/api/unhandled', static function (): never {
+            throw new \RuntimeException('Something broke internally');
+        });
+    }
+
+    /**
+     * Test that the always_json strategy forces the JSON envelope for a request
+     * that accepts HTML rather than JSON.
+     *
+     * @return void
+     */
+    public function testAlwaysJsonForcesJsonEnvelopeForHtmlRequest(): void
+    {
+        Config::set('api-toolkit.exceptions.render_strategy', 'always_json');
+
+        $response = $this->get('/api/abort-conflict', ['Accept' => 'text/html']);
+
+        $response->assertStatus(409);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertJsonPath('error.status', 409);
+        $response->assertJsonPath('error.code', 10113);
+    }
+
+    /**
+     * Test that include_debug_info surfaces the underlying throwable internals
+     * into the rendered error meta even when the framework debug flag is off.
+     *
+     * @return void
+     */
+    public function testIncludeDebugInfoSurfacesThrowableInternals(): void
+    {
+        Config::set('app.debug', false);
+        Config::set('api-toolkit.exceptions.include_debug_info', true);
+
+        $response = $this->getJson('/api/unhandled');
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error.meta.message', 'Something broke internally');
+        $response->assertJsonPath('error.meta.exception', \RuntimeException::class);
+
+        $meta = $response->json('error.meta');
+
+        self::assertIsArray($meta);
+        self::assertArrayHasKey('file', $meta);
+        self::assertArrayHasKey('line', $meta);
+        self::assertArrayHasKey('trace', $meta);
+        self::assertIsArray($meta['trace']);
+    }
+
+    /**
+     * Test that the auto strategy defers to the framework HTML error page for a
+     * non-JSON request when debug mode is enabled.
+     *
+     * @return void
+     */
+    public function testAutoDefersToHtmlForNonJsonRequestInDebug(): void
+    {
+        Config::set('api-toolkit.exceptions.render_strategy', 'auto');
+        Config::set('app.debug', true);
+
+        $response = $this->get('/api/abort-conflict', ['Accept' => 'text/html']);
+
+        $response->assertStatus(409);
+
+        $contentType = $response->headers->get('Content-Type');
+
+        self::assertIsString($contentType);
+        self::assertStringContainsString('text/html', $contentType);
+
+        $content = $response->baseResponse->getContent();
+
+        self::assertIsString($content);
+        self::assertStringNotContainsString('"error":', $content);
+    }
+
+    /**
+     * Test that the pretty flag indents the rendered error body while the
+     * absence of the flag keeps it compact.
+     *
+     * @return void
+     */
+    public function testPrettyFlagIndentsErrorBody(): void
+    {
+        $pretty = $this->getJson('/api/abort-conflict?pretty=1');
+
+        $pretty->assertStatus(409);
+
+        $prettyContent = $pretty->baseResponse->getContent();
+
+        self::assertIsString($prettyContent);
+        self::assertStringContainsString("\n", $prettyContent);
+        self::assertStringContainsString('    ', $prettyContent);
+
+        $compact = $this->getJson('/api/abort-conflict');
+
+        $compact->assertStatus(409);
+
+        $compactContent = $compact->baseResponse->getContent();
+
+        self::assertIsString($compactContent);
+        self::assertStringNotContainsString("\n", $compactContent);
+    }
+}

--- a/tests/Feature/ExceptionTaxonomyTest.php
+++ b/tests/Feature/ExceptionTaxonomyTest.php
@@ -7,7 +7,13 @@ namespace Tests\Feature;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Exceptions\BadRequestException;
+use SineMacula\ApiToolkit\Exceptions\GoneException;
+use SineMacula\ApiToolkit\Exceptions\LockedException;
+use SineMacula\ApiToolkit\Exceptions\PayloadTooLargeException;
+use SineMacula\ApiToolkit\Exceptions\ServiceUnavailableException;
 use Tests\Concerns\RegistersApiExceptionHandler;
 use Tests\Fixtures\Models\User;
 use Tests\TestCase;
@@ -55,6 +61,39 @@ final class ExceptionTaxonomyTest extends TestCase
         Route::get('/api/forbidden', static function (): never {
             throw new AuthorizationException('This action is unauthorized.');
         });
+
+        // A GET-only route so that a POST raises the router's
+        // MethodNotAllowedHttpException, which the toolkit maps to the
+        // not-allowed envelope.
+        Route::get('/api/get-only', static fn (): array => ['ok' => true]);
+
+        // A route behind the auth middleware so an unauthenticated JSON caller
+        // raises an AuthenticationException, which the toolkit maps to the
+        // unauthenticated envelope.
+        Route::get('/api/requires-auth', static fn (): array => ['ok' => true])
+            ->middleware('auth');
+
+        // Directly-thrown taxonomy exceptions render their dedicated envelopes
+        // rather than the generic HTTP error an abort() would produce.
+        Route::get('/api/bad-request', static function (): never {
+            throw new BadRequestException;
+        });
+
+        Route::get('/api/gone', static function (): never {
+            throw new GoneException;
+        });
+
+        Route::get('/api/payload-too-large', static function (): never {
+            throw new PayloadTooLargeException;
+        });
+
+        Route::get('/api/locked', static function (): never {
+            throw new LockedException;
+        });
+
+        Route::get('/api/service-unavailable', static function (): never {
+            throw new ServiceUnavailableException;
+        });
     }
 
     /**
@@ -83,5 +122,76 @@ final class ExceptionTaxonomyTest extends TestCase
         $response->assertStatus(403);
         $response->assertJsonPath('error.status', 403);
         $response->assertJsonPath('error.code', 10102);
+    }
+
+    /**
+     * Test that posting to a GET-only route renders as a 405 not-allowed
+     * envelope.
+     *
+     * @return void
+     */
+    public function testMethodNotAllowedIsRenderedAsNotAllowed(): void
+    {
+        $response = $this->postJson('/api/get-only');
+
+        $response->assertStatus(405);
+        $response->assertJsonPath('error.status', 405);
+        $response->assertJsonPath('error.code', 10104);
+        $response->assertJsonPath('error.title', 'Not Allowed');
+    }
+
+    /**
+     * Test that an unauthenticated request to an auth-guarded route renders as
+     * a 401 unauthenticated envelope.
+     *
+     * @return void
+     */
+    public function testAuthenticationFailureIsRenderedAsUnauthenticated(): void
+    {
+        $response = $this->getJson('/api/requires-auth');
+
+        $response->assertStatus(401);
+        $response->assertJsonPath('error.status', 401);
+        $response->assertJsonPath('error.code', 10101);
+        $response->assertJsonPath('error.title', 'Unauthenticated');
+    }
+
+    /**
+     * Provide the directly-thrown taxonomy exceptions and their envelopes.
+     *
+     * @return iterable<string, array{string, int, int, string, string}>
+     */
+    public static function taxonomyExceptionProvider(): iterable
+    {
+        yield from [
+            'bad request'         => ['/api/bad-request', 400, 10100, 'Bad Request', 'There was an issue with the request, please try again'],
+            'gone'                => ['/api/gone', 410, 10109, 'Gone', 'The requested resource is no longer available'],
+            'payload too large'   => ['/api/payload-too-large', 413, 10110, 'Payload Too Large', 'The request payload exceeds the maximum permitted size'],
+            'locked'              => ['/api/locked', 423, 10111, 'Locked', 'The requested resource is locked'],
+            'service unavailable' => ['/api/service-unavailable', 503, 10112, 'Service Unavailable', 'The service is temporarily unavailable, please try again a little later'],
+        ];
+    }
+
+    /**
+     * Test that a directly-thrown taxonomy exception renders its dedicated
+     * status, code, title, and detail rather than the generic HTTP error.
+     *
+     * @param  string  $path
+     * @param  int  $status
+     * @param  int  $code
+     * @param  string  $title
+     * @param  string  $detail
+     * @return void
+     */
+    #[DataProvider('taxonomyExceptionProvider')]
+    public function testDirectlyThrownTaxonomyExceptionsRenderTheirEnvelopes(string $path, int $status, int $code, string $title, string $detail): void
+    {
+        $response = $this->getJson($path);
+
+        $response->assertStatus($status);
+        $response->assertJsonPath('error.status', $status);
+        $response->assertJsonPath('error.code', $code);
+        $response->assertJsonPath('error.title', $title);
+        $response->assertJsonPath('error.detail', $detail);
     }
 }

--- a/tests/Feature/FailQuietPostureHttpTest.php
+++ b/tests/Feature/FailQuietPostureHttpTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test for the fail-quiet allowlist posture over HTTP.
+ *
+ * With reject_undeclared disabled the allowlist posture drops an undeclared key
+ * rather than rejecting it: no ValidationException surfaces, so a real request
+ * carrying an undeclared filter returns 200 with the full unfiltered set rather
+ * than the fail-closed 422 envelope. This proves the dropped-key path travels
+ * through the kernel without escaping as a client error.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class FailQuietPostureHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test under the allowlist posture with fail-quiet rejection
+     * and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.repositories.reject_undeclared', false);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'status' => 'active']);
+        User::create(['name' => 'Charlie', 'email' => 'charlie@example.com', 'status' => 'inactive']);
+    }
+
+    /**
+     * Test that an undeclared filter key is dropped and returns the full set
+     * with a 200 status rather than a validation error.
+     *
+     * @return void
+     */
+    public function testUndeclaredFilterIsDroppedAndReturnsFullSet(): void
+    {
+        $filters = json_encode(['status' => 'active']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('meta.total', 3);
+    }
+}

--- a/tests/Feature/FieldGuardResponseTest.php
+++ b/tests/Feature/FieldGuardResponseTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use Tests\Concerns\RegistersApiExceptionHandler;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\AuthUserGuardedUserResource;
 use Tests\Fixtures\Resources\GuardedUserResource;
 use Tests\TestCase;
 
@@ -48,6 +49,8 @@ final class FieldGuardResponseTest extends TestCase
         // Fetch a fresh instance per request so the model is not flagged as
         // recently created, which would make the resource response a 201.
         Route::get('/api/guarded', static fn (): GuardedUserResource => new GuardedUserResource(User::query()->firstOrFail()));
+
+        Route::get('/api/auth-guarded', static fn (): AuthUserGuardedUserResource => new AuthUserGuardedUserResource(User::query()->firstOrFail()));
     }
 
     /**
@@ -75,6 +78,38 @@ final class FieldGuardResponseTest extends TestCase
     public function testGuardRevealsFieldWhenPermitted(): void
     {
         $response = $this->getJson('/api/guarded?show=yes');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.email', 'alice@example.com');
+    }
+
+    /**
+     * Test that a guard keyed on the authenticated user hides the field for a
+     * guest.
+     *
+     * @return void
+     */
+    public function testAuthUserGuardHidesFieldForGuest(): void
+    {
+        $response = $this->getJson('/api/auth-guarded');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.name', 'Alice');
+
+        self::assertArrayNotHasKey('email', (array) $response->json('data'));
+    }
+
+    /**
+     * Test that a guard keyed on the authenticated user reveals the field under
+     * an acting admin.
+     *
+     * @return void
+     */
+    public function testAuthUserGuardRevealsFieldForActingAdmin(): void
+    {
+        $admin = User::create(['name' => 'Admin', 'email' => 'admin@example.com', 'status' => 'active']);
+
+        $response = $this->actingAs($admin)->getJson('/api/auth-guarded');
 
         $response->assertOk();
         $response->assertJsonPath('data.email', 'alice@example.com');

--- a/tests/Feature/FieldOverrideHttpTest.php
+++ b/tests/Feature/FieldOverrideHttpTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test for an imperative field override on a single resource.
+ *
+ * Drives a route that returns a single UserResource with withoutFields()
+ * applied, proving the exclusion reaches the rendered response body: a default
+ * field is removed while the remaining default and fixed fields survive.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiResource::class)]
+#[CoversClass(FieldResolver::class)]
+final class FieldOverrideHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a single-resource route and a seeded user.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/user', function (): UserResource {
+
+            $user = User::query()->firstOrFail();
+
+            return (new UserResource($user))->withoutFields(['email']);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+    }
+
+    /**
+     * Test that withoutFields() removes a default field from the response body
+     * while the remaining default and fixed fields survive.
+     *
+     * @return void
+     */
+    public function testWithoutFieldsRemovesFieldFromBody(): void
+    {
+        $response = $this->getJson('/api/user');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.name', 'Alice');
+        $response->assertJsonPath('data._type', 'users');
+
+        /** @var array<string, mixed> $record */
+        $record = $response->json('data');
+
+        self::assertArrayHasKey('id', $record);
+        self::assertArrayNotHasKey('email', $record);
+    }
+}

--- a/tests/Feature/FilterOperatorMatrixTest.php
+++ b/tests/Feature/FilterOperatorMatrixTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\BetweenOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\GreaterThanOrEqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LessThanOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\LessThanOrEqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotNullOperator;
+use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NullOperator;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\Fixtures\Resources\NullableFilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests exercising the filter-operator matrix over real HTTP requests.
+ *
+ * Drives the comparison operators, the between range operator and its
+ * malformed-payload no-op, the null and not-null presence operators against a
+ * nullable filterable column, multi-clause AND composition, and the logical
+ * grouping operators through the parsed query string, asserting the narrowed
+ * rows and meta totals in the rendered envelope.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(NotEqualOperator::class)]
+#[CoversClass(LessThanOperator::class)]
+#[CoversClass(GreaterThanOrEqualOperator::class)]
+#[CoversClass(LessThanOrEqualOperator::class)]
+#[CoversClass(BetweenOperator::class)]
+#[CoversClass(NullOperator::class)]
+#[CoversClass(NotNullOperator::class)]
+final class FilterOperatorMatrixTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up two repository-backed routes and seed five rows with a mix of
+     * present and absent organization ids.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        Route::middleware(ParseApiQuery::class)->get('/api/nullable-users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(NullableFilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, NullableFilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'organization_id' => null]);
+        User::create(['name' => 'Alan', 'email' => 'alan@example.com', 'organization_id' => 10]);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'organization_id' => null]);
+        User::create(['name' => 'Carol', 'email' => 'carol@example.com', 'organization_id' => 20]);
+        User::create(['name' => 'Dave', 'email' => 'dave@example.com', 'organization_id' => null]);
+    }
+
+    /**
+     * Test that the not-equal operator excludes the matching row.
+     *
+     * @return void
+     */
+    public function testNotEqualOperatorExcludesTheMatchingName(): void
+    {
+        $names = $this->names($this->query(['name' => ['$neq' => 'Alice']]));
+
+        self::assertCount(4, $names);
+        self::assertNotContains('Alice', $names);
+        self::assertContains('Alan', $names);
+    }
+
+    /**
+     * Test that the less-than operator narrows the result set by id.
+     *
+     * @return void
+     */
+    public function testLessThanOperatorNarrowsById(): void
+    {
+        $names = $this->names($this->query(['id' => ['$lt' => 3]]));
+
+        self::assertEqualsCanonicalizing(['Alice', 'Alan'], $names);
+    }
+
+    /**
+     * Test that the greater-than-or-equal operator narrows by id.
+     *
+     * @return void
+     */
+    public function testGreaterThanOrEqualOperatorNarrowsById(): void
+    {
+        $names = $this->names($this->query(['id' => ['$ge' => 4]]));
+
+        self::assertEqualsCanonicalizing(['Carol', 'Dave'], $names);
+    }
+
+    /**
+     * Test that the less-than-or-equal operator narrows the result set by id.
+     *
+     * @return void
+     */
+    public function testLessThanOrEqualOperatorNarrowsById(): void
+    {
+        $names = $this->names($this->query(['id' => ['$le' => 2]]));
+
+        self::assertEqualsCanonicalizing(['Alice', 'Alan'], $names);
+    }
+
+    /**
+     * Test that the between operator applies an inclusive range over ids.
+     *
+     * @return void
+     */
+    public function testBetweenOperatorAppliesAnInclusiveRange(): void
+    {
+        $names = $this->names($this->query(['id' => ['$between' => [2, 4]]]));
+
+        self::assertEqualsCanonicalizing(['Alan', 'Bob', 'Carol'], $names);
+    }
+
+    /**
+     * Test that a between payload with fewer than two bounds is dropped and
+     * widens to the full set.
+     *
+     * @return void
+     */
+    public function testBetweenOperatorDropsAnUnderLongPayload(): void
+    {
+        $response = $this->query(['id' => ['$between' => [2]]]);
+
+        $response->assertJsonPath('meta.total', 5);
+        self::assertCount(5, $this->names($response));
+    }
+
+    /**
+     * Test that a between payload with more than two bounds is dropped and
+     * widens to the full set.
+     *
+     * @return void
+     */
+    public function testBetweenOperatorDropsAnOverLongPayload(): void
+    {
+        $response = $this->query(['id' => ['$between' => [2, 3, 4]]]);
+
+        $response->assertJsonPath('meta.total', 5);
+        self::assertCount(5, $this->names($response));
+    }
+
+    /**
+     * Test that the null operator returns only rows with an absent value.
+     *
+     * @return void
+     */
+    public function testNullOperatorReturnsOnlyNullRows(): void
+    {
+        $names = $this->names($this->query(['organization_id' => ['$null' => true]], '/api/nullable-users'));
+
+        self::assertEqualsCanonicalizing(['Alice', 'Bob', 'Dave'], $names);
+    }
+
+    /**
+     * Test that the not-null operator returns only rows with a present value.
+     *
+     * @return void
+     */
+    public function testNotNullOperatorReturnsOnlyNonNullRows(): void
+    {
+        $names = $this->names($this->query(['organization_id' => ['$notNull' => true]], '/api/nullable-users'));
+
+        self::assertEqualsCanonicalizing(['Alan', 'Carol'], $names);
+    }
+
+    /**
+     * Test that the presence-operator payload boolean is ignored and only the
+     * token decides the constraint.
+     *
+     * @return void
+     */
+    public function testNullOperatorIgnoresThePayloadBoolean(): void
+    {
+        $names = $this->names($this->query(['organization_id' => ['$null' => false]], '/api/nullable-users'));
+
+        self::assertEqualsCanonicalizing(['Alice', 'Bob', 'Dave'], $names);
+    }
+
+    /**
+     * Test that two distinct field-operator filters compose with AND semantics.
+     *
+     * @return void
+     */
+    public function testTwoFiltersComposeWithAndSemantics(): void
+    {
+        $names = $this->names($this->query([
+            'name' => ['$like' => 'Al'],
+            'id'   => ['$gt' => 1],
+        ]));
+
+        self::assertSame(['Alan'], $names);
+    }
+
+    /**
+     * Test that the or grouping operator returns the union of both branches.
+     *
+     * @return void
+     */
+    public function testOrGroupingReturnsTheUnionOfBranches(): void
+    {
+        $names = $this->names($this->query([
+            '$or' => [
+                'name' => 'Alice',
+                'id'   => ['$gt' => 4],
+            ],
+        ]));
+
+        self::assertEqualsCanonicalizing(['Alice', 'Dave'], $names);
+    }
+
+    /**
+     * Test that the and grouping operator returns the intersection of branches.
+     *
+     * @return void
+     */
+    public function testAndGroupingReturnsTheIntersectionOfBranches(): void
+    {
+        $names = $this->names($this->query([
+            '$and' => [
+                'name' => ['$like' => 'Al'],
+                'id'   => ['$gt' => 1],
+            ],
+        ]));
+
+        self::assertSame(['Alan'], $names);
+    }
+
+    /**
+     * Issue a filtered request against the given route and return the response.
+     *
+     * @param  array<string, mixed>  $filters
+     * @param  string  $route
+     * @return \Illuminate\Testing\TestResponse<\Illuminate\Http\JsonResponse>
+     */
+    private function query(array $filters, string $route = '/api/users'): TestResponse
+    {
+        $response = $this->getJson($route . '?filters=' . urlencode((string) json_encode($filters)));
+
+        $response->assertOk();
+
+        return $response;
+    }
+
+    /**
+     * Extract the name column from a response data payload.
+     *
+     * @param  \Illuminate\Testing\TestResponse<\Illuminate\Http\JsonResponse>  $response
+     * @return array<int, string>
+     */
+    private function names(TestResponse $response): array
+    {
+        return array_column((array) $response->json('data'), 'name');
+    }
+}

--- a/tests/Feature/FilteredCacheFingerprintTest.php
+++ b/tests/Feature/FilteredCacheFingerprintTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\CacheableUserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a filtered HTTP read caches under its own fingerprint
+ * rather than the whole table.
+ *
+ * A filtered read is keyed by the executed query, so repeating one filter is a
+ * zero-query hit returning only its rows, while a different filter issues fresh
+ * queries and returns a distinct rowset. This guards the highest-value
+ * correctness case: a whole-table collision would silently serve the wrong rows
+ * for the second filter.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(QuerySurface::class)]
+final class FilteredCacheFingerprintTest extends TestCase
+{
+    /**
+     * Set up each test with a cacheable users route and seeded rows split
+     * across two email domains.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Route::middleware(ParseApiQuery::class)->get('/api/cached-users', function (CacheableUserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alpha', 'email' => 'alpha@keep.com']);
+        User::create(['name' => 'Bravo', 'email' => 'bravo@keep.com']);
+        User::create(['name' => 'Charlie', 'email' => 'charlie@drop.com']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that two distinct filters are cached under separate fingerprints,
+     * with no whole-table collision.
+     *
+     * @return void
+     */
+    public function testDistinctFiltersAreCachedUnderSeparateFingerprints(): void
+    {
+        $keepUrl = '/api/cached-users?' . http_build_query(['filters' => json_encode(['email' => ['$like' => '@keep.com']])]);
+        $dropUrl = '/api/cached-users?' . http_build_query(['filters' => json_encode(['email' => ['$like' => '@drop.com']])]);
+
+        // Warm the cache for the first filter.
+        $this->getJson($keepUrl)->assertOk()->assertJsonCount(2, 'data');
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        // Repeating the first filter is a zero-query hit returning its rows.
+        $keepRepeat = $this->getJson($keepUrl);
+
+        $keepRepeat->assertOk();
+        $keepRepeat->assertJsonCount(2, 'data');
+        self::assertCount(0, DB::getQueryLog());
+        self::assertSame(['Alpha', 'Bravo'], $keepRepeat->json('data.*.name'));
+
+        DB::flushQueryLog();
+
+        // A different filter falls through to a fresh query with a distinct
+        // rowset, proving it was not served from the first filter's entry nor a
+        // whole-table snapshot.
+        $dropRead = $this->getJson($dropUrl);
+
+        $dropRead->assertOk();
+        $dropRead->assertJsonCount(1, 'data');
+        self::assertNotCount(0, DB::getQueryLog());
+        self::assertSame(['Charlie'], $dropRead->json('data.*.name'));
+    }
+}

--- a/tests/Feature/GuardedExportTest.php
+++ b/tests/Feature/GuardedExportTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivesTabularSchema;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitCollection;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitResource;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\Exporter\ExporterServiceProvider;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\GuardedExportResource;
+use Tests\Fixtures\Resources\PerItemGuardedExportResource;
+use Tests\Fixtures\Resources\ThrowingGuardExportResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests proving the data-leak guarantees of field guards inside
+ * content-negotiated exports, observed on the streamed bytes and the aborted
+ * response.
+ *
+ * A request-scoped guard drops or keeps its whole column in the streamed CSV
+ * depending on the request, so a guarded value never reaches the wire unless
+ * the request permits it. A row-dependent or fail-closed guard cannot be
+ * honoured by a flat tabular schema, so the export aborts before any row is
+ * streamed, surfacing a non-200 error with a non-tabular content type and no
+ * leaked rows.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ToolkitCollection::class)]
+#[CoversClass(ToolkitResource::class)]
+#[CoversClass(ApiResource::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+#[CoversClass(PerItemGuardedFieldException::class)]
+#[CoversTrait(DerivesTabularSchema::class)]
+final class GuardedExportTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with the exporter bound, the handler wired, seeded users
+     * and the guarded export routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SchemaCompiler::clearCache();
+
+        $this->registerApiExceptionHandler();
+
+        $this->seedUsers();
+        $this->registerRoutes();
+    }
+
+    /**
+     * Tear down, clearing the schema compiler cache.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        SchemaCompiler::clearCache();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a request-scoped guard omits its column and every guarded value
+     * from the streamed CSV by default, and includes them when the request
+     * permits the field.
+     *
+     * @return void
+     */
+    public function testRequestScopedGuardDropsAndKeepsColumnInStreamedCsv(): void
+    {
+        $bare = $this->get('/guarded-export/users', ['Accept' => 'text/csv']);
+
+        $bare->assertOk();
+        $bare->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+
+        $bareContent = $bare->streamedContent();
+
+        self::assertStringContainsString('ALICE', $bareContent);
+        self::assertStringNotContainsStringIgnoringCase('secret', $bareContent);
+        self::assertStringNotContainsString('CLASSIFIED-1', $bareContent);
+        self::assertStringNotContainsString('CLASSIFIED-2', $bareContent);
+
+        $permitted = $this->get('/guarded-export/users?show=yes', ['Accept' => 'text/csv']);
+
+        $permitted->assertOk();
+        $permitted->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+
+        $permittedContent = $permitted->streamedContent();
+
+        self::assertStringContainsStringIgnoringCase('secret', $permittedContent);
+        self::assertStringContainsString('CLASSIFIED-1', $permittedContent);
+        self::assertStringContainsString('CLASSIFIED-2', $permittedContent);
+    }
+
+    /**
+     * Test that a row-dependent guard and a fail-closed guard abort the export
+     * before any row is streamed, returning a non-200 error with a non-tabular
+     * content type and no leaked values, for both the item and collection
+     * forms.
+     *
+     * @return void
+     */
+    public function testRowDependentAndFailClosedGuardsAbortWithoutLeakingRows(): void
+    {
+        $routes = [
+            '/guarded-abort/per-item',
+            '/guarded-abort/per-item/1',
+            '/guarded-abort/throwing',
+            '/guarded-abort/throwing/1',
+        ];
+
+        foreach ($routes as $route) {
+
+            $response = $this->get($route, ['Accept' => 'text/csv']);
+
+            $response->assertServerError();
+
+            $contentType = (string) $response->headers->get('Content-Type');
+
+            self::assertStringNotContainsStringIgnoringCase('csv', $contentType, "Route {$route} must not return a tabular content type.");
+            self::assertStringNotContainsStringIgnoringCase('tab-separated-values', $contentType, "Route {$route} must not return a tabular content type.");
+
+            $response->assertDontSee('alice@example.com');
+            $response->assertDontSee('bob@example.com');
+        }
+    }
+
+    /**
+     * Register the exporter service provider alongside the toolkit.
+     *
+     * @param  mixed  $app
+     * @return array<int, class-string>
+     */
+    #[\Override]
+    protected function getPackageProviders(mixed $app): array
+    {
+        return [
+            ...parent::getPackageProviders($app),
+            ExporterServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Seed the database with two users of differing status.
+     *
+     * @return void
+     */
+    private function seedUsers(): void
+    {
+        User::create([
+            'name'   => 'Alice',
+            'email'  => 'alice@example.com',
+            'status' => 'active',
+        ]);
+
+        User::create([
+            'name'   => 'Bob',
+            'email'  => 'bob@example.com',
+            'status' => 'inactive',
+        ]);
+    }
+
+    /**
+     * Register the guarded export routes.
+     *
+     * The streaming route attaches a distinctive secret value to each row so
+     * the guarded column can be proven present or absent in the streamed bytes.
+     * The aborting routes carry guards that cannot be honoured on a flat
+     * tabular schema, so building their export throws before streaming.
+     *
+     * @return void
+     */
+    private function registerRoutes(): void
+    {
+        Route::get('/guarded-export/users', static function (): AnonymousResourceCollection {
+            $users = User::all();
+
+            $users->each(static fn (User $user) => $user->setAttribute('secret', 'CLASSIFIED-' . $user->id));
+
+            return GuardedExportResource::collection($users);
+        });
+
+        Route::get('/guarded-abort/per-item', static fn (): AnonymousResourceCollection => PerItemGuardedExportResource::collection(User::paginate(10)));
+
+        Route::get('/guarded-abort/per-item/{id}', static fn (int $id): PerItemGuardedExportResource => new PerItemGuardedExportResource(User::findOrFail($id)));
+
+        Route::get('/guarded-abort/throwing', static fn (): AnonymousResourceCollection => ThrowingGuardExportResource::collection(User::paginate(10)));
+
+        Route::get('/guarded-abort/throwing/{id}', static fn (int $id): ThrowingGuardExportResource => new ThrowingGuardExportResource(User::findOrFail($id)));
+    }
+}

--- a/tests/Feature/JsonPrettyPrintTest.php
+++ b/tests/Feature/JsonPrettyPrintTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\JsonPrettyPrint;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the JSON pretty-print middleware through the HTTP kernel.
+ *
+ * Dispatches real requests against a route wrapped in the pretty-print
+ * middleware and proves the query-string toggle survives the full request flow:
+ * a truthy pretty parameter renders indented JSON while its absence or a falsey
+ * value leaves the compact envelope untouched.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(JsonPrettyPrint::class)]
+final class JsonPrettyPrintTest extends TestCase
+{
+    /** @var array<string, mixed> The payload rendered by the test route. */
+    private const array PAYLOAD = ['key' => 'value', 'nested' => ['a' => 1]];
+
+    /**
+     * Set up each test with a route returning a fixed JSON payload behind the
+     * pretty-print middleware.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(JsonPrettyPrint::class)->get('/api/pretty', static fn (): JsonResponse => new JsonResponse(self::PAYLOAD));
+    }
+
+    /**
+     * Test that a truthy pretty parameter renders indented JSON over HTTP.
+     *
+     * @return void
+     */
+    public function testPrettyParameterRendersIndentedJson(): void
+    {
+        $response = $this->getJson('/api/pretty?pretty=1');
+
+        $response->assertOk();
+
+        $content = $response->baseResponse->getContent();
+
+        self::assertIsString($content);
+        self::assertStringContainsString("\n", $content);
+        self::assertSame(json_encode(self::PAYLOAD, JSON_PRETTY_PRINT), $content);
+    }
+
+    /**
+     * Test that an omitted pretty parameter leaves the compact envelope
+     * untouched over HTTP.
+     *
+     * @return void
+     */
+    public function testMissingPrettyParameterRendersCompactJson(): void
+    {
+        $response = $this->getJson('/api/pretty');
+
+        $response->assertOk();
+
+        $content = $response->baseResponse->getContent();
+
+        self::assertIsString($content);
+        self::assertStringNotContainsString("\n", $content);
+        self::assertSame(json_encode(self::PAYLOAD), $content);
+    }
+
+    /**
+     * Test that a falsey pretty parameter leaves the compact envelope untouched
+     * over HTTP.
+     *
+     * @return void
+     */
+    public function testFalseyPrettyParameterRendersCompactJson(): void
+    {
+        $response = $this->getJson('/api/pretty?pretty=0');
+
+        $response->assertOk();
+
+        $content = $response->baseResponse->getContent();
+
+        self::assertIsString($content);
+        self::assertSame(json_encode(self::PAYLOAD), $content);
+    }
+}

--- a/tests/Feature/MalformedFilterRequestTest.php
+++ b/tests/Feature/MalformedFilterRequestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a non-JSON filters payload is rejected up front.
+ *
+ * The base validation rule requires the filters parameter to be valid JSON, so
+ * a malformed value is rejected as the toolkit 422 envelope keyed on the
+ * filters parameter itself rather than on a nested column, and the request
+ * never reaches the repository.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+final class MalformedFilterRequestTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up a repository-backed users route and seed a row.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+    }
+
+    /**
+     * Test that a non-JSON filters value renders the 422 envelope keyed on the
+     * filters parameter.
+     *
+     * @return void
+     */
+    public function testNonJsonFiltersValueIsRejectedWithValidationEnvelope(): void
+    {
+        $response = $this->getJson('/api/users?filters=' . urlencode('{not-valid-json'));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error.status', 422);
+        $response->assertJsonPath('error.code', 10106);
+
+        self::assertArrayHasKey('filters', (array) $response->json('error.meta'));
+        self::assertArrayNotHasKey('filters.status', (array) $response->json('error.meta'));
+    }
+}

--- a/tests/Feature/MultiColumnSortTest.php
+++ b/tests/Feature/MultiColumnSortTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for multi-column ordering through the kernel.
+ *
+ * A comma-separated `order` applies each column in turn: the first column is
+ * the primary sort and every subsequent column breaks ties. Two rows sharing a
+ * name are ordered by name ascending, and the descending id secondary sort
+ * decides which of the tied rows appears first.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(OrderApplier::class)]
+final class MultiColumnSortTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        // Two rows share the name Mia so the secondary id sort decides their
+        // order; Zed trails both alphabetically.
+        User::create(['name' => 'Mia', 'email' => 'mia-first@example.com']);
+        User::create(['name' => 'Mia', 'email' => 'mia-second@example.com']);
+        User::create(['name' => 'Zed', 'email' => 'zed@example.com']);
+    }
+
+    /**
+     * Test that a comma-separated order applies the primary column with the
+     * secondary column breaking ties.
+     *
+     * @return void
+     */
+    public function testSecondaryColumnBreaksTheTie(): void
+    {
+        $response = $this->getJson('/api/users?order=name:asc,id:desc');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+
+        // Name ascending puts the two Mia rows first; id descending then places
+        // the later-created Mia (higher id) before the earlier one.
+        $response->assertJsonPath('data.0.name', 'Mia');
+        $response->assertJsonPath('data.1.name', 'Mia');
+        $response->assertJsonPath('data.2.name', 'Zed');
+
+        $response->assertJsonPath('data.0.email', 'mia-second@example.com');
+        $response->assertJsonPath('data.1.email', 'mia-first@example.com');
+
+        self::assertGreaterThan($response->json('data.1.id'), $response->json('data.0.id'));
+    }
+}

--- a/tests/Feature/NestedRelationFilterHttpTest.php
+++ b/tests/Feature/NestedRelationFilterHttpTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\Fixtures\Resources\PostResource;
+use Tests\TestCase;
+
+/**
+ * Feature test for filtering on a traversable relation column over HTTP.
+ *
+ * Under the allowlist posture a filter keyed on a declared-traversable relation
+ * whose related resource declares the target column filterable compiles to a
+ * whereHas constraint. A real request proves the nested key narrows the
+ * envelope to only the users owning a matching related row, with the meta total
+ * reduced accordingly.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class NestedRelationFilterHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a users route, the Post resource map, and seeded
+     * users and posts.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.resources.resource_map', [
+            Post::class => PostResource::class,
+        ]);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        $alice = User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        $bob   = User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+
+        User::create(['name' => 'Charlie', 'email' => 'charlie@example.com']);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'Alice Post', 'body' => 'Content']);
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob Post', 'body' => 'Content']);
+    }
+
+    /**
+     * Test that a filter on a traversable relation column narrows the envelope
+     * to the matching owner.
+     *
+     * @return void
+     */
+    public function testRelationColumnFilterNarrowsTheEnvelope(): void
+    {
+        $filters = json_encode(['posts' => ['title' => ['$like' => 'Alice']]]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Alice');
+        $response->assertJsonPath('meta.total', 1);
+    }
+}

--- a/tests/Feature/NestedRelationRejectionEnvelopeTest.php
+++ b/tests/Feature/NestedRelationRejectionEnvelopeTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\Fixtures\Resources\PostResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests proving a nested-relation rejection renders as a 422 envelope.
+ *
+ * A ValidationException raised deep inside a traversed relation - an undeclared
+ * column on the related resource, or an onward traversal the related resource
+ * never declared - must unwind out of the whereHas closure mid-pagination and
+ * render as the toolkit 422 envelope keyed on the offending nested field, not
+ * escape the kernel as a 500. Both the undeclared-column and the
+ * undeclared-traversal cases are driven through a real request.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class NestedRelationRejectionEnvelopeTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a users route, the Post resource map, and seeded
+     * users and posts.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.resources.resource_map', [
+            Post::class => PostResource::class,
+        ]);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        $alice = User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'Alice Post', 'body' => 'Content']);
+    }
+
+    /**
+     * Test that an undeclared column on a traversed relation renders as a 422
+     * envelope keyed on the nested column, not a 500.
+     *
+     * @return void
+     */
+    public function testUndeclaredNestedColumnRendersValidationEnvelope(): void
+    {
+        $filters = json_encode(['posts' => ['body' => 'Content']]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error.status', 422);
+        $response->assertJsonPath('error.code', 10106);
+
+        self::assertArrayHasKey('filters.body', (array) $response->json('error.meta'));
+    }
+
+    /**
+     * Test that an undeclared onward traversal renders as a 422 envelope keyed
+     * on the nested relation, not a 500.
+     *
+     * @return void
+     */
+    public function testUndeclaredNestedTraversalRendersValidationEnvelope(): void
+    {
+        $filters = json_encode(['posts' => ['nested' => ['user' => ['name' => 'Alice']]]]);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error.status', 422);
+        $response->assertJsonPath('error.code', 10106);
+
+        self::assertArrayHasKey('filters.user', (array) $response->json('error.meta'));
+    }
+}

--- a/tests/Feature/OffsetPaginationTest.php
+++ b/tests/Feature/OffsetPaginationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\ProvidesApiEnvelope;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for offset-paginated collections through the kernel.
+ *
+ * Driving `page=` over the length-aware paginator returns the requested
+ * slice of rows alongside the full meta block (total, count, continue), the
+ * self, first, prev, next, and last links, and the total-count response
+ * header. The terminal page reports no further pages and a null next link,
+ * and the configured default limit applies when the client supplies none.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+#[CoversTrait(ProvidesApiEnvelope::class)]
+final class OffsetPaginationTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        // Created in ascending id order; the paginator orders by the primary
+        // key by default, so page order follows creation order.
+        User::create(['name' => 'Anna', 'email' => 'anna@example.com']);
+        User::create(['name' => 'Ben', 'email' => 'ben@example.com']);
+        User::create(['name' => 'Cara', 'email' => 'cara@example.com']);
+        User::create(['name' => 'Dan', 'email' => 'dan@example.com']);
+        User::create(['name' => 'Evan', 'email' => 'evan@example.com']);
+    }
+
+    /**
+     * Test that the second offset page returns the next slice of rows with the
+     * full meta block, the complete links block, and the total-count header.
+     *
+     * @return void
+     */
+    public function testSecondPageReturnsNextRowsWithLinksMetaAndTotalCountHeader(): void
+    {
+        $response = $this->getJson('/api/users?limit=2&page=2');
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('data.0.name', 'Cara');
+        $response->assertJsonPath('data.1.name', 'Dan');
+
+        $response->assertJsonPath('meta.total', 5);
+        $response->assertJsonPath('meta.count', 2);
+        $response->assertJsonPath('meta.continue', true);
+
+        $response->assertHeader('Total-Count', '5');
+
+        self::assertIsString($response->json('links.self'));
+        self::assertIsString($response->json('links.first'));
+        self::assertIsString($response->json('links.prev'));
+        self::assertIsString($response->json('links.next'));
+        self::assertIsString($response->json('links.last'));
+
+        self::assertStringContainsString('page=2', $response->json('links.self'));
+        self::assertStringContainsString('page=1', $response->json('links.first'));
+        self::assertStringContainsString('page=1', $response->json('links.prev'));
+        self::assertStringContainsString('page=3', $response->json('links.next'));
+        self::assertStringContainsString('page=3', $response->json('links.last'));
+    }
+
+    /**
+     * Test that the last offset page reports no further pages and a null next
+     * link while the prev link points at the preceding page.
+     *
+     * @return void
+     */
+    public function testLastPageReportsContinueFalseAndNullNextLink(): void
+    {
+        $response = $this->getJson('/api/users?limit=2&page=3');
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Evan');
+
+        $response->assertJsonPath('meta.total', 5);
+        $response->assertJsonPath('meta.count', 1);
+        $response->assertJsonPath('meta.continue', false);
+
+        self::assertNull($response->json('links.next'));
+        self::assertIsString($response->json('links.prev'));
+        self::assertStringContainsString('page=2', $response->json('links.prev'));
+    }
+
+    /**
+     * Test that the configured default limit applies when the client supplies
+     * none.
+     *
+     * @return void
+     */
+    public function testDefaultLimitAppliesWhenNoLimitSupplied(): void
+    {
+        Config::set('api-toolkit.parser.defaults.limit', 2);
+
+        $response = $this->getJson('/api/users');
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('meta.total', 5);
+        $response->assertJsonPath('meta.count', 2);
+        $response->assertJsonPath('meta.continue', true);
+    }
+}

--- a/tests/Feature/PerItemGuardResponseTest.php
+++ b/tests/Feature/PerItemGuardResponseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\PerItemGuardedUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for a per-row field guard varying visibility inside one body.
+ *
+ * A field guard that reads the row being rendered must be evaluated once per
+ * element as the collection is mapped, so a single JSON body can reveal the
+ * guarded field on some rows and omit it on others. This drives a two-row
+ * collection (one active, one inactive) through a real route and asserts the
+ * guarded email surfaces on the active row and is absent on the inactive one.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiResource::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class PerItemGuardResponseTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a two-row per-item-guarded collection route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'status' => 'inactive']);
+
+        // Fetch fresh instances per request so no model is flagged as recently
+        // created, which would alter the response status.
+        Route::get('/api/per-item-guarded', static function (): ApiResourceCollection {
+            $users = User::query()->get();
+
+            return new ApiResourceCollection($users, PerItemGuardedUserResource::class);
+        });
+    }
+
+    /**
+     * Test that the guarded field appears on the active row and is absent on
+     * the inactive row within the same response body.
+     *
+     * @return void
+     */
+    public function testGuardVariesVisibilityPerRowInOneBody(): void
+    {
+        $response = $this->getJson('/api/per-item-guarded');
+
+        $response->assertOk();
+
+        $response->assertJsonPath('data.0.name', 'Alice');
+        $response->assertJsonPath('data.0.email', 'alice@example.com');
+
+        $response->assertJsonPath('data.1.name', 'Bob');
+
+        self::assertArrayHasKey('email', (array) $response->json('data.0'));
+        self::assertArrayNotHasKey('email', (array) $response->json('data.1'));
+    }
+}

--- a/tests/Feature/PolymorphicResourceEnvelopeTest.php
+++ b/tests/Feature/PolymorphicResourceEnvelopeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\PolymorphicResource;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for a single polymorphic resource through the HTTP kernel.
+ *
+ * A single mapped model is returned from a real route as a PolymorphicResource
+ * and asserted to render the data-wrapped envelope with its type discriminator
+ * - the JsonResource wrap that unit tests never travel through, which only a
+ * real dispatch confirms. A field excluded via withoutFields drops from the
+ * body even when it is a default field.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(PolymorphicResource::class)]
+final class PolymorphicResourceEnvelopeTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a single mapped polymorphic resource route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.resources.resource_map', [
+            User::class => UserResource::class,
+        ]);
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+
+        // Fetch a fresh instance per request so the model is not flagged as
+        // recently created, which would alter the response status.
+        Route::get('/api/polymorphic-item', static fn (): PolymorphicResource => (new PolymorphicResource(User::query()->firstOrFail()))->withoutFields(['email']));
+    }
+
+    /**
+     * Test that the single polymorphic resource renders a data-wrapped typed
+     * item with the excluded field absent.
+     *
+     * @return void
+     */
+    public function testSinglePolymorphicResourceRendersTypedDataWrappedItem(): void
+    {
+        $response = $this->getJson('/api/polymorphic-item');
+
+        $response->assertOk();
+        $response->assertJsonPath('data._type', 'users');
+        $response->assertJsonPath('data.name', 'Alice');
+
+        self::assertArrayNotHasKey('email', (array) $response->json('data'));
+    }
+}

--- a/tests/Feature/ReferenceCacheModeTest.php
+++ b/tests/Feature/ReferenceCacheModeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\ReferenceCacheUserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving whole-table reference-cache mode over repeated HTTP
+ * reads.
+ *
+ * A reference-mode repository serves the whole-table snapshot with zero queries
+ * on a repeat read, but a criteria-composed read is an active composition that
+ * bypasses the snapshot and falls through to the database, so a filtered
+ * request never receives the unfiltered snapshot.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class ReferenceCacheModeTest extends TestCase
+{
+    /**
+     * Set up each test with snapshot and criteria-composed reference routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Route::middleware(ParseApiQuery::class)->get('/api/reference-users', function (ReferenceCacheUserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        Route::middleware(ParseApiQuery::class)->get('/api/reference-users-filtered', function (ReferenceCacheUserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alpha', 'email' => 'alpha@keep.com']);
+        User::create(['name' => 'Bravo', 'email' => 'bravo@keep.com']);
+        User::create(['name' => 'Charlie', 'email' => 'charlie@drop.com']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a repeat snapshot read serves zero queries while a
+     * criteria-composed read falls through to the database.
+     *
+     * @return void
+     */
+    public function testSnapshotReadHitsCacheWhileCriteriaReadFallsThrough(): void
+    {
+        // Warm the whole-table snapshot.
+        $this->getJson('/api/reference-users')->assertOk()->assertJsonCount(3, 'data');
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        // The repeat snapshot read is served with zero queries.
+        $snapshot = $this->getJson('/api/reference-users');
+
+        $snapshot->assertOk();
+        $snapshot->assertJsonCount(3, 'data');
+        self::assertCount(0, DB::getQueryLog());
+
+        DB::flushQueryLog();
+
+        // A criteria-composed read is an active composition: it bypasses the
+        // snapshot, issues a fresh query, and narrows to the matching rows.
+        $filtered = $this->getJson('/api/reference-users-filtered?' . http_build_query([
+            'filters' => json_encode(['email' => ['$like' => '@keep.com']]),
+        ]));
+
+        $filtered->assertOk();
+        $filtered->assertJsonCount(2, 'data');
+        self::assertNotCount(0, DB::getQueryLog());
+        self::assertSame(['Alpha', 'Bravo'], $filtered->json('data.*.name'));
+    }
+}

--- a/tests/Feature/RelationExistenceFilterHttpTest.php
+++ b/tests/Feature/RelationExistenceFilterHttpTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\QuerySurface;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\Fixtures\Resources\PostResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the relation-existence filter operators over HTTP.
+ *
+ * The $has and $hasnt tokens on a declared-traversable relation compile to
+ * whereHas / whereDoesntHave existence constraints. A real request proves each
+ * token narrows the envelope to the complementary partition - users owning at
+ * least one related row versus those owning none - with the meta total tracking
+ * each partition.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(FilterApplier::class)]
+#[CoversClass(QuerySurface::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class RelationExistenceFilterHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a users route, the Post resource map, and seeded
+     * users where only two own posts.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Config::set('api-toolkit.resources.resource_map', [
+            Post::class => PostResource::class,
+        ]);
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        $alice = User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        $bob   = User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+
+        User::create(['name' => 'Charlie', 'email' => 'charlie@example.com']);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'Alice Post', 'body' => 'Content']);
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob Post', 'body' => 'Content']);
+    }
+
+    /**
+     * Test that $has returns only the users owning at least one related row.
+     *
+     * @return void
+     */
+    public function testHasReturnsUsersOwningRelatedRows(): void
+    {
+        $filters = json_encode(['$has' => 'posts']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('meta.total', 2);
+    }
+
+    /**
+     * Test that $hasnt returns only the users owning no related rows.
+     *
+     * @return void
+     */
+    public function testHasntReturnsUsersWithoutRelatedRows(): void
+    {
+        $filters = json_encode(['$hasnt' => 'posts']);
+
+        $response = $this->getJson('/api/users?filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Charlie');
+        $response->assertJsonPath('meta.total', 1);
+    }
+}

--- a/tests/Feature/RepositoryCacheHitTest.php
+++ b/tests/Feature/RepositoryCacheHitTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\CacheableUserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a repeated identical HTTP read is served from the
+ * per-query cache without touching the database.
+ *
+ * Two identical requests travel through the real ParseApiQuery middleware into
+ * a Cacheable repository read. The first request warms the per-query cache; the
+ * second returns a byte-identical envelope while the database query log stays
+ * empty, proving the cache hit is observable end to end rather than only
+ * through a direct repository call.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class RepositoryCacheHitTest extends TestCase
+{
+    /**
+     * Set up each test with a cacheable users route and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Route::middleware(ParseApiQuery::class)->get('/api/cached-users', function (CacheableUserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+        User::create(['name' => 'Charlie', 'email' => 'charlie@example.com']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a second identical read serves a byte-identical envelope with
+     * zero database queries.
+     *
+     * @return void
+     */
+    public function testSecondIdenticalReadServesFromCacheWithZeroQueries(): void
+    {
+        // Warm the per-query cache with the first read.
+        $first = $this->getJson('/api/cached-users');
+
+        $first->assertOk();
+        $first->assertJsonCount(3, 'data');
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        $second = $this->getJson('/api/cached-users');
+
+        $second->assertOk();
+
+        // The repeat read did not touch the database.
+        self::assertCount(0, DB::getQueryLog());
+
+        // The envelope is byte-identical to the warmed response.
+        self::assertSame($first->baseResponse->getContent(), $second->baseResponse->getContent());
+    }
+}

--- a/tests/Feature/ResourceResponseShapeTest.php
+++ b/tests/Feature/ResourceResponseShapeTest.php
@@ -4,11 +4,16 @@ declare(strict_types = 1);
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\EagerLoadApplier;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\FilterApplier;
 use Tests\Concerns\RegistersApiExceptionHandler;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\Post;
@@ -33,6 +38,10 @@ use Tests\TestCase;
  */
 #[CoversClass(ApiResource::class)]
 #[CoversClass(ApiResourceCollection::class)]
+#[CoversClass(ValueResolver::class)]
+#[CoversClass(EagerLoadPlanner::class)]
+#[CoversClass(EagerLoadApplier::class)]
+#[CoversClass(FilterApplier::class)]
 final class ResourceResponseShapeTest extends TestCase
 {
     use RegistersApiExceptionHandler;
@@ -109,5 +118,122 @@ final class ResourceResponseShapeTest extends TestCase
 
         self::assertArrayHasKey('posts_id', (array) $item['sums']);
         self::assertArrayHasKey('posts_id', (array) $item['averages']);
+    }
+
+    /**
+     * Test that undeclared and non-existent aggregate relations are silently
+     * omitted without raising a database error.
+     *
+     * @return void
+     */
+    public function testUndeclaredAggregateRelationsAreSilentlyOmitted(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields'   => ['users' => 'name,counts,sums,averages'],
+            'counts'   => ['users' => 'posts,organization,comments'],
+            'sums'     => ['users' => ['posts' => 'id', 'organization' => 'id', 'comments' => 'id']],
+            'averages' => ['users' => ['posts' => 'id', 'comments' => 'id']],
+        ]));
+
+        $response->assertOk();
+
+        // Only the declared aggregate surfaces; the undeclared relation
+        // (organization) and the non-existent relation (comments) are dropped
+        // rather than compiled into a broken query.
+        $response->assertJsonPath('data.0.counts.posts', 2);
+
+        /** @var array<string, mixed> $item */
+        $item = $response->json('data.0');
+
+        self::assertArrayNotHasKey('organization', (array) $item['counts']);
+        self::assertArrayNotHasKey('comments', (array) $item['counts']);
+        self::assertSame(['posts'], array_keys((array) $item['counts']));
+        self::assertSame(['posts_id'], array_keys((array) $item['sums']));
+        self::assertSame(['posts_id'], array_keys((array) $item['averages']));
+    }
+
+    /**
+     * Test that default-flagged aggregates surface without explicit selection
+     * while non-default aggregates stay omitted.
+     *
+     * @return void
+     */
+    public function testDefaultAggregatesSurfaceWhileNonDefaultsAreOmitted(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields' => ['users' => 'name,counts,sums,averages'],
+        ]));
+
+        $response->assertOk();
+
+        // The default count and sum surface with no selection parameters.
+        $response->assertJsonPath('data.0.counts.posts', 2);
+
+        /** @var array<string, mixed> $item */
+        $item = $response->json('data.0');
+
+        self::assertArrayHasKey('posts_id', (array) $item['sums']);
+
+        // The average is declared but not default, so the whole bucket is
+        // absent when nothing requests it.
+        self::assertArrayNotHasKey('averages', $item);
+    }
+
+    /**
+     * Test that the sum and average aggregate values are numerically correct in
+     * the rendered payload.
+     *
+     * @return void
+     */
+    public function testAggregateValuesAreNumericallyCorrect(): void
+    {
+        /** @var array<int, int> $postIds */
+        $postIds     = Post::all()->pluck('id')->all();
+        $expectedSum = array_sum($postIds);
+        $expectedAvg = $expectedSum / count($postIds);
+
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields'   => ['users' => 'name,sums,averages'],
+            'sums'     => ['users' => ['posts' => 'id']],
+            'averages' => ['users' => ['posts' => 'id']],
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0.sums.posts_id', $expectedSum);
+        $response->assertJsonPath('data.0.averages.posts_id', $expectedAvg);
+    }
+
+    /**
+     * Test that aggregates reflect only the rows belonging to a filtered user.
+     *
+     * @return void
+     */
+    public function testAggregatesRespectAnAppliedFilter(): void
+    {
+        // The blocklist posture lets a filter narrow on an undeclared column,
+        // since UserResource declares no filterable columns of its own.
+        Config::set('api-toolkit.repositories.query_posture', 'blocklist');
+
+        $bob = User::create(['name' => 'Bob', 'email' => 'bob@example.com', 'status' => 'active']);
+
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob One', 'body' => 'Content', 'published' => true]);
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob Two', 'body' => 'Content', 'published' => true]);
+        Post::create(['user_id' => $bob->id, 'title' => 'Bob Three', 'body' => 'Content', 'published' => false]);
+
+        $filters = json_encode(['name' => 'Bob']);
+
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields' => ['users' => 'name,counts'],
+            'counts' => ['users' => 'posts'],
+        ]) . '&filters=' . urlencode((string) $filters));
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('meta.total', 1);
+
+        // The single returned row is Bob, and its count reflects only Bob's
+        // three posts, not Alice's two.
+        $response->assertJsonPath('data.0.name', 'Bob');
+        $response->assertJsonPath('data.0.counts.posts', 3);
     }
 }

--- a/tests/Feature/ServiceEnvelopeTest.php
+++ b/tests/Feature/ServiceEnvelopeTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Exceptions\ForbiddenException;
+use SineMacula\ApiToolkit\Exceptions\InvalidInputException;
+use SineMacula\ApiToolkit\Exceptions\TooManyRequestsException;
+use SineMacula\ApiToolkit\Services\Actors\EloquentActor;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Service;
+use SineMacula\ApiToolkit\Services\ServiceResult;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Services\AuthorizingService;
+use Tests\Fixtures\Services\InsertThenFailService;
+use Tests\Fixtures\Services\LockableService;
+use Tests\Fixtures\Services\ValidatingUserService;
+use Tests\TestCase;
+
+/**
+ * Feature tests proving the service failure path renders the right envelope.
+ *
+ * Each route runs a service through run()->throw()->output() inside the real
+ * request lifecycle, so a captured business failure is rethrown, mapped by the
+ * toolkit exception handler, and rendered as the taxonomy JSON envelope. Covers
+ * the four failure origins: input validation (422), lock contention (429),
+ * authorization denial (403), and a handle() failure that rolls its write back
+ * behind a 500.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(Service::class)]
+#[CoversClass(ServiceRunner::class)]
+#[CoversClass(ServiceResult::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+#[CoversClass(ForbiddenException::class)]
+#[CoversClass(InvalidInputException::class)]
+#[CoversClass(TooManyRequestsException::class)]
+final class ServiceEnvelopeTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up the toolkit handler and the service-backed failure routes.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::post('/api/service-validate', static function (Request $request): array {
+
+            $output = (new ValidatingUserService(new ArrayInput($request->all())))
+                ->run()
+                ->throw()
+                ->output();
+
+            return ['output' => $output];
+        });
+
+        Route::post('/api/service-lock', static function (): array {
+
+            (new LockableService)->run()->throw()->output();
+
+            return ['output' => true];
+        });
+
+        Route::post('/api/service-authorize', static function (Request $request): array {
+
+            $service = new AuthorizingService;
+            $user    = $request->user();
+
+            if ($user instanceof User) {
+                $service->by(EloquentActor::for($user));
+            }
+
+            $service->run()->throw()->output();
+
+            return ['output' => true];
+        });
+
+        Route::post('/api/service-handle-fail', static function (): array {
+
+            (new InsertThenFailService)->run()->throw();
+
+            return ['output' => true];
+        });
+    }
+
+    /**
+     * Test that a service validation failure renders the 422 envelope.
+     *
+     * @return void
+     */
+    public function testValidationFailureRendersInvalidInputEnvelope(): void
+    {
+        $response = $this->postJson('/api/service-validate', ['age' => 30]);
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error.status', 422);
+        $response->assertJsonPath('error.code', 10106);
+
+        $errors = $response->json('error.meta.city');
+
+        self::assertIsArray($errors);
+        self::assertNotEmpty($errors);
+    }
+
+    /**
+     * Test that service lock contention renders the 429 envelope.
+     *
+     * @return void
+     */
+    public function testLockContentionRendersTooManyRequestsEnvelope(): void
+    {
+        $lock = Cache::lock((new LockableService)->getLockKey(), 60);
+
+        self::assertTrue($lock->get());
+
+        try {
+            $response = $this->postJson('/api/service-lock');
+
+            $response->assertStatus(429);
+            $response->assertJsonPath('error.status', 429);
+            $response->assertJsonPath('error.code', 10107);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * Test that a service authorize() denial renders the 403 envelope.
+     *
+     * @return void
+     */
+    public function testAuthorizationDenialRendersForbiddenEnvelope(): void
+    {
+        $user = User::create(['name' => 'Acting', 'email' => 'acting@service.test']);
+
+        $response = $this->actingAs($user)->postJson('/api/service-authorize');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error.status', 403);
+        $response->assertJsonPath('error.code', 10102);
+    }
+
+    /**
+     * Test that a handle() failure rolls back and renders a 500 envelope.
+     *
+     * @return void
+     */
+    public function testHandleFailureRollsBackAndRendersErrorEnvelope(): void
+    {
+        $response = $this->postJson('/api/service-handle-fail');
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error.status', 500);
+
+        $this->assertDatabaseCount('users', 0);
+    }
+}

--- a/tests/Feature/SortEdgeCaseTest.php
+++ b/tests/Feature/SortEdgeCaseTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\Criteria\Concerns\OrderApplier;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the random-ordering keyword through the kernel.
+ *
+ * The `random` keyword bypasses the sortable-column guard and applies a random
+ * ordering rather than a column sort, so the request still returns the complete
+ * seeded set. Order is non-deterministic, so the assertions are order-agnostic.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(OrderApplier::class)]
+final class SortEdgeCaseTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded rows.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Anna', 'email' => 'anna@example.com']);
+        User::create(['name' => 'Ben', 'email' => 'ben@example.com']);
+        User::create(['name' => 'Cara', 'email' => 'cara@example.com']);
+        User::create(['name' => 'Dan', 'email' => 'dan@example.com']);
+        User::create(['name' => 'Evan', 'email' => 'evan@example.com']);
+    }
+
+    /**
+     * Test that random ordering returns the full seeded set regardless of the
+     * resulting order.
+     *
+     * @return void
+     */
+    public function testRandomOrderReturnsTheFullSet(): void
+    {
+        $response = $this->getJson('/api/users?order=random');
+
+        $response->assertOk();
+        $response->assertJsonCount(5, 'data');
+        $response->assertJsonPath('meta.total', 5);
+
+        $names = array_column((array) $response->json('data'), 'name');
+
+        sort($names);
+
+        self::assertSame(['Anna', 'Ben', 'Cara', 'Dan', 'Evan'], $names);
+    }
+}

--- a/tests/Feature/SparseFieldsetHttpTest.php
+++ b/tests/Feature/SparseFieldsetHttpTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\FieldResolver;
+use SineMacula\ApiToolkit\Http\Resources\Concerns\ValueResolver;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\UserRepository;
+use Tests\Fixtures\Resources\UserResource;
+use Tests\TestCase;
+
+/**
+ * Feature tests for sparse fieldset resolution over the real HTTP pipeline.
+ *
+ * Drives the middleware plus repository pagination path so field selection is
+ * proven on the wire: the `:all` token expands to every declared field, the
+ * default set applies when the fields parameter is omitted, computed and
+ * accessor fields surface with their closure output, and an undeclared
+ * requested field is silently dropped rather than rejected.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiResource::class)]
+#[CoversClass(ApiResourceCollection::class)]
+#[CoversClass(FieldResolver::class)]
+#[CoversClass(ValueResolver::class)]
+final class SparseFieldsetHttpTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a repository-backed users route and seeded data.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ParseApiQuery::class)->get('/api/users', function (UserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(UserResource::class)->withApiCriteria()->paginate();
+
+            return new ApiResourceCollection($users, UserResource::class);
+        });
+
+        $alice = User::create(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+
+        Post::create(['user_id' => $alice->id, 'title' => 'First', 'body' => 'Content', 'published' => true]);
+        Post::create(['user_id' => $alice->id, 'title' => 'Second', 'body' => 'Content', 'published' => false]);
+    }
+
+    /**
+     * Test that the `:all` token expands to every declared non-metric field.
+     *
+     * @return void
+     */
+    public function testAllTokenExpandsToEveryDeclaredField(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields' => ['users' => ':all'],
+        ]));
+
+        $response->assertOk();
+
+        /** @var array<string, mixed> $record */
+        $record = $response->json('data.0');
+
+        foreach (['id', '_type', 'name', 'email', 'status', 'created_at', 'updated_at', 'full_label', 'display_label'] as $field) {
+            self::assertArrayHasKey($field, $record);
+        }
+    }
+
+    /**
+     * Test that the default field set applies when the fields parameter is
+     * omitted, exposing only the default fields while withholding non-default
+     * declared fields and the aggregate buckets whose pseudo-fields are absent
+     * from the default set.
+     *
+     * @return void
+     */
+    public function testDefaultFieldSetAppliesWhenFieldsOmitted(): void
+    {
+        $response = $this->getJson('/api/users');
+
+        $response->assertOk();
+
+        /** @var array<string, mixed> $record */
+        $record = $response->json('data.0');
+
+        foreach (['id', '_type', 'name', 'email'] as $field) {
+            self::assertArrayHasKey($field, $record);
+        }
+
+        foreach (['status', 'created_at', 'updated_at', 'full_label', 'display_label', 'organization', 'posts', 'counts', 'sums', 'averages'] as $field) {
+            self::assertArrayNotHasKey($field, $record);
+        }
+    }
+
+    /**
+     * Test that computed and accessor fields surface with their closure output.
+     *
+     * @return void
+     */
+    public function testComputedAndAccessorFieldsSurface(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields' => ['users' => 'full_label,display_label'],
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0.full_label', 'Alice <alice@example.com>');
+        $response->assertJsonPath('data.0.display_label', 'Alice <alice@example.com>');
+    }
+
+    /**
+     * Test that an undeclared requested field is silently dropped rather than
+     * rejected with an error envelope.
+     *
+     * @return void
+     */
+    public function testUndeclaredFieldIsSilentlyDropped(): void
+    {
+        $response = $this->getJson('/api/users?' . http_build_query([
+            'fields' => ['users' => 'name,not_a_real_field'],
+        ]));
+
+        $response->assertOk();
+
+        /** @var array<string, mixed> $record */
+        $record = $response->json('data.0');
+
+        self::assertArrayHasKey('name', $record);
+        self::assertArrayHasKey('id', $record);
+        self::assertArrayHasKey('_type', $record);
+        self::assertArrayNotHasKey('not_a_real_field', $record);
+        self::assertArrayNotHasKey('email', $record);
+        self::assertNull($response->json('error'));
+    }
+}

--- a/tests/Feature/ThrottlePerCallerKeyingTest.php
+++ b/tests/Feature/ThrottlePerCallerKeyingTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\Exceptions\ApiExceptionHandler;
+use SineMacula\ApiToolkit\Http\Middleware\Concerns\ThrottleRequestsTrait;
+use SineMacula\ApiToolkit\Http\Middleware\ThrottleRequests;
+use Tests\Concerns\RegistersApiExceptionHandler;
+use Tests\Fixtures\Models\User;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the per-caller throttle keying through the HTTP kernel.
+ *
+ * Drives a rate-limited route with several distinct callers to prove the
+ * signature the throttle trait builds gives every caller its own bucket: an
+ * authenticated caller exhausting its limit and receiving a 429 must not
+ * consume the allowance of a second authenticated caller (keyed by a different
+ * user identifier) or of a guest (keyed by the client IP).
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ThrottleRequests::class)]
+#[CoversClass(ApiExceptionHandler::class)]
+#[CoversTrait(ThrottleRequestsTrait::class)]
+final class ThrottlePerCallerKeyingTest extends TestCase
+{
+    use RegistersApiExceptionHandler;
+
+    /**
+     * Set up each test with a route limited to a single request per caller.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerApiExceptionHandler();
+
+        Route::middleware(ThrottleRequests::class . ':1,1')->get('/api/ping', static fn (): array => ['ok' => true]);
+    }
+
+    /**
+     * Test that an authenticated caller exhausting its bucket does not throttle
+     * a second authenticated caller or a guest.
+     *
+     * @return void
+     */
+    public function testAuthenticatedThrottleDoesNotAffectOtherCallers(): void
+    {
+        $userOne = User::create(['name' => 'One', 'email' => 'one@example.com']);
+        $userTwo = User::create(['name' => 'Two', 'email' => 'two@example.com']);
+
+        // The first caller exhausts its own single-request bucket.
+        $this->actingAs($userOne);
+        $this->getJson('/api/ping')->assertOk();
+        $this->getJson('/api/ping')->assertStatus(429);
+
+        // A second authenticated caller is keyed by a different identifier and
+        // still has its full allowance.
+        $this->actingAs($userTwo);
+        $this->getJson('/api/ping')->assertOk();
+
+        // A guest is keyed by the client IP rather than a user identifier, so
+        // it is unaffected by the first caller's exhausted bucket.
+        Auth::forgetGuards();
+
+        $this->getJson('/api/ping')->assertOk();
+    }
+}

--- a/tests/Feature/ThrottleTest.php
+++ b/tests/Feature/ThrottleTest.php
@@ -64,4 +64,43 @@ final class ThrottleTest extends TestCase
         $response->assertJsonPath('error.code', 10107);
         $response->assertHeader('Retry-After');
     }
+
+    /**
+     * Test that an allowed response carries the rate-limit headers and the
+     * remaining count decrements across successive successful requests.
+     *
+     * @return void
+     */
+    public function testAllowedResponseCarriesRateLimitHeaders(): void
+    {
+        Route::middleware(ThrottleRequests::class . ':2,1')->get('/api/multi', static fn (): array => ['ok' => true]);
+
+        $first = $this->getJson('/api/multi');
+
+        $first->assertOk();
+        $first->assertHeader('X-RateLimit-Limit', 2);
+        $first->assertHeader('X-RateLimit-Remaining', 1);
+
+        $second = $this->getJson('/api/multi');
+
+        $second->assertOk();
+        $second->assertHeader('X-RateLimit-Limit', 2);
+        $second->assertHeader('X-RateLimit-Remaining', 0);
+    }
+
+    /**
+     * Test that the throttled response carries the retry and reset headers.
+     *
+     * @return void
+     */
+    public function testThrottledResponseCarriesRetryAndResetHeaders(): void
+    {
+        $this->getJson('/api/ping')->assertOk();
+
+        $response = $this->getJson('/api/ping');
+
+        $response->assertStatus(429);
+        $response->assertHeader('Retry-After');
+        $response->assertHeader('X-RateLimit-Reset');
+    }
 }

--- a/tests/Feature/WithoutCacheBypassTest.php
+++ b/tests/Feature/WithoutCacheBypassTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Middleware\ParseApiQuery;
+use SineMacula\ApiToolkit\Http\Resources\ApiResourceCollection;
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\CacheableUserRepository;
+use Tests\Fixtures\Resources\FilterableUserResource;
+use Tests\TestCase;
+
+/**
+ * Feature test proving a route calling withoutCache() bypasses the warm cache
+ * and re-queries the database.
+ *
+ * With the per-query cache warmed and a row inserted out of band (which does
+ * not pass through the repository's write invalidation), the cached route still
+ * serves the stale collection while the withoutCache() route issues a fresh
+ * query and reflects the new row.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiRepository::class)]
+#[CoversClass(ApiResourceCollection::class)]
+final class WithoutCacheBypassTest extends TestCase
+{
+    /**
+     * Set up each test with a cached route and a cache-bypassing route.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+
+        Route::middleware(ParseApiQuery::class)->get('/api/cached-users', function (CacheableUserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->usingResource(FilterableUserResource::class)->withApiCriteria()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        Route::middleware(ParseApiQuery::class)->get('/api/fresh-users', function (CacheableUserRepository $repository): ApiResourceCollection {
+
+            $users = $repository->withoutCache()->usingResource(FilterableUserResource::class)->withApiCriteria()->get(); // @phpstan-ignore staticMethod.dynamicCall
+
+            return new ApiResourceCollection($users, FilterableUserResource::class);
+        });
+
+        User::create(['name' => 'Alice', 'email' => 'alice@example.com']);
+        User::create(['name' => 'Bob', 'email' => 'bob@example.com']);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that withoutCache() re-queries and reflects an out-of-band write the
+     * warm cache would otherwise hide.
+     *
+     * @return void
+     */
+    public function testWithoutCacheReQueriesAndReflectsFreshRow(): void
+    {
+        // Warm the per-query cache: two rows.
+        $this->getJson('/api/cached-users')->assertOk()->assertJsonCount(2, 'data');
+
+        // Insert out of band, bypassing the repository's write invalidation.
+        User::create(['name' => 'Carol', 'email' => 'carol@example.com']);
+
+        // The cached route still serves the stale two-row collection.
+        $this->getJson('/api/cached-users')->assertOk()->assertJsonCount(2, 'data');
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        // withoutCache() issues a fresh query and reflects the new row.
+        $fresh = $this->getJson('/api/fresh-users');
+
+        $fresh->assertOk();
+        $fresh->assertJsonCount(3, 'data');
+        self::assertNotCount(0, DB::getQueryLog());
+        self::assertContains('carol@example.com', $fresh->json('data.*.email'));
+    }
+}

--- a/tests/Fixtures/Actors/ActorUser.php
+++ b/tests/Fixtures/Actors/ActorUser.php
@@ -6,17 +6,21 @@ namespace Tests\Fixtures\Actors;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Minimal Eloquent + Authenticatable fixture for EloquentActor tests.
  *
  * Backed by the `users` table created in the base TestCase. Named (not
- * anonymous) so PHP can serialise it during queue round-trip tests.
+ * anonymous) so PHP can serialise it during queue round-trip tests. The
+ * is_admin accessor lets an authenticated-user-keyed guard read a simple admin
+ * predicate when this fixture is the actingAs() subject.
  *
  * @property int $id
  * @property string $name
  * @property string $email
+ * @property bool $is_admin
  *
  * @method static static create(array<string, mixed> $attributes = [])
  *
@@ -32,4 +36,20 @@ final class ActorUser extends Model implements AuthenticatableContract
 
     /** @var array<int, string> */
     protected $fillable = ['name', 'email', 'password'];
+
+    /**
+     * Determine whether the actor is an admin.
+     *
+     * A fixture-only predicate: an actor is treated as an admin when its email
+     * begins with "admin@", so an authenticated-user-keyed guard can toggle
+     * without a dedicated column.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    public function isAdmin(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): bool => str_starts_with($this->email, 'admin@'),
+        );
+    }
 }

--- a/tests/Fixtures/Console/DeferUsersCommand.php
+++ b/tests/Fixtures/Console/DeferUsersCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Console;
+
+use Illuminate\Console\Command;
+use Tests\Fixtures\Repositories\DeferrableUserRepository;
+
+/**
+ * Fixture command that defers user rows through a deferrable repository.
+ *
+ * The rows are buffered in the scoped write pool during handle() and are only
+ * persisted when the framework fires the command-finished boundary, so a real
+ * Artisan run can prove the boundary flush without any manual event dispatch.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class DeferUsersCommand extends Command
+{
+    /** @var string The console command signature. */
+    protected $signature = 'fixtures:defer-users {--count=2 : The number of user rows to defer}';
+
+    /** @var string The console command description. */
+    protected $description = 'Defer a number of user rows through the deferrable repository';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Tests\Fixtures\Repositories\DeferrableUserRepository  $repository
+     * @return int
+     */
+    public function handle(DeferrableUserRepository $repository): int
+    {
+        $count = (int) $this->option('count');
+
+        for ($index = 1; $index <= $count; $index++) {
+            $repository->defer([
+                'name'  => 'Deferred ' . $index,
+                'email' => 'deferred-' . $index . '@console.test',
+            ]);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Fixtures/Models/Log.php
+++ b/tests/Fixtures/Models/Log.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Fixture log model backed by the JSON-column logs table.
+ *
+ * The `context` column is a JSON payload cast to an array, giving a filterable
+ * JSON column for the `$contains` containment operator. The primary key is a
+ * string UUID generated on create, and the table carries only a `created_at`
+ * timestamp, so automatic timestamps are disabled.
+ *
+ * @property string $id
+ * @property string $level
+ * @property string $message
+ * @property array<string, mixed>|null $context
+ *
+ * @method static static create(array<string, mixed> $attributes = [])
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class Log extends Model
+{
+    use HasUuids;
+
+    /** @var bool */
+    public $incrementing = false;
+
+    /** @var bool */
+    public $timestamps = false;
+
+    /** @var string|null */
+    protected $table = 'logs';
+
+    /** @var string */
+    protected $keyType = 'string';
+
+    /** @var array<int, string> */
+    protected $fillable = ['level', 'message', 'context', 'created_at'];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'context' => 'array',
+        ];
+    }
+}

--- a/tests/Fixtures/Models/User.php
+++ b/tests/Fixtures/Models/User.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Tests\Fixtures\Models;
 
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,12 +16,17 @@ use Tests\Fixtures\Enums\UserStatus;
 /**
  * Fixture user model.
  *
+ * Implements Authenticatable so tests can drive it through actingAs(). The
+ * is_admin accessor lets an authenticated-user-keyed field guard read a simple
+ * admin predicate without a dedicated column.
+ *
  * @property int $id
  * @property int|null $organization_id
  * @property string $name
  * @property string $email
  * @property string|null $password
  * @property string $status
+ * @property bool $is_admin
  * @property \Tests\Fixtures\Models\Organization|null $organization
  *
  * @formatter:off
@@ -36,8 +43,10 @@ use Tests\Fixtures\Enums\UserStatus;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class User extends Model
+final class User extends Model implements AuthenticatableContract
 {
+    use Authenticatable;
+
     /** @var string|null */
     protected $table = 'users';
 
@@ -83,6 +92,22 @@ final class User extends Model
     {
         return Attribute::make(
             get: fn () => $this->name . ' <' . $this->email . '>',
+        );
+    }
+
+    /**
+     * Determine whether the user is an admin.
+     *
+     * A fixture-only predicate: a user is treated as an admin when its email
+     * begins with "admin@", so an authenticated-user-keyed guard can toggle
+     * without a dedicated column.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    public function isAdmin(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): bool => str_starts_with($this->email, 'admin@'),
         );
     }
 

--- a/tests/Fixtures/Repositories/CacheableUserRepository.php
+++ b/tests/Fixtures/Repositories/CacheableUserRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Repositories;
+
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\Repositories\Concerns\Cacheable;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture cacheable user repository.
+ *
+ * Mirrors CacheableTagRepository but over the User model, so per-query caching
+ * can be exercised across the HTTP surface for users.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @extends \SineMacula\ApiToolkit\Repositories\ApiRepository<\Tests\Fixtures\Models\User>
+ */
+final class CacheableUserRepository extends ApiRepository
+{
+    use Cacheable;
+
+    /**
+     * Return the model class.
+     *
+     * @return class-string<\Tests\Fixtures\Models\User>
+     */
+    #[\Override]
+    public function model(): string
+    {
+        return User::class;
+    }
+}

--- a/tests/Fixtures/Repositories/LogRepository.php
+++ b/tests/Fixtures/Repositories/LogRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Repositories;
+
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use Tests\Fixtures\Models\Log;
+
+/**
+ * Fixture log repository backing the JSON-column containment tests.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @extends \SineMacula\ApiToolkit\Repositories\ApiRepository<\Tests\Fixtures\Models\Log>
+ */
+final class LogRepository extends ApiRepository
+{
+    /**
+     * Return the model class.
+     *
+     * @return class-string<\Tests\Fixtures\Models\Log>
+     */
+    #[\Override]
+    public function model(): string
+    {
+        return Log::class;
+    }
+}

--- a/tests/Fixtures/Repositories/ReferenceCacheUserRepository.php
+++ b/tests/Fixtures/Repositories/ReferenceCacheUserRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Repositories;
+
+use SineMacula\ApiToolkit\Repositories\ApiRepository;
+use SineMacula\Repositories\Concerns\Cacheable;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture cacheable user repository operating in whole-table reference mode.
+ *
+ * Opts into the whole-table reference cache so a repeat read serves the
+ * snapshot with zero queries, while a criteria-composed read falls through
+ * to the database.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @extends \SineMacula\ApiToolkit\Repositories\ApiRepository<\Tests\Fixtures\Models\User>
+ */
+final class ReferenceCacheUserRepository extends ApiRepository
+{
+    use Cacheable;
+
+    /** @var bool Serve the whole table from a single cached snapshot */
+    protected bool $cacheReferenceTable = true;
+
+    /**
+     * Return the model class.
+     *
+     * @return class-string<\Tests\Fixtures\Models\User>
+     */
+    #[\Override]
+    public function model(): string
+    {
+        return User::class;
+    }
+}

--- a/tests/Fixtures/Resources/AuthUserGuardedUserResource.php
+++ b/tests/Fixtures/Resources/AuthUserGuardedUserResource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+
+/**
+ * Fixture user resource whose email field is guarded on the authenticated user.
+ *
+ * The email guard reads the request's authenticated user and reveals the
+ * field only when that user is an admin. The is_admin accessor on the User
+ * and ActorUser fixtures resolves to true when the authenticated user's email
+ * begins with "admin@", so the field is absent for a guest and present only
+ * under actingAs() of an admin user.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class AuthUserGuardedUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'auth_user_guarded_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name'),
+            Field::scalar('email')->guard(static fn ($resource, $request): bool => data_get($request?->user(), 'is_admin') === true),
+        );
+    }
+}

--- a/tests/Fixtures/Resources/LogResource.php
+++ b/tests/Fixtures/Resources/LogResource.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+
+/**
+ * Fixture log resource exposing a filterable JSON column.
+ *
+ * The `context` field maps to the JSON `context` column and is declared
+ * filterable so the `$contains` containment operator can be driven over HTTP.
+ * SQLite's grammar rejects `whereJsonContains`, so tests exercising `$contains`
+ * against this resource must run under MySQL or PostgreSQL.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class LogResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'logs';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'level', 'message', 'context'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('level')->filterable()->sortable(),
+            Field::scalar('message'),
+            Field::scalar('context')->filterable(),
+            Field::timestamp('created_at'),
+        );
+    }
+}

--- a/tests/Fixtures/Resources/NullableFilterableUserResource.php
+++ b/tests/Fixtures/Resources/NullableFilterableUserResource.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+
+/**
+ * Fixture user resource exposing a nullable filterable column.
+ *
+ * The `organization_id` column is nullable on the users table and is declared
+ * filterable here so the `$null` / `$notNull` operators can be exercised under
+ * the allowlist posture. The scalar fields alongside it give a stable set to
+ * assert the narrowed rows against.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class NullableFilterableUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'nullable_filterable_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email', 'organization_id'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id')->filterable()->sortable(),
+            Field::scalar('name')->filterable(),
+            Field::scalar('email')->filterable(),
+            Field::scalar('organization_id')->filterable(),
+            Field::scalar('status'),
+        );
+    }
+}

--- a/tests/Fixtures/Resources/PerItemGuardedUserResource.php
+++ b/tests/Fixtures/Resources/PerItemGuardedUserResource.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Resources;
+
+use SineMacula\ApiToolkit\Http\Resources\ApiResource;
+use SineMacula\ApiToolkit\Schema\Field;
+use Tests\Fixtures\Enums\UserStatus;
+use Tests\Fixtures\Models\User;
+
+/**
+ * Fixture user resource whose email field is guarded per row.
+ *
+ * The email guard reads the row being rendered and reveals the field only
+ * when that user's status is active. Driven as a plain JSON collection, a
+ * two-row set (one active, one inactive) therefore carries email on the
+ * active row and omits it on the inactive row within the same body.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class PerItemGuardedUserResource extends ApiResource
+{
+    /** @var string */
+    public const string RESOURCE_TYPE = 'per_item_guarded_users';
+
+    /** @var array<int, string> */
+    protected static array $default = ['id', 'name', 'email'];
+
+    /**
+     * Return the resource schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
+    public static function schema(): array
+    {
+        return Field::set(
+            Field::scalar('id'),
+            Field::scalar('name'),
+            Field::scalar('email')->guard(static function ($resource): bool {
+
+                $model = $resource->resource;
+
+                if (!$model instanceof User) {
+                    return false;
+                }
+
+                // status casts to the UserStatus enum, so read the cast value.
+                return $model->getAttributeValue('status') === UserStatus::ACTIVE;
+            }),
+        );
+    }
+}

--- a/tests/Fixtures/Services/AuthorizingService.php
+++ b/tests/Fixtures/Services/AuthorizingService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Services;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use SineMacula\ApiToolkit\Services\Contracts\ServiceInput;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Service;
+
+/**
+ * Fixture service whose authorization hook always denies.
+ *
+ * The authorize() hook runs before the lock and transaction and throws an
+ * AuthorizationException, which the runner captures as a failure so handle()
+ * never runs. Over HTTP, run()->throw() rethrows it and the exception handler
+ * renders the forbidden envelope.
+ *
+ * @extends \SineMacula\ApiToolkit\Services\Service<\SineMacula\ApiToolkit\Services\Input\ArrayInput, true>
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class AuthorizingService extends Service
+{
+    /**
+     * Constructor.
+     *
+     * @param  \SineMacula\ApiToolkit\Services\Contracts\ServiceInput  $input
+     */
+    public function __construct(ServiceInput $input = new ArrayInput([]))
+    {
+        parent::__construct($input);
+    }
+
+    /**
+     * Deny the current actor.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    #[\Override]
+    protected function authorize(): void
+    {
+        throw new AuthorizationException('The actor is not authorized to perform this action.');
+    }
+
+    /**
+     * Handles the main execution of the service.
+     *
+     * @return true
+     */
+    #[\Override]
+    protected function handle(): mixed
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Services/InsertThenFailService.php
+++ b/tests/Fixtures/Services/InsertThenFailService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixtures\Services;
+
+use Illuminate\Support\Facades\DB;
+use SineMacula\ApiToolkit\Services\Contracts\ServiceInput;
+use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Service;
+
+/**
+ * Fixture service that inserts a row inside the transaction and then throws.
+ *
+ * handle() writes a users row and then raises, so the transactional lifecycle
+ * must roll the insert back. Over HTTP, run()->throw() surfaces the failure as
+ * a 500 envelope while the row stays absent, proving the rollback and the
+ * rendered error together.
+ *
+ * @extends \SineMacula\ApiToolkit\Services\Service<\SineMacula\ApiToolkit\Services\Input\ArrayInput, never>
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ */
+final class InsertThenFailService extends Service
+{
+    /**
+     * Constructor.
+     *
+     * @param  \SineMacula\ApiToolkit\Services\Contracts\ServiceInput  $input
+     */
+    public function __construct(ServiceInput $input = new ArrayInput([]))
+    {
+        parent::__construct($input);
+    }
+
+    /**
+     * Insert a users row inside the transaction, then fail.
+     *
+     * @return never
+     *
+     * @throws \RuntimeException
+     */
+    #[\Override]
+    protected function handle(): never
+    {
+        DB::table('users')->insert([
+            'name'  => 'Rolled Back',
+            'email' => 'rolled-back@insert-then-fail.test',
+        ]);
+
+        throw new \RuntimeException('Service handle failed after inserting a row.');
+    }
+}

--- a/tests/Integration/OctaneBoundaryFlushTest.php
+++ b/tests/Integration/OctaneBoundaryFlushTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Octane\Contracts\OperationTerminated;
+use Laravel\Octane\Events\RequestTerminated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
+use SineMacula\ApiToolkit\Providers\Registrars\LifecycleRegistrar;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
+use Tests\TestCase;
+
+/**
+ * End-to-end proof that the wired OperationTerminated event flushes toolkit
+ * metadata.
+ *
+ * Every other Octane-flush test invokes the listener via a hand-built handle()
+ * call. This file dispatches the real OperationTerminated event through the
+ * container's dispatcher under the shipped default config, proving that the
+ * boot-time listener wiring - not just the listener in isolation - clears the
+ * toolkit metadata memo while a non-toolkit key on the shared store survives.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(CacheManager::class)]
+#[CoversClass(LifecycleRegistrar::class)]
+#[CoversClass(MetadataCacheWriter::class)]
+#[CoversClass(OctaneFlushListener::class)]
+#[CoversClass(RuntimeContext::class)]
+final class OctaneBoundaryFlushTest extends TestCase
+{
+    /** @var bool Whether LARAVEL_OCTANE was set before each test. */
+    private bool $octaneWasSet;
+
+    /**
+     * Capture the initial LARAVEL_OCTANE server state.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore the LARAVEL_OCTANE server variable after each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        } else {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that dispatching the real OperationTerminated event through the
+     * wired dispatcher flushes toolkit metadata while a non-toolkit key
+     * survives.
+     *
+     * The boot-time wiring subscribes the OctaneFlushListener under the shipped
+     * default config. Dispatching the genuine event - rather than calling
+     * handle() directly - proves the registration binds the correct event to
+     * the correct listener, clearing the toolkit key while leaving a
+     * non-toolkit key on the shared memo store untouched.
+     *
+     * @return void
+     */
+    public function testDispatchingOperationTerminatedFlushesToolkitMetadata(): void
+    {
+        // The shipped default engages the Octane lifecycle flush, so the
+        // listener must already be wired at boot.
+        self::assertTrue((bool) config('api-toolkit.lifecycle.octane'));
+        self::assertTrue($this->events()->hasListeners(OperationTerminated::class));
+
+        // Simulate a serving Octane worker so the runtime gate opens.
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        $toolkitKey    = 'integration:octane-boundary-toolkit';
+        $nonToolkitKey = 'app:octane-boundary-keep';
+
+        $this->writer()->rememberMetadataForever($toolkitKey, static fn () => 'toolkit-value');
+        Cache::memo()->rememberForever($nonToolkitKey, static fn () => 'keep-me'); // @phpstan-ignore method.notFound
+
+        self::assertSame('toolkit-value', Cache::memo()->get($toolkitKey)); // @phpstan-ignore method.notFound
+        self::assertSame('keep-me', Cache::memo()->get($nonToolkitKey)); // @phpstan-ignore method.notFound
+
+        // Act: dispatch the real event through the wired dispatcher.
+        $this->events()->dispatch($this->operationTerminated());
+
+        // Assert: the toolkit key is flushed; the non-toolkit key survives.
+        self::assertNull(Cache::memo()->get($toolkitKey)); // @phpstan-ignore method.notFound
+        self::assertSame('keep-me', Cache::memo()->get($nonToolkitKey)); // @phpstan-ignore method.notFound
+    }
+
+    /**
+     * Build a genuine OperationTerminated event for the current application.
+     *
+     * @return \Laravel\Octane\Contracts\OperationTerminated
+     */
+    private function operationTerminated(): OperationTerminated
+    {
+        assert($this->app !== null);
+
+        return new RequestTerminated(
+            $this->app,
+            $this->app,
+            Request::create('/'),
+            new Response,
+        );
+    }
+
+    /**
+     * Resolve the wired MetadataCacheWriter singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+     */
+    private function writer(): MetadataCacheWriter
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataCacheWriter */
+        return $this->app->make(MetadataCacheWriter::class);
+    }
+
+    /**
+     * Resolve the event dispatcher.
+     *
+     * @return \Illuminate\Contracts\Events\Dispatcher
+     */
+    private function events(): Dispatcher
+    {
+        assert($this->app !== null);
+
+        /** @var \Illuminate\Contracts\Events\Dispatcher */
+        return $this->app->make('events');
+    }
+}

--- a/tests/Integration/OctaneRequestIsolationTest.php
+++ b/tests/Integration/OctaneRequestIsolationTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Integration;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use SineMacula\ApiToolkit\ApiQueryParser;
+use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
+use SineMacula\ApiToolkit\Listeners\OctaneFlushListener;
+use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
+use SineMacula\ApiToolkit\Repositories\Concerns\Deferrable;
+use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
+use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
+use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Repositories\DeferrableUserRepository;
+use Tests\TestCase;
+
+/**
+ * Cross-request state isolation for the long-running Octane runtime.
+ *
+ * Proves that request-scoped toolkit state does not leak between simulated
+ * Octane requests: the scoped ApiQueryParser and WritePool bindings each yield
+ * a fresh instance once the per-operation container reset runs, while
+ * schema-level singletons (the operator registry and the morph map) survive the
+ * boundary that only flushes per-request metadata. A binding regressing to
+ * singleton would leak request A's state into request B; an over-aggressive
+ * flush would drop the schema-level singletons.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ApiQueryParser::class)]
+#[CoversClass(CacheManager::class)]
+#[CoversClass(ContainerBindingRegistrar::class)]
+#[CoversClass(MetadataCacheWriter::class)]
+#[CoversClass(OctaneFlushListener::class)]
+#[CoversClass(OperatorRegistry::class)]
+#[CoversClass(RuntimeContext::class)]
+#[CoversClass(WritePool::class)]
+#[CoversTrait(Deferrable::class)]
+final class OctaneRequestIsolationTest extends TestCase
+{
+    /** @var bool Whether LARAVEL_OCTANE was set before each test. */
+    private bool $octaneWasSet;
+
+    /**
+     * Capture the initial LARAVEL_OCTANE server state.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->octaneWasSet = isset($_SERVER['LARAVEL_OCTANE']);
+    }
+
+    /**
+     * Restore the LARAVEL_OCTANE server variable after each test.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ($this->octaneWasSet) {
+            $_SERVER['LARAVEL_OCTANE'] = 1;
+        } else {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the scoped ApiQueryParser does not leak parsed state across the
+     * Octane per-operation boundary.
+     *
+     * Request A parses a query carrying filters, fields, order, and limit;
+     * after the container's scoped-instance reset, request B resolves a fresh
+     * parser whose getters all return their empty defaults, proving no residue
+     * from request A survives.
+     *
+     * @return void
+     */
+    public function testApiQueryParserScopedStateDoesNotLeakAcrossRequests(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        $app = $this->app;
+
+        assert($app !== null);
+
+        $alias = config('api-toolkit.parser.alias');
+
+        // Request A: parse a fully-populated query string.
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parserA */
+        $parserA = $app->make($alias);
+        $parserA->parse($this->request(
+            '/api/users?filters=' . urlencode('{"name":"Alice"}')
+            . '&fields[users]=name&order=name:desc&limit=5',
+        ));
+
+        self::assertSame(['name' => 'Alice'], $parserA->getFilters());
+        self::assertSame(['name'], $parserA->getFields('users'));
+        self::assertSame(['name' => 'desc'], $parserA->getOrder());
+        self::assertSame(5, $parserA->getLimit());
+
+        // Boundary: Octane resets scoped instances between operations.
+        $app->forgetScopedInstances();
+
+        // Request B: a fresh instance with no query params.
+        /** @var \SineMacula\ApiToolkit\ApiQueryParser $parserB */
+        $parserB = $app->make($alias);
+        $parserB->parse($this->request('/api/users'));
+
+        self::assertNotSame($parserA, $parserB);
+        self::assertSame([], $parserB->getFilters());
+        self::assertNull($parserB->getFields('users'));
+        self::assertSame([], $parserB->getOrder());
+        self::assertNull($parserB->getLimit());
+    }
+
+    /**
+     * Test that buffered deferred writes do not leak over the Octane boundary.
+     *
+     * Request A defers a row so the scoped WritePool holds a non-empty buffer.
+     * After the boundary flush persists it and the container resets scoped
+     * instances, request B resolves a fresh, empty pool that carries none of
+     * request A's records, and a request-B deferral flushes only request B's
+     * row.
+     *
+     * @return void
+     */
+    public function testWritePoolBufferedWritesDoNotLeakAcrossRequests(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        $app = $this->app;
+
+        assert($app !== null);
+
+        // Request A: defer a row through the Deferrable repository.
+        /** @var \Tests\Fixtures\Repositories\DeferrableUserRepository $repositoryA */
+        $repositoryA = $app->make(DeferrableUserRepository::class);
+        $repositoryA->defer(['name' => 'Alice', 'email' => 'alice@example.com']);
+
+        /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePool $poolA */
+        $poolA = $app->make(WritePool::class);
+
+        self::assertFalse($poolA->isEmpty());
+        self::assertSame(1, $poolA->count());
+
+        // Boundary: flush the buffer (RequestHandled) then reset scoped
+        // instances the way Octane does per operation.
+        $poolA->flush();
+        $app->forgetScopedInstances();
+
+        self::assertSame(1, DB::table('users')->count());
+
+        // Request B: a fresh, empty pool with none of request A's records.
+        /** @var \SineMacula\ApiToolkit\Repositories\Concerns\WritePool $poolB */
+        $poolB = $app->make(WritePool::class);
+
+        self::assertNotSame($poolA, $poolB);
+        self::assertTrue($poolB->isEmpty());
+        self::assertSame(0, $poolB->count());
+
+        // A request-B deferral flushes only request B's row.
+        /** @var \Tests\Fixtures\Repositories\DeferrableUserRepository $repositoryB */
+        $repositoryB = $app->make(DeferrableUserRepository::class);
+        $repositoryB->defer(['name' => 'Bob', 'email' => 'bob@example.com']);
+
+        self::assertSame(1, $poolB->count());
+
+        $poolB->flush();
+
+        self::assertSame(2, DB::table('users')->count());
+        self::assertSame(1, DB::table('users')->where('name', 'Alice')->count());
+        self::assertSame(1, DB::table('users')->where('name', 'Bob')->count());
+    }
+
+    /**
+     * Test that schema-level singletons survive the Octane request boundary
+     * while per-request metadata is flushed.
+     *
+     * A custom operator registered on the singleton registry and a morph-map
+     * binding are both schema-level state that must outlive the per-request
+     * flush; a memoised toolkit metadata key must not. Firing the boundary
+     * clears the metadata but leaves the operator and the morph map intact,
+     * proving the flush is scoped to per-request caches.
+     *
+     * @return void
+     */
+    public function testSchemaLevelSingletonsSurviveBoundaryWhileMetadataIsFlushed(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = 1;
+
+        $app = $this->app;
+
+        assert($app !== null);
+
+        Event::fake();
+
+        // Schema-level state established at boot.
+        /** @var \SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry $registry */
+        $registry = $app->make(OperatorRegistry::class);
+        $registry->register('$starts', $registry->resolve('$like'));
+
+        Relation::morphMap(['users' => User::class]);
+
+        // Per-request metadata memoised through the writer.
+        $key = 'integration:octane-schema-survival';
+        $this->writer()->rememberMetadataForever($key, static fn () => 'value');
+
+        self::assertSame('value', Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Boundary: the Octane flush clears per-request metadata only.
+        $this->octaneListener()->handle(new \stdClass);
+
+        self::assertNull(Cache::memo()->get($key)); // @phpstan-ignore method.notFound
+
+        // Schema-level singletons survive: the custom operator and the morph
+        // map still resolve on the same singleton instances.
+        self::assertSame($registry, $app->make(OperatorRegistry::class));
+        self::assertTrue($registry->has('$starts'));
+        self::assertSame(User::class, Relation::getMorphedModel('users'));
+    }
+
+    /**
+     * Build a GET request for the given URI.
+     *
+     * @param  string  $uri
+     * @return \Illuminate\Http\Request
+     */
+    private function request(string $uri): Request
+    {
+        return Request::create($uri, 'GET');
+    }
+
+    /**
+     * Resolve the wired MetadataCacheWriter singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+     */
+    private function writer(): MetadataCacheWriter
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\MetadataCacheWriter */
+        return $this->app->make(MetadataCacheWriter::class);
+    }
+
+    /**
+     * Build an OctaneFlushListener backed by the wired CacheManager singleton.
+     *
+     * @return \SineMacula\ApiToolkit\Listeners\OctaneFlushListener
+     */
+    private function octaneListener(): OctaneFlushListener
+    {
+        assert($this->app !== null);
+
+        /** @var \SineMacula\ApiToolkit\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->make(CacheManager::class);
+
+        return new OctaneFlushListener($cacheManager, new RuntimeContext);
+    }
+}

--- a/tests/Integration/Providers/Registrars/ContainerBindingRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/ContainerBindingRegistrarTest.php
@@ -8,12 +8,19 @@ use Illuminate\Foundation\Application;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\ApiQueryParser;
 use SineMacula\ApiToolkit\Cache\CacheManager;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
 use SineMacula\ApiToolkit\Contracts\ResourceMetadataProvider;
 use SineMacula\ApiToolkit\Contracts\SchemaIntrospectionProvider;
+use SineMacula\ApiToolkit\OpenApi\Contracts\DocumentWriter;
+use SineMacula\ApiToolkit\OpenApi\Contracts\MetadataCatalogue;
+use SineMacula\ApiToolkit\OpenApi\Metadata\ConfigMetadataCatalogue;
+use SineMacula\ApiToolkit\OpenApi\Output\FilesystemDocumentWriter;
 use SineMacula\ApiToolkit\Providers\Registrars\ContainerBindingRegistrar;
 use SineMacula\ApiToolkit\Repositories\Concerns\WritePool;
 use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
+use SineMacula\ApiToolkit\Runtime\RuntimeContext;
 use SineMacula\ApiToolkit\Schema\Validation\SchemaValidator;
+use SineMacula\ApiToolkit\Services\ServiceRunner;
 use Tests\TestCase;
 
 /**
@@ -55,6 +62,66 @@ final class ContainerBindingRegistrarTest extends TestCase
         self::assertInstanceOf(SchemaValidator::class, $app->make(SchemaValidator::class));
         self::assertInstanceOf(WritePool::class, $app->make(WritePool::class));
         self::assertInstanceOf(CacheManager::class, $app->make(CacheManager::class));
+    }
+
+    /**
+     * Test that the OpenAPI exporter ports bind to their default adapters and
+     * the lifecycle collaborators bind as shared singletons.
+     *
+     * @return void
+     */
+    public function testRegisterBindsExporterPortsAndLifecycleSingletons(): void
+    {
+        $app = $this->getApplication();
+
+        (new ContainerBindingRegistrar($app))->register();
+
+        self::assertInstanceOf(ConfigMetadataCatalogue::class, $app->make(MetadataCatalogue::class));
+        self::assertInstanceOf(FilesystemDocumentWriter::class, $app->make(DocumentWriter::class));
+
+        self::assertSame($app->make(RuntimeContext::class), $app->make(RuntimeContext::class));
+        self::assertSame($app->make(MetadataCacheWriter::class), $app->make(MetadataCacheWriter::class));
+        self::assertSame($app->make(ServiceRunner::class), $app->make(ServiceRunner::class));
+    }
+
+    /**
+     * Test that the write pool is built with the configured values cast to int
+     * and the transactional flag defaulting to false when unconfigured.
+     *
+     * @return void
+     */
+    public function testRegisterBuildsWritePoolWithCastConfigAndDefaultTransactional(): void
+    {
+        $app = $this->getApplication();
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app->make('config');
+
+        $config->set('api-toolkit.deferred_writes', [
+            'chunk_size' => '700',
+            'pool_limit' => '900',
+            'on_failure' => 'collect',
+        ]);
+
+        (new ContainerBindingRegistrar($app))->register();
+
+        $pool = $app->make(WritePool::class);
+
+        self::assertSame(700, $this->readProperty($pool, 'chunkSize'));
+        self::assertSame(900, $this->readProperty($pool, 'poolLimit'));
+        self::assertFalse($this->readProperty($pool, 'transactional'));
+    }
+
+    /**
+     * Read a private property value from the given object via reflection.
+     *
+     * @param  object  $object
+     * @param  string  $property
+     * @return mixed
+     */
+    private function readProperty(object $object, string $property): mixed
+    {
+        return (new \ReflectionProperty($object, $property))->getValue($object);
     }
 
     /**

--- a/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
+++ b/tests/Integration/Providers/Registrars/LifecycleRegistrarTest.php
@@ -159,10 +159,12 @@ final class LifecycleRegistrarTest extends TestCase
         $config = $this->getApplication()->make('config');
         $config->set('api-toolkit.lifecycle.octane', false);
 
+        $expected = 'API Toolkit: serving under Octane but the lifecycle cache flush is disabled'
+            . ' (API_TOOLKIT_LIFECYCLE_OCTANE=false); cross-request metadata may go stale'
+            . ' and field-keyed metadata memos can grow unbounded per worker (memory tradeoff).';
+
         Log::shouldReceive('info')->once()->with(\Mockery::on(
-            fn (string $message): bool => str_contains($message, 'Octane')
-                && str_contains($message, 'API_TOOLKIT_LIFECYCLE_OCTANE')
-                && str_contains($message, 'unbounded'),
+            fn (string $message): bool => $message === $expected,
         ));
 
         (new LifecycleRegistrar)->register();

--- a/tests/Unit/ApiQueryParserTest.php
+++ b/tests/Unit/ApiQueryParserTest.php
@@ -429,6 +429,19 @@ final class ApiQueryParserTest extends TestCase
     }
 
     /**
+     * Test that getCursor coerces a non-string scalar into its string form
+     * rather than returning the raw scalar.
+     *
+     * @return void
+     */
+    public function testGetCursorCastsNonStringScalarToString(): void
+    {
+        $this->setProperty($this->parser, 'parameters', ['cursor' => 100]);
+
+        self::assertSame('100', $this->parser->getCursor());
+    }
+
+    /**
      * Test that validation fails for invalid page parameter.
      *
      * @return void

--- a/tests/Unit/Concerns/QueryParameterExtractorTest.php
+++ b/tests/Unit/Concerns/QueryParameterExtractorTest.php
@@ -264,6 +264,29 @@ final class QueryParameterExtractorTest extends TestCase
     }
 
     /**
+     * Test that extract retains every aggregation resource rather than
+     * truncating the parsed set.
+     *
+     * @return void
+     */
+    public function testExtractParsesEveryAggregationResource(): void
+    {
+        $request = Request::create(self::TEST_URL, HttpMethod::GET->getVerb(), [
+            'sums' => [
+                'account' => ['transaction' => 'amount'],
+                'user'    => ['posts' => 'votes'],
+            ],
+        ]);
+
+        $parameters = $this->extractor->extract($request);
+
+        self::assertSame([
+            'account' => ['transaction' => ['amount']],
+            'user'    => ['posts' => ['votes']],
+        ], $parameters['sums']);
+    }
+
+    /**
      * Test that extract decodes a JSON filter string.
      *
      * @return void

--- a/tests/Unit/Console/ExportOpenApiCommandTest.php
+++ b/tests/Unit/Console/ExportOpenApiCommandTest.php
@@ -6,9 +6,12 @@ namespace Tests\Unit\Console;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Testing\PendingCommand;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Console\ExportOpenApiCommand;
+use SineMacula\ApiToolkit\OpenApi\Contracts\DocumentWriter;
+use SineMacula\ApiToolkit\OpenApi\ExportOpenApiComponents;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use Tests\Fixtures\Models\Organization;
 use Tests\Fixtures\Models\User;
@@ -25,6 +28,7 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ExportOpenApiCommand::class)]
+#[CoversClass(ExportOpenApiComponents::class)]
 final class ExportOpenApiCommandTest extends TestCase
 {
     /** @var string The console command signature. */
@@ -160,6 +164,43 @@ final class ExportOpenApiCommandTest extends TestCase
         self::assertFileExists($default);
 
         @unlink($default);
+    }
+
+    /**
+     * Test that a document-write failure is surfaced as a non-zero outcome.
+     *
+     * The command has no try/catch around the write, so a failing writer port
+     * propagates its exception uncaught rather than reporting success.
+     *
+     * @return void
+     */
+    public function testCommandSurfacesDocumentWriteFailure(): void
+    {
+        $this->registerResourceMap();
+
+        assert($this->app instanceof Application);
+
+        $this->app->instance(DocumentWriter::class, new class implements DocumentWriter {
+            /**
+             * Persist the serialized document at the given path.
+             *
+             * @param  string  $path
+             * @param  string  $contents
+             * @return void
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            public function write(string $path, string $contents): void
+            {
+                throw new \RuntimeException('Unable to write the OpenAPI document.');
+            }
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write the OpenAPI document.');
+
+        Artisan::call(self::COMMAND, ['--output' => $this->outputPath]);
     }
 
     /**

--- a/tests/Unit/Console/ValidateSchemasCommandTest.php
+++ b/tests/Unit/Console/ValidateSchemasCommandTest.php
@@ -10,9 +10,12 @@ use Illuminate\Testing\PendingCommand;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Console\ValidateSchemasCommand;
 use SineMacula\ApiToolkit\Contracts\SchemaValidationRule;
+use SineMacula\ApiToolkit\Schema\SchemaCompiler;
+use SineMacula\ApiToolkit\Schema\Validation\Rules\ValidateRelationClasses;
 use SineMacula\ApiToolkit\Schema\Validation\SchemaValidationError;
 use SineMacula\ApiToolkit\Schema\Validation\SchemaValidator;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\BrokenResource;
 use Tests\Fixtures\Resources\UserResource;
 use Tests\TestCase;
 
@@ -25,6 +28,8 @@ use Tests\TestCase;
  * @internal
  */
 #[CoversClass(ValidateSchemasCommand::class)]
+#[CoversClass(SchemaValidator::class)]
+#[CoversClass(ValidateRelationClasses::class)]
 final class ValidateSchemasCommandTest extends TestCase
 {
     /** @var string The command signature. */
@@ -75,6 +80,27 @@ final class ValidateSchemasCommandTest extends TestCase
 
         $this->runCommand()
             ->expectsOutputToContain('Schema validation failed:')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * Test that the container-wired validator, exercised against a genuinely
+     * broken resource with no stub, drives the command's catch, format, and
+     * exit-one path using a real defect string from the shipped rule set.
+     *
+     * @return void
+     */
+    public function testCommandFailsWithRealValidatorAgainstBrokenResource(): void
+    {
+        SchemaCompiler::clearCache();
+
+        $this->getConfig()->set('api-toolkit.resources.resource_map', [
+            User::class => BrokenResource::class,
+        ]);
+
+        $this->runCommand()
+            ->expectsOutputToContain('Schema validation failed:')
+            ->expectsOutputToContain('does not exist')
             ->assertExitCode(1);
     }
 

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -358,6 +358,41 @@ final class ApiExceptionTest extends TestCase
     }
 
     /**
+     * Test that getCustomTitle returns the code-keyed title translation
+     * when one is registered, over the status-derived default title.
+     *
+     * @return void
+     */
+    public function testGetCustomTitleUsesCodeKeyedTranslationWhenPresent(): void
+    {
+        // Register a code-keyed title under a custom namespace whose value
+        // differs from the status-derived default (which would be "Bad
+        // Request"), so resolving through the translation branch is the oracle.
+        Lang::addLines(['exceptions.10100.title' => 'Bespoke Title'], 'en', 'code-keyed-title-ns');
+
+        $exception = new class extends ApiException {
+            /** The internal error code for the test exception. */
+            public const \SineMacula\ApiToolkit\Contracts\ErrorCodeInterface CODE = ErrorCode::BAD_REQUEST;
+
+            /** The mapped HTTP status for the test exception. */
+            public const HttpStatus HTTP_STATUS = HttpStatus::BAD_REQUEST;
+
+            /**
+             * Resolve translations from the custom namespace.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function getNamespace(): string
+            {
+                return 'code-keyed-title-ns';
+            }
+        };
+
+        self::assertSame('Bespoke Title', $exception->getCustomTitle());
+    }
+
+    /**
      * Test that getCustomTitle derives a multi-word title from the HTTP status
      * enum case name when no translation exists.
      *

--- a/tests/Unit/Exceptions/PerItemGuardedFieldExceptionTest.php
+++ b/tests/Unit/Exceptions/PerItemGuardedFieldExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Exceptions;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Exceptions\PerItemGuardedFieldException;
+
+/**
+ * Tests for the PerItemGuardedFieldException.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(PerItemGuardedFieldException::class)]
+final class PerItemGuardedFieldExceptionTest extends TestCase
+{
+    /**
+     * Test that forField builds the full guidance message verbatim, with the
+     * field and resource type interpolated and every sentence fragment in its
+     * intended order.
+     *
+     * @return void
+     */
+    public function testForFieldBuildsTheFullGuidanceMessage(): void
+    {
+        $exception = PerItemGuardedFieldException::forField('email', 'posts');
+
+        $expected = 'The "email" field on the "posts" resource carries a guard that depends on the row, '
+            . 'so it cannot be exported to a tabular format. A tabular export includes or '
+            . 'omits whole columns rather than individual cells, so a per-row guard cannot '
+            . 'be honoured without leaking the values it is meant to hide. Exclude the field '
+            . 'from the export, or override tabular() and gate the column with the exporter\'s '
+            . '->visible().';
+
+        self::assertSame($expected, $exception->getMessage());
+    }
+}

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -2234,6 +2234,33 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
+     * Test that resolve skips a field resolving to MissingValue and still
+     * resolves later fields in the list.
+     *
+     * @return void
+     */
+    public function testResolveContinuesPastMissingValueFields(): void
+    {
+        $user = User::create([
+            'name'  => 'MissingValueSkip',
+            'email' => 'missingvalueskip@example.com',
+        ]);
+
+        // The unloaded relation resolves to MissingValue and must be skipped
+        // without aborting resolution of the later 'name' field.
+        self::assertFalse($user->relationLoaded('organization'));
+
+        $resource = new UserResource($user);
+        $resource->withFields(['organization', 'name']);
+
+        $result = $resource->resolve();
+
+        self::assertArrayNotHasKey('organization', $result);
+        self::assertArrayHasKey('name', $result);
+        self::assertSame('MissingValueSkip', $result['name']);
+    }
+
+    /**
      * Test that the constructor does not eager load relations by default.
      *
      * @return void
@@ -2634,6 +2661,155 @@ final class ApiResourceTest extends TestCase
     }
 
     /**
+     * Test that load_missing does not load sum or average aggregates when the
+     * corresponding virtual fields are neither requested nor default, even
+     * though the aggregate definitions are themselves default.
+     *
+     * @return void
+     */
+    public function testLoadMissingSkipsAggregatesWhenVirtualFieldsNotRequested(): void
+    {
+        $this->clearSchemaCache();
+
+        $resourceClass = new class (null) extends ApiResource {
+            /** @var string */
+            public const string RESOURCE_TYPE = 'agg_gate_rt';
+
+            /** @var array<int, string> */
+            protected static array $default = ['id'];
+
+            /**
+             * Get the resource schema.
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            #[\Override]
+            public static function schema(): array
+            {
+                return [
+                    'id'               => [],
+                    '__sum__:posts_id' => [
+                        'metric'   => 'sum',
+                        'relation' => 'posts',
+                        'column'   => 'id',
+                        'default'  => true,
+                    ],
+                    '__avg__:posts_id' => [
+                        'metric'   => 'avg',
+                        'relation' => 'posts',
+                        'column'   => 'id',
+                        'default'  => true,
+                    ],
+                ];
+            }
+        };
+
+        $spy = new class {
+            /** @var array<int, array<int, mixed>> */
+            public array $sumCalls = [];
+
+            /** @var array<int, array<int, mixed>> */
+            public array $avgCalls = [];
+
+            /** @var array<string, mixed> */
+            private array $attributes = [];
+
+            /**
+             * Magic getter for attribute access.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+
+            /**
+             * Magic isset for attribute existence check.
+             *
+             * @param  string  $key
+             * @return bool
+             */
+            public function __isset(string $key): bool
+            {
+                return isset($this->attributes[$key]);
+            }
+
+            /**
+             * Return the attribute map.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * No-op for the eager-load relations path.
+             *
+             * @SuppressWarnings("php:S1172")
+             *
+             * @param  mixed  $with
+             * @return static
+             */
+            public function loadMissing(mixed $with): static
+            {
+                return $this;
+            }
+
+            /**
+             * No-op for the count-loading path.
+             *
+             * @SuppressWarnings("php:S1172")
+             *
+             * @param  mixed  $relations
+             * @return static
+             */
+            public function loadCount(mixed $relations): static
+            {
+                return $this;
+            }
+
+            /**
+             * Record a sum-loading call.
+             *
+             * @param  mixed  $relations
+             * @param  string  $column
+             * @return static
+             */
+            public function loadSum(mixed $relations, string $column): static
+            {
+                $this->sumCalls[] = [$relations, $column];
+
+                return $this;
+            }
+
+            /**
+             * Record an average-loading call.
+             *
+             * @param  mixed  $relations
+             * @param  string  $column
+             * @return static
+             */
+            public function loadAvg(mixed $relations, string $column): static
+            {
+                $this->avgCalls[] = [$relations, $column];
+
+                return $this;
+            }
+        };
+
+        new $resourceClass($spy, true);
+
+        static::assertSame([], $spy->sumCalls);
+        static::assertSame([], $spy->avgCalls);
+
+        $this->clearSchemaCache();
+    }
+
+    /**
      * Test that fields declared on the resource's fixed property are merged
      * with the config-driven fixed fields.
      *
@@ -2677,8 +2853,8 @@ final class ApiResourceTest extends TestCase
 
         $result = $resource->resolve();
 
-        self::assertArrayHasKey('email', $result, 'resource-level fixed fields must be included');
-        self::assertArrayHasKey('id', $result, 'config-level fixed fields must be included');
+        static::assertArrayHasKey('email', $result, 'resource-level fixed fields must be included');
+        static::assertArrayHasKey('id', $result, 'config-level fixed fields must be included');
     }
 
     /**
@@ -2707,11 +2883,11 @@ final class ApiResourceTest extends TestCase
 
         $values = array_values($result);
 
-        self::assertContains('comments as comments_count', $values);
-        self::assertArrayHasKey('tags as tags_count', $result);
-        self::assertContains(['relation' => 'authors as authors_sum_id', 'column' => 'id'], $values);
-        self::assertNotContains('posts as posts_count', $values);
-        self::assertNotContains(['relation' => 'posts as posts_sum_id', 'column' => 'id'], $values);
+        static::assertContains('comments as comments_count', $values);
+        static::assertArrayHasKey('tags as tags_count', $result);
+        static::assertContains(['relation' => 'authors as authors_sum_id', 'column' => 'id'], $values);
+        static::assertNotContains('posts as posts_count', $values);
+        static::assertNotContains(['relation' => 'posts as posts_sum_id', 'column' => 'id'], $values);
     }
 
     /**

--- a/tests/Unit/Http/Resources/Concerns/DerivedTabularSchemaTest.php
+++ b/tests/Unit/Http/Resources/Concerns/DerivedTabularSchemaTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\DerivedTabularSchema;
 use SineMacula\Exporter\Schema\Column;
+use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\TestCase;
 
 /**
@@ -21,6 +22,23 @@ use Tests\TestCase;
 #[CoversClass(DerivedTabularSchema::class)]
 final class DerivedTabularSchemaTest extends TestCase
 {
+    use InteractsWithNonPublicMembers;
+
+    /**
+     * Test that the constructor forwards the request to the parent schema, so
+     * the schema carries the exact request it was built for.
+     *
+     * @return void
+     */
+    public function testConstructorForwardsRequestToParentSchema(): void
+    {
+        $request = Request::create('/');
+
+        $schema = new DerivedTabularSchema($request, []);
+
+        self::assertSame($request, $this->getProperty($schema, 'request'));
+    }
+
     /**
      * Test that the schema returns the ordered columns it was built with.
      *

--- a/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
+++ b/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
@@ -251,6 +251,118 @@ final class DerivesTabularSchemaTest extends TestCase
     }
 
     /**
+     * Test that an active field selection narrows the columns to exactly the
+     * requested subset, intersected with the schema, and excludes the rest.
+     *
+     * @return void
+     */
+    public function testFieldSelectionLimitsColumnsToRequestedSubset(): void
+    {
+        $user    = new User(['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active']);
+        $request = Request::create('/?fields[guarded_exports]=name');
+
+        ApiQuery::parse($request);
+
+        $keys = array_map(
+            static fn (Column $column): string => $column->getKey(),
+            (new GuardedExportResource($user))->tabular($request)->columns(),
+        );
+
+        self::assertSame(['name'], $keys);
+    }
+
+    /**
+     * Test that a relation field encountered before a scalar field is skipped
+     * without abandoning the remaining fields, so the later scalar column is
+     * still built.
+     *
+     * @return void
+     */
+    public function testRelationFieldIsSkippedButLaterScalarStillIncluded(): void
+    {
+        $resource = new class (null) extends ApiResource implements ProvidesTabularExport {
+            use DerivesTabularSchema;
+
+            /** @var string */
+            public const string RESOURCE_TYPE = 'relation_before_scalar_export';
+
+            /** @var array<int, string> */
+            protected static array $default = ['related', 'flagged'];
+
+            /**
+             * Return a schema whose relation field precedes a scalar field.
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            #[\Override]
+            public static function schema(): array
+            {
+                return [
+                    'related' => [
+                        'relation' => 'related',
+                    ],
+                    'flagged' => [],
+                ];
+            }
+        };
+
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $columns = $resource->tabular($request)->columns();
+
+        self::assertCount(1, $columns);
+        self::assertSame('flagged', $columns[0]->getKey());
+    }
+
+    /**
+     * Test that a non-callable guard preceding a request-scoped guard
+     * that hides the field is skipped rather than ending the check early,
+     * so the hiding guard still drops the column.
+     *
+     * @return void
+     */
+    public function testNonCallableGuardBeforeHidingGuardStillHidesColumn(): void
+    {
+        $resource = new class (null) extends ApiResource implements ProvidesTabularExport {
+            use DerivesTabularSchema;
+
+            /** @var string */
+            public const string RESOURCE_TYPE = 'hiding_guard_after_non_callable_export';
+
+            /** @var array<int, string> */
+            protected static array $default = ['gated'];
+
+            /**
+             * Return a schema whose guard list holds a non-callable entry
+             * before a request-scoped guard that always hides the field.
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            #[\Override]
+            public static function schema(): array
+            {
+                return [
+                    'gated' => [
+                        'guards' => [123, static fn ($resource, $request): bool => false],
+                    ],
+                ];
+            }
+        };
+
+        $request = Request::create('/');
+
+        ApiQuery::parse($request);
+
+        $columns = $resource->tabular($request)->columns();
+
+        self::assertCount(1, $columns);
+        self::assertSame('gated', $columns[0]->getKey());
+        self::assertFalse($columns[0]->isVisible($request));
+    }
+
+    /**
      * Resolve the column with the given key from the guarded export schema.
      *
      * @param  string  $key

--- a/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
+++ b/tests/Unit/Http/Resources/Concerns/EagerLoadPlannerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Facades\ApiQuery;
 use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Http\Resources\Concerns\EagerLoadPlanner;
+use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
 use Tests\Concerns\InteractsWithNonPublicMembers;
 use Tests\Fixtures\Models\User;
@@ -1146,5 +1147,39 @@ final class EagerLoadPlannerTest extends TestCase
         $result = $this->invokeStaticMethod(EagerLoadPlanner::class, 'getRequestedChildFields', \stdClass::class);
 
         self::assertSame([], $result);
+    }
+
+    /**
+     * Test that explicit child fields are returned as a zero-indexed list with
+     * blank entries stripped, so a leading blank does not leave a gap in the
+     * keys and does not survive as an empty relation field.
+     *
+     * @return void
+     */
+    public function testResolveChildFieldsReturnsZeroIndexedListWithBlanksRemoved(): void
+    {
+        $definition = new CompiledFieldDefinition(null, null, null, null, ['', 'tags'], null, [], [], [], []);
+
+        $result = $this->invokeStaticMethod(EagerLoadPlanner::class, 'resolveChildFields', $definition, 'x');
+
+        self::assertSame(['tags'], $result);
+    }
+
+    /**
+     * Test that the requested child fields are returned as a zero-indexed list
+     * with blank entries stripped, so a leading blank does not leave a gap in
+     * the keys.
+     *
+     * @return void
+     */
+    public function testGetRequestedChildFieldsReturnsZeroIndexedListWithBlanksRemoved(): void
+    {
+        ApiQuery::shouldReceive('getFields')
+            ->with('users')
+            ->andReturn(['', 'name']);
+
+        $result = $this->invokeStaticMethod(EagerLoadPlanner::class, 'getRequestedChildFields', UserResource::class);
+
+        self::assertSame(['name'], $result);
     }
 }

--- a/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
+++ b/tests/Unit/Http/Resources/Concerns/ValueResolverTest.php
@@ -174,6 +174,47 @@ final class ValueResolverTest extends TestCase
     }
 
     /**
+     * Test that a method whose return type is a named type other than Attribute
+     * is not treated as a cast accessor, so the field resolves to MissingValue
+     * and the memo records the rejection.
+     *
+     * @return void
+     */
+    public function testComputeIsCastAccessorRejectsNonAttributeReturnType(): void
+    {
+
+        $model = new class {
+            /**
+             * A method whose return type is a named type other than Attribute.
+             *
+             * @return string
+             */
+            public function label(): string
+            {
+                return 'real';
+            }
+
+            /**
+             * Return the attributes array without the field.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return [];
+            }
+        };
+
+        $result = $this->resolver->resolveFieldValue('label', $this->makeFieldDefinition(), new JsonResource($model), null);
+
+        self::assertInstanceOf(MissingValue::class, $result);
+
+        $cache = $this->getStaticProperty(ValueResolver::class, 'castAccessorCache');
+
+        self::assertFalse($cache[$model::class]['label']);
+    }
+
+    /**
      * Test that the resolved child field set is memoised per compiled
      * definition.
      *
@@ -661,6 +702,42 @@ final class ValueResolverTest extends TestCase
         $result = $this->resolver->resolveFieldValue('organization', $definition, $resource, null);
 
         self::assertInstanceOf(OrganizationResource::class, $result);
+    }
+
+    /**
+     * Test that wrapping a single related model in a child resource that does
+     * not expose withFields does not attempt to call it, even when an explicit
+     * child field set is declared.
+     *
+     * @return void
+     */
+    public function testResolveFieldValueDoesNotCallWithFieldsOnChildResourceWithoutIt(): void
+    {
+        $organization = Organization::create([
+            'name' => 'NoWithFieldsOrg',
+            'slug' => 'no-withfields-org',
+        ]);
+
+        $user = User::create([
+            'name'            => 'NoWithFieldsUser',
+            'email'           => 'no-withfields-user@example.com',
+            'organization_id' => $organization->id,
+        ]);
+
+        $user->load('organization');
+
+        $resource   = new JsonResource($user);
+        $definition = $this->makeFieldDefinition(
+            relation: 'organization',
+            resource: JsonResource::class,
+            fields: ['name'],
+        );
+
+        self::assertFalse(method_exists(JsonResource::class, 'withFields'));
+
+        $result = $this->resolver->resolveFieldValue('organization', $definition, $resource, null);
+
+        self::assertInstanceOf(JsonResource::class, $result);
     }
 
     /**
@@ -1858,6 +1935,106 @@ final class ValueResolverTest extends TestCase
         $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
 
         self::assertSame([], $result);
+    }
+
+    /**
+     * Test that a count whose attribute is not loaded is skipped while a later
+     * count on the same payload is still resolved.
+     *
+     * @return void
+     */
+    public function testResolveCountsPayloadContinuesAfterNullValuedCount(): void
+    {
+
+        ApiQuery::shouldReceive('getCounts')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_count' => 4];
+
+            /**
+             * Return the attributes array carrying only the later count.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [
+            'missing' => new CompiledCountDefinition('missing', 'missing', null, true, []),
+            'posts'   => new CompiledCountDefinition('posts', 'posts', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveCountsPayload($resource, $schema, 'users', null);
+
+        self::assertSame(['posts' => 4], $result);
+    }
+
+    /**
+     * Test that an aggregate whose attribute is not loaded is skipped while a
+     * later aggregate on the same payload is still resolved.
+     *
+     * @return void
+     */
+    public function testResolveAggregatesPayloadContinuesAfterNullValuedAggregate(): void
+    {
+
+        ApiQuery::shouldReceive('getSums')
+            ->with('users')
+            ->andReturn(null);
+
+        $model = new class {
+            /** @var array<string, mixed> */
+            private array $attributes = ['posts_id_sum_id' => '20'];
+
+            /**
+             * Return the attributes array carrying only the later aggregate.
+             *
+             * @return array<string, mixed>
+             */
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            /**
+             * Magic getter to resolve attributes.
+             *
+             * @param  string  $key
+             * @return mixed
+             */
+            public function __get(string $key): mixed
+            {
+                return $this->attributes[$key] ?? null;
+            }
+        };
+
+        $resource = new JsonResource($model);
+        $schema   = new CompiledSchema([], [], [
+            'missing_id' => new CompiledAggregateDefinition('missing_id', 'missing', 'id', 'sum', null, true, []),
+            'posts_id'   => new CompiledAggregateDefinition('posts_id', 'posts', 'id', 'sum', null, true, []),
+        ]);
+
+        $result = $this->resolver->resolveAggregatesPayload('sum', $resource, $schema, 'users', null);
+
+        self::assertSame(['posts_id' => 20.0], $result);
     }
 
     /**

--- a/tests/Unit/Http/Resources/PolymorphicResourceTest.php
+++ b/tests/Unit/Http/Resources/PolymorphicResourceTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Contracts\ApiResourceInterface;
 use SineMacula\ApiToolkit\Exceptions\ResourceMappingException;
 use SineMacula\ApiToolkit\Http\Resources\PolymorphicResource;
 use Tests\Fixtures\Models\Organization;
@@ -359,7 +360,7 @@ final class PolymorphicResourceTest extends TestCase
         $resource = new PolymorphicResource($user);
 
         $this->expectException(ResourceMappingException::class);
-        $this->expectExceptionMessage('must implement');
+        $this->expectExceptionMessage('Resource [' . \stdClass::class . '] must implement ' . ApiResourceInterface::class);
 
         $resource->toArray(request());
     }

--- a/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
+++ b/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
@@ -505,6 +505,120 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
+     * Test that a non-PHP file encountered while walking a resource directory
+     * does not halt enumeration: a resource sitting beside a stray file is
+     * still discovered.
+     *
+     * @return void
+     */
+    public function testNonPhpFilesDoNotHaltDiscovery(): void
+    {
+        $directory = sys_get_temp_dir() . '/resource-discovery-' . uniqid((string) getmypid(), true);
+
+        mkdir($directory, 0o755, true);
+
+        $contents = file_get_contents($this->fixturePath('Primary') . '/DiscoveredUserResource.php');
+
+        assert($contents !== false);
+
+        file_put_contents($directory . '/notes.txt', 'not a php file');
+        file_put_contents($directory . '/DiscoveredUserResource.php', $contents);
+
+        try {
+            Config::set('api-toolkit.resources.paths', [$directory]);
+
+            self::assertSame([
+                User::class => DiscoveredUserResource::class,
+            ], $this->discovery()->discover());
+        } finally {
+            unlink($directory . '/notes.txt');
+            unlink($directory . '/DiscoveredUserResource.php');
+            rmdir($directory);
+        }
+    }
+
+    /**
+     * Test that a class declared in the global namespace is resolved without a
+     * leading namespace separator, so the compiled name matches the value the
+     * autoloader and reflection expect.
+     *
+     * @return void
+     */
+    public function testGlobalNamespaceClassNameHasNoLeadingSeparator(): void
+    {
+        $directory = sys_get_temp_dir() . '/resource-discovery-' . uniqid((string) getmypid(), true);
+
+        mkdir($directory, 0o755, true);
+
+        $file = $directory . '/global-class.php';
+
+        file_put_contents($file, "<?php\n\nclass ResourceDiscoveryGlobalProbe {}\n");
+
+        $method = new \ReflectionMethod(ResourceDiscovery::class, 'classesFromFile');
+
+        try {
+            self::assertSame(['ResourceDiscoveryGlobalProbe'], $method->invoke($this->discovery(), $file));
+        } finally {
+            unlink($file);
+            rmdir($directory);
+        }
+    }
+
+    /**
+     * Test that the namespace name is read from the token that abuts the
+     * keyword: a non-name token sitting immediately after namespace resolves
+     * to no name rather than skipping ahead to a later identifier.
+     *
+     * @return void
+     */
+    public function testNamespaceNameIsReadFromTheTokenAbuttingTheKeyword(): void
+    {
+        $tokens = \PhpToken::tokenize('<?php namespace(Foo)');
+        $method = new \ReflectionMethod(ResourceDiscovery::class, 'namespaceFromTokens');
+
+        // The keyword sits at index 1; the token at index 2 abuts it and is
+        // not a name token, so no namespace resolves. Beginning the scan a
+        // token later would wrongly read the identifier at index 3.
+        self::assertNull($method->invoke($this->discovery(), $tokens, 1));
+    }
+
+    /**
+     * Test that the declared class name is read from the token that abuts the
+     * keyword: a non-name token sitting immediately after class resolves to no
+     * declaration rather than skipping ahead to a later identifier.
+     *
+     * @return void
+     */
+    public function testDeclaredNameIsReadFromTheTokenAbuttingTheKeyword(): void
+    {
+        $tokens = \PhpToken::tokenize('<?php class(Foo)');
+        $method = new \ReflectionMethod(ResourceDiscovery::class, 'declaredNameFromTokens');
+
+        // The keyword sits at index 1; the token at index 2 abuts it and is
+        // not a name token, so no declaration resolves. Beginning the scan a
+        // token later would wrongly read the identifier at index 3.
+        self::assertNull($method->invoke($this->discovery(), $tokens, 1, null));
+    }
+
+    /**
+     * Test that a class keyword preceded by a double colon is treated as a
+     * class-constant reference and never as a declaration, even when an
+     * identifier token follows it.
+     *
+     * @return void
+     */
+    public function testClassConstantReferenceIsNeverADeclaration(): void
+    {
+        $tokens = \PhpToken::tokenize('<?php Foo::class Bar');
+        $method = new \ReflectionMethod(ResourceDiscovery::class, 'declaredNameFromTokens');
+
+        // The class keyword sits at index 3, preceded by the double colon at
+        // index 2; the guard must short-circuit before the loop reads the
+        // trailing identifier at index 5.
+        self::assertNull($method->invoke($this->discovery(), $tokens, 3, $tokens[2]));
+    }
+
+    /**
      * Resolve the discovery service from the container.
      *
      * @return \SineMacula\ApiToolkit\Http\Resources\ResourceDiscovery

--- a/tests/Unit/Http/Resources/Schema/BaseDefinitionTest.php
+++ b/tests/Unit/Http/Resources/Schema/BaseDefinitionTest.php
@@ -203,6 +203,34 @@ final class BaseDefinitionTest extends TestCase
     }
 
     /**
+     * Test that needs accumulates columns across calls and deduplicates them.
+     *
+     * @return void
+     */
+    public function testNeedsAccumulatesColumnsAndDeduplicates(): void
+    {
+        $field = Field::scalar('name');
+
+        $field->needs('first_name')->needs('last_name', 'first_name');
+
+        $array = $field->toArray();
+
+        self::assertSame(['first_name', 'last_name'], $array['name']['needs']);
+    }
+
+    /**
+     * Test that needs returns self for fluent chaining.
+     *
+     * @return void
+     */
+    public function testNeedsReturnsSelfForChaining(): void
+    {
+        $field = Field::scalar('name');
+
+        self::assertSame($field, $field->needs('first_name'));
+    }
+
+    /**
      * Test that openapi returns a declaration carrier.
      *
      * @return void

--- a/tests/Unit/Http/Resources/Schema/FieldColumnMapperTest.php
+++ b/tests/Unit/Http/Resources/Schema/FieldColumnMapperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
+use SineMacula\ApiToolkit\Schema\CompiledSchema;
+use SineMacula\ApiToolkit\Schema\FieldColumnMapper;
+
+/**
+ * Tests for the FieldColumnMapper builder.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(FieldColumnMapper::class)]
+final class FieldColumnMapperTest extends TestCase
+{
+    /**
+     * Test that build skips unmapped fields but still processes later mapped
+     * fields rather than stopping at the first unmapped one.
+     *
+     * @return void
+     */
+    public function testBuildContinuesPastUnmappedFieldsToLaterMappedFields(): void
+    {
+        $schema = new CompiledSchema([
+            'opaque' => $this->definition(accessor: 'nested.path'),
+            'plain'  => $this->definition(),
+        ], []);
+
+        $map = FieldColumnMapper::build($schema);
+
+        self::assertFalse($map->isMapped('opaque'));
+        self::assertTrue($map->isMapped('plain'));
+        self::assertSame(['plain'], $map->columnsFor('plain'));
+    }
+
+    /**
+     * Test that build maps a needs-carrying field to its declared columns.
+     *
+     * @return void
+     */
+    public function testBuildMapsNeedsCarryingFieldToDeclaredColumns(): void
+    {
+        $schema = new CompiledSchema([
+            'full_name' => $this->definition(accessor: 'x', needs: ['first_name', 'last_name']),
+        ], []);
+
+        $map = FieldColumnMapper::build($schema);
+
+        self::assertTrue($map->isMapped('full_name'));
+        self::assertSame(['first_name', 'last_name'], $map->columnsFor('full_name'));
+    }
+
+    /**
+     * Build a compiled field definition with sensible defaults for the fields
+     * not under test.
+     *
+     * @param  mixed  $accessor
+     * @param  array<int, string>  $needs
+     * @return \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition
+     */
+    private function definition(mixed $accessor = null, array $needs = []): CompiledFieldDefinition
+    {
+        return new CompiledFieldDefinition(
+            accessor    : $accessor,
+            compute     : null,
+            relation    : null,
+            resource    : null,
+            fields      : null,
+            constraint  : null,
+            extras      : [],
+            needs       : $needs,
+            guards      : [],
+            transformers: [],
+        );
+    }
+}

--- a/tests/Unit/Http/Resources/Schema/FieldTest.php
+++ b/tests/Unit/Http/Resources/Schema/FieldTest.php
@@ -494,6 +494,50 @@ final class FieldTest extends TestCase
     }
 
     /**
+     * Test that toArray emits the declared base-table column reads when needs
+     * are set.
+     *
+     * @return void
+     */
+    public function testToArrayIncludesNeedsWhenSet(): void
+    {
+        $array = Field::scalar('display_name')->needs('first_name', 'last_name')->toArray();
+
+        self::assertArrayHasKey('needs', $array['display_name']);
+        self::assertSame(['first_name', 'last_name'], $array['display_name']['needs']);
+    }
+
+    /**
+     * Test that timestamp declares a nullable date-time OpenAPI contract.
+     *
+     * @return void
+     */
+    public function testTimestampDeclaresDateTimeOpenApiContract(): void
+    {
+        $openapi = Field::timestamp('created_at')->toArray()['created_at']['openapi'];
+
+        self::assertInstanceOf(OpenApiFieldSchema::class, $openapi);
+        self::assertSame('string', $openapi->type);
+        self::assertSame('date-time', $openapi->format);
+        self::assertTrue($openapi->nullable);
+    }
+
+    /**
+     * Test that date declares a nullable date OpenAPI contract.
+     *
+     * @return void
+     */
+    public function testDateDeclaresDateOpenApiContract(): void
+    {
+        $openapi = Field::date('birth_date')->toArray()['birth_date']['openapi'];
+
+        self::assertInstanceOf(OpenApiFieldSchema::class, $openapi);
+        self::assertSame('string', $openapi->type);
+        self::assertSame('date', $openapi->format);
+        self::assertTrue($openapi->nullable);
+    }
+
+    /**
      * Test that the openapi key is emitted when a declaration was made.
      *
      * @return void

--- a/tests/Unit/Http/Resources/Schema/OpenApiFieldSchemaTest.php
+++ b/tests/Unit/Http/Resources/Schema/OpenApiFieldSchemaTest.php
@@ -174,6 +174,19 @@ final class OpenApiFieldSchemaTest extends TestCase
     }
 
     /**
+     * Test that the type keyword is omitted when the type is null even when the
+     * field is declared nullable.
+     *
+     * @return void
+     */
+    public function testTypeIsOmittedWhenNullEvenWhenNullable(): void
+    {
+        $schema = new OpenApiFieldSchema(type: null, nullable: true);
+
+        self::assertSame([], $schema->toArray());
+    }
+
+    /**
      * Test that an example value is included in the fragment.
      *
      * @return void

--- a/tests/Unit/Http/Resources/ToolkitCollectionTest.php
+++ b/tests/Unit/Http/Resources/ToolkitCollectionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\ReportCollection;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitCollection;
+use SineMacula\Exporter\Http\ExportNegotiator;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Reports\SalesSummaryResource;
+use Tests\Fixtures\Reports\SalesSummaryRow;
+use Tests\TestCase;
+
+/**
+ * Tests for the shared toolkit resource collection base.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ToolkitCollection::class)]
+final class ToolkitCollectionTest extends TestCase
+{
+    /**
+     * Test that toResponse returns the native envelope, without the export
+     * negotiation Vary header, when the exporter is not bound.
+     *
+     * @return void
+     */
+    public function testToResponseFallsBackToNativeEnvelopeWhenExporterUnbound(): void
+    {
+        self::assertFalse(App::bound(ExportNegotiator::class));
+
+        $rows = collect([
+            new SalesSummaryRow('2026-01', 5, '50.00'),
+            new SalesSummaryRow('2026-02', 9, '90.00'),
+        ]);
+
+        $collection = new ReportCollection($rows, SalesSummaryResource::class);
+
+        $response = $collection->toResponse(Request::create('/', HttpMethod::GET->getVerb()));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertFalse($response->headers->has('Vary'));
+    }
+}

--- a/tests/Unit/Http/Resources/ToolkitResourceTest.php
+++ b/tests/Unit/Http/Resources/ToolkitResourceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Unit\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Http\Resources\ToolkitResource;
+use SineMacula\Exporter\Http\ExportNegotiator;
+use SineMacula\Http\Enums\HttpMethod;
+use Tests\Fixtures\Reports\SalesSummaryResource;
+use Tests\Fixtures\Reports\SalesSummaryRow;
+use Tests\TestCase;
+
+/**
+ * Tests for the shared toolkit single-item resource base.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+#[CoversClass(ToolkitResource::class)]
+final class ToolkitResourceTest extends TestCase
+{
+    /**
+     * Test that toResponse returns the native JSON response, without the export
+     * negotiation Vary header, when the exporter is not bound.
+     *
+     * @return void
+     */
+    public function testToResponseFallsBackToNativeResponseWhenExporterUnbound(): void
+    {
+        self::assertFalse(App::bound(ExportNegotiator::class));
+
+        $resource = new SalesSummaryResource(new SalesSummaryRow('2026-01', 42, '4821.00'));
+
+        $response = $resource->toResponse(Request::create('/', HttpMethod::GET->getVerb()));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertFalse($response->headers->has('Vary'));
+    }
+}

--- a/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
+++ b/tests/Unit/Listeners/WritePoolFlushSubscriberTest.php
@@ -414,6 +414,38 @@ final class WritePoolFlushSubscriberTest extends TestCase
     }
 
     /**
+     * Test that the subscriber does not re-throw a flush exception when the
+     * rethrow_at_boundary key is absent, so the safe default keeps the boundary
+     * from hard-crashing.
+     *
+     * @return void
+     */
+    public function testHandleFlushDoesNotRethrowWhenRethrowKeyAbsent(): void
+    {
+        $deferred = (array) Config::get('api-toolkit.deferred_writes');
+        unset($deferred['rethrow_at_boundary']);
+        Config::set('api-toolkit.deferred_writes', $deferred);
+
+        $pool = new WritePool(500, 10000, FlushStrategy::THROW);
+        $pool->add('nonexistent_table', ['col' => 'val']);
+
+        $container = \Mockery::mock(Container::class);
+        $container->shouldReceive('make')
+            ->with(WritePool::class)
+            ->andReturn($pool);
+
+        Log::shouldReceive('warning')->once();
+
+        Event::fake([WritePoolFlushFailed::class]);
+
+        $subscriber = new WritePoolFlushSubscriber($container);
+
+        $subscriber->handleFlush();
+
+        Event::assertDispatched(WritePoolFlushFailed::class);
+    }
+
+    /**
      * Test that the subscriber re-throws a flush exception after escalating it
      * when the rethrow_at_boundary flag is enabled.
      *

--- a/tests/Unit/OpenApi/Builder/ErrorResponseBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/ErrorResponseBuilderTest.php
@@ -87,6 +87,21 @@ final class ErrorResponseBuilderTest extends TestCase
     }
 
     /**
+     * Test that the response description uses the descriptor title when one is
+     * defined, in preference to the detail.
+     *
+     * @return void
+     */
+    public function testResponseDescriptionUsesTitleWhenPresent(): void
+    {
+        $responses = $this->makeBuilder([
+            new ErrorDescriptor(code: 10103, httpStatus: 404, title: 'Not Found', detail: 'The resource was not found.'),
+        ])->build();
+
+        self::assertSame('Not Found', $responses['ErrorResponse10103']['description']);
+    }
+
+    /**
      * Test that the response carries an example payload mirroring the runtime
      * error envelope shape.
      *

--- a/tests/Unit/OpenApi/Builder/QueryParameterBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/QueryParameterBuilderTest.php
@@ -133,9 +133,24 @@ final class QueryParameterBuilderTest extends TestCase
     {
         $schema = $this->makeBuilder()->build()['Filter']['schema'];
 
+        self::assertSame('object', $schema['type']);
         self::assertTrue($schema['additionalProperties']);
         self::assertArrayNotHasKey('enum', $schema);
         self::assertArrayNotHasKey('properties', $schema);
+    }
+
+    /**
+     * Test that the filter description states the grammar up front and
+     * disclaims any per-resource allow-list, keeping both clauses in order.
+     *
+     * @return void
+     */
+    public function testFilterDescriptionStatesTheGrammarAndDisclaimsAnyAllowList(): void
+    {
+        $description = $this->makeBuilder()->build()['Filter']['description'];
+
+        self::assertStringStartsWith('Generic filter grammar. Filters are keyed by field', $description);
+        self::assertStringContainsString('the toolkit applies no per-resource field allow-list.', $description);
     }
 
     /**
@@ -167,7 +182,72 @@ final class QueryParameterBuilderTest extends TestCase
         self::assertSame('integer', $parameters['Limit']['schema']['type']);
         self::assertSame(1, $parameters['Limit']['schema']['minimum']);
         self::assertSame('integer', $parameters['Page']['schema']['type']);
+        self::assertSame(1, $parameters['Page']['schema']['minimum']);
         self::assertSame('string', $parameters['Cursor']['schema']['type']);
+    }
+
+    /**
+     * Test that the sparse-fieldset parameter carries an object schema of
+     * string members, is optional, and uses the deepObject exploded style.
+     *
+     * @return void
+     */
+    public function testFieldsParameterCarriesObjectSchemaAndDeepObjectStyle(): void
+    {
+        $fields = $this->makeBuilder()->build()['Fields'];
+
+        self::assertSame(['type' => 'object', 'additionalProperties' => ['type' => 'string']], $fields['schema']);
+        self::assertFalse($fields['required']);
+        self::assertSame('deepObject', $fields['style']);
+        self::assertTrue($fields['explode']);
+    }
+
+    /**
+     * Test that a parameter without an explicit style omits both the style and
+     * explode keys.
+     *
+     * @return void
+     */
+    public function testNonStyledParametersOmitStyleAndExplode(): void
+    {
+        $order = $this->makeBuilder()->build()['Order'];
+
+        self::assertArrayNotHasKey('style', $order);
+        self::assertArrayNotHasKey('explode', $order);
+    }
+
+    /**
+     * Test that the ordering parameter is a plain string schema.
+     *
+     * @return void
+     */
+    public function testOrderParameterIsAPlainStringSchema(): void
+    {
+        self::assertSame(['type' => 'string'], $this->makeBuilder()->build()['Order']['schema']);
+    }
+
+    /**
+     * Test that the relation-aggregate parameters describe their nested
+     * string-keyed object maps.
+     *
+     * @return void
+     */
+    public function testDeepObjectSchemasDescribeNestedStringMaps(): void
+    {
+        $parameters = $this->makeBuilder()->build();
+
+        self::assertSame(
+            ['type' => 'object', 'additionalProperties' => ['type' => 'string']],
+            $parameters['Counts']['schema'],
+        );
+        self::assertSame(
+            ['type' => 'object', 'additionalProperties' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]],
+            $parameters['Sums']['schema'],
+        );
+        self::assertSame(
+            ['type' => 'object', 'additionalProperties' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]],
+            $parameters['Averages']['schema'],
+        );
     }
 
     /**

--- a/tests/Unit/OpenApi/Builder/ResourceSchemaBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/ResourceSchemaBuilderTest.php
@@ -9,6 +9,7 @@ use SineMacula\ApiToolkit\OpenApi\Builder\ResourceSchemaBuilder;
 use SineMacula\ApiToolkit\OpenApi\Contracts\MetadataCatalogue;
 use SineMacula\ApiToolkit\OpenApi\Resolution\ColumnTypeMapper;
 use SineMacula\ApiToolkit\OpenApi\Resolution\FieldTypeResolver;
+use SineMacula\ApiToolkit\Schema\CompiledFieldDefinition;
 use SineMacula\ApiToolkit\Schema\CompiledSchema;
 use SineMacula\ApiToolkit\Schema\Introspection\SchemaIntrospector;
 use SineMacula\ApiToolkit\Schema\SchemaCompiler;
@@ -69,6 +70,43 @@ final class ResourceSchemaBuilderTest extends TestCase
         $schemas = (new ResourceSchemaBuilder($catalogue, $this->resolver()))->build();
 
         self::assertSame(['type' => 'object', 'properties' => []], $schemas['Ghost']);
+    }
+
+    /**
+     * Test that a null field definition only skips its own key: later
+     * field keys in the same compiled schema are still emitted as properties.
+     *
+     * @return void
+     */
+    public function testNullFieldKeySkipsOnlyItselfNotLaterKeys(): void
+    {
+        $relation = new CompiledFieldDefinition(
+            accessor: null,
+            compute: null,
+            relation: 'posts',
+            resource: 'PostResource',
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: [],
+            transformers: [],
+        );
+
+        // The null 'ghost' key precedes a valid relation key; skipping the null
+        // must not abandon the rest of the loop.
+        $schema = new CompiledSchema(['ghost' => null, 'posts' => $relation], []); // @phpstan-ignore argument.type
+
+        $this->setStaticProperty(SchemaCompiler::class, 'cache', ['GhostResource' => $schema]);
+
+        $catalogue = self::createStub(MetadataCatalogue::class);
+        $catalogue->method('getResourceMap')->willReturn(['GhostModel' => 'GhostResource']);
+
+        $properties = (new ResourceSchemaBuilder($catalogue, $this->resolver()))->build()['Ghost']['properties'];
+
+        self::assertArrayNotHasKey('ghost', $properties);
+        self::assertArrayHasKey('posts', $properties);
+        self::assertSame(['$ref' => '#/components/schemas/Post'], $properties['posts']['oneOf'][0]);
     }
 
     /**

--- a/tests/Unit/OpenApi/Metadata/ConfigMetadataCatalogueTest.php
+++ b/tests/Unit/OpenApi/Metadata/ConfigMetadataCatalogueTest.php
@@ -13,7 +13,9 @@ use SineMacula\ApiToolkit\OpenApi\Metadata\ErrorDescriptor;
 use SineMacula\ApiToolkit\Repositories\Criteria\OperatorRegistry;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\EqualOperator;
 use SineMacula\ApiToolkit\Repositories\Criteria\Operators\NotEqualOperator;
+use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
+use Tests\Fixtures\Resources\PostResource;
 use Tests\Fixtures\Resources\UserResource;
 use Tests\TestCase;
 
@@ -37,11 +39,15 @@ final class ConfigMetadataCatalogueTest extends TestCase
     {
         Config::set('api-toolkit.resources.resource_map', [
             User::class => UserResource::class,
+            Post::class => PostResource::class,
         ]);
 
         $catalogue = $this->makeCatalogue();
 
-        self::assertSame([User::class => UserResource::class], $catalogue->getResourceMap());
+        self::assertSame([
+            User::class => UserResource::class,
+            Post::class => PostResource::class,
+        ], $catalogue->getResourceMap());
     }
 
     /**

--- a/tests/Unit/OpenApi/Metadata/ErrorCatalogueReaderTest.php
+++ b/tests/Unit/OpenApi/Metadata/ErrorCatalogueReaderTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\OpenApi\Metadata;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SineMacula\ApiToolkit\Enums\ErrorCode;
+use SineMacula\ApiToolkit\Exceptions\BadRequestException;
 use SineMacula\ApiToolkit\Exceptions\NotFoundException;
 use SineMacula\ApiToolkit\OpenApi\Exceptions\MetadataReadException;
 use SineMacula\ApiToolkit\OpenApi\Metadata\ErrorCatalogueReader;
@@ -209,10 +210,40 @@ final class ErrorCatalogueReaderTest extends TestCase
     {
         FunctionOverrides::set('glob', static fn (): false => false);
 
-        $this->expectException(MetadataReadException::class);
-        $this->expectExceptionMessage('Unable to scan the exceptions directory');
+        try {
+            (new ErrorCatalogueReader)->read();
+        } catch (MetadataReadException $e) {
+            self::assertStringStartsWith('Unable to scan the exceptions directory: ', $e->getMessage());
+            self::assertStringContainsString('/Exceptions', $e->getMessage());
 
-        (new ErrorCatalogueReader)->read();
+            return;
+        }
+
+        self::fail('Expected a MetadataReadException to be thrown.');
+    }
+
+    /**
+     * Test that a discovered subclass declaring no CODE constant does not
+     * abort the scan: a later file is still processed and mapped, proving the
+     * CODE guard skips the offending file rather than stopping the loop.
+     *
+     * @return void
+     */
+    public function testContinuesScanningAfterCodelessSubclass(): void
+    {
+        $codeless = (new \ReflectionClass(BadRequestException::class))->getFileName();
+        $later    = (new \ReflectionClass(NotFoundException::class))->getFileName();
+
+        self::assertIsString($codeless);
+        self::assertIsString($later);
+
+        FunctionOverrides::set('glob', static fn (): array => [$codeless, $later]);
+        FunctionOverrides::set('defined', static fn (string $constant): bool => !str_starts_with($constant, BadRequestException::class . '::') && \defined($constant));
+
+        $descriptor = $this->findDescriptor((new ErrorCatalogueReader)->read(), ErrorCode::NOT_FOUND->getCode());
+
+        self::assertNotNull($descriptor);
+        self::assertSame(404, $descriptor->httpStatus);
     }
 
     /**

--- a/tests/Unit/OpenApi/Output/FilesystemDocumentWriterTest.php
+++ b/tests/Unit/OpenApi/Output/FilesystemDocumentWriterTest.php
@@ -81,6 +81,28 @@ final class FilesystemDocumentWriterTest extends TestCase
     }
 
     /**
+     * Test that the parent directory is created with the expected mode and the
+     * recursive and force flags both enabled.
+     *
+     * @return void
+     */
+    public function testCreatesDirectoryWithExpectedModeAndFlags(): void
+    {
+        $path      = $this->directory . '/nested/openapi.json';
+        $directory = dirname($path);
+
+        $files = $this->createMock(Filesystem::class);
+        $files->method('isDirectory')->willReturn(false);
+        $files->expects(self::once())
+            ->method('makeDirectory')
+            ->with($directory, 0o755, true, true)
+            ->willReturn(true);
+        $files->method('put')->willReturn(8);
+
+        (new FilesystemDocumentWriter($files))->write($path, 'contents');
+    }
+
+    /**
      * Test that a write failure surfaces as a DocumentWriteException.
      *
      * @return void

--- a/tests/Unit/OpenApi/Resolution/ColumnTypeMapperTest.php
+++ b/tests/Unit/OpenApi/Resolution/ColumnTypeMapperTest.php
@@ -230,7 +230,40 @@ final class ColumnTypeMapperTest extends TestCase
 
         $schema = $mapper->map($column, 'date');
 
+        self::assertSame('string', $schema->type);
         self::assertSame('date', $schema->format);
+    }
+
+    /**
+     * Test that a cast is matched case-insensitively, mirroring the way
+     * Eloquent normalises cast names.
+     *
+     * @return void
+     */
+    public function testMatchesCastCaseInsensitively(): void
+    {
+        $mapper = new ColumnTypeMapper;
+        $column = new ColumnDefinition(name: 'active', typeName: 'varchar', nullable: false);
+
+        $schema = $mapper->map($column, 'BOOLEAN');
+
+        self::assertSame('boolean', $schema->type);
+    }
+
+    /**
+     * Test that a parameterised encrypted array cast resolves to an array
+     * schema off the full cast token, not just its colon-prefixed base.
+     *
+     * @return void
+     */
+    public function testEncryptedArrayCastResolvesToArray(): void
+    {
+        $mapper = new ColumnTypeMapper;
+        $column = new ColumnDefinition(name: 'meta', typeName: 'varchar', nullable: false);
+
+        $schema = $mapper->map($column, 'encrypted:array');
+
+        self::assertSame('array', $schema->type);
     }
 
     /**

--- a/tests/Unit/Repositories/ApiRepositoryTest.php
+++ b/tests/Unit/Repositories/ApiRepositoryTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SineMacula\ApiToolkit\Cache\MetadataCacheWriter;
 use SineMacula\ApiToolkit\Repositories\ApiRepository;
 use SineMacula\ApiToolkit\Repositories\Concerns\AttributeSetter;
 use SineMacula\ApiToolkit\Repositories\Criteria\ApiCriteria;
@@ -159,6 +160,40 @@ final class ApiRepositoryTest extends TestCase
         $result = $this->repository->getResourceClass();
 
         self::assertNull($result);
+    }
+
+    /**
+     * Test that the metadata cache writer accessor keeps protected visibility
+     * so a subclass override is honoured when resolving the resource, rather
+     * than being shadowed by a private base implementation.
+     *
+     * @return void
+     */
+    public function testResourceResolutionUsesSubclassMetadataCacheWriterOverride(): void
+    {
+        assert($this->app !== null);
+
+        $repository = new class ($this->app) extends UserRepository {
+            /** @var bool Whether the overridden writer accessor was invoked. */
+            public bool $writerAccessed = false;
+
+            /**
+             * Record that the accessor was invoked and return the real writer.
+             *
+             * @return \SineMacula\ApiToolkit\Cache\MetadataCacheWriter
+             */
+            #[\Override]
+            protected function metadataCacheWriter(): MetadataCacheWriter
+            {
+                $this->writerAccessed = true;
+
+                return $this->app->make(MetadataCacheWriter::class);
+            }
+        };
+
+        $repository->getResourceClass();
+
+        self::assertTrue($repository->writerAccessed);
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
+++ b/tests/Unit/Repositories/Concerns/AttributeSetterTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Tests\Unit\Repositories\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
@@ -368,6 +369,41 @@ final class AttributeSetterTest extends TestCase
     }
 
     /**
+     * Test that syncing honours an explicit detaching flag carried on the value
+     * array, passing it through to the relation's sync call rather than forcing
+     * the default of true.
+     *
+     * @return void
+     */
+    public function testSetSyncAttributeForwardsExplicitDetachingFlagToRelation(): void
+    {
+        $relation = $this->createMock(BelongsToMany::class);
+
+        $relation->expects(self::once())
+            ->method('sync')
+            ->with(['detaching' => false], false);
+
+        $model = new class extends Model {
+            /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany<\Illuminate\Database\Eloquent\Model, \Illuminate\Database\Eloquent\Model>|null The relation returned for the tags attribute. */
+            public ?BelongsToMany $tagRelation = null;
+
+            /**
+             * Return the stubbed tags relation.
+             *
+             * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\Illuminate\Database\Eloquent\Model, \Illuminate\Database\Eloquent\Model>|null
+             */
+            public function tags(): ?BelongsToMany
+            {
+                return $this->tagRelation;
+            }
+        };
+
+        $model->tagRelation = $relation;
+
+        $this->invokeMethod($this->attributeSetter, 'setSyncAttribute', $model, 'tags', ['detaching' => false]);
+    }
+
+    /**
      * Test that persist skips attributes whose cast resolves to null.
      *
      * @return void
@@ -382,6 +418,26 @@ final class AttributeSetterTest extends TestCase
 
         self::assertTrue($result);
         self::assertSame('Alice', $user->fresh()?->name);
+    }
+
+    /**
+     * Test that persist continues to later attributes after skipping one whose
+     * cast resolves to null, rather than aborting the remaining attributes.
+     *
+     * @return void
+     */
+    public function testPersistContinuesToLaterAttributesAfterNullCast(): void
+    {
+        $user = User::create(['name' => 'Alice', 'email' => self::ALICE_EMAIL]);
+
+        $this->schemaIntrospector->method('resolveRelation')->willReturn(null);
+
+        $this->setProperty($this->attributeSetter, 'casts', ['name' => 'string']);
+
+        $result = $this->attributeSetter->persist($user, ['unknown_field' => 'value', 'name' => 'Bob'], User::class);
+
+        self::assertTrue($result);
+        self::assertSame('Bob', $user->fresh()?->name);
     }
 
     /**

--- a/tests/Unit/Repositories/Concerns/WritePoolFlushAccumulatorTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolFlushAccumulatorTest.php
@@ -65,6 +65,25 @@ final class WritePoolFlushAccumulatorTest extends TestCase
     }
 
     /**
+     * Test that recordFailure accumulates the failed record count across
+     * multiple failed chunks rather than overwriting it with the latest chunk.
+     *
+     * @return void
+     */
+    public function testRecordFailureAccumulatesFailedRecordCountAcrossChunks(): void
+    {
+        $accumulator = new WritePoolFlushAccumulator;
+
+        $accumulator->recordFailure('orders', [['id' => 1], ['id' => 2]], new \RuntimeException);
+        $accumulator->recordFailure('orders', [['id' => 3], ['id' => 4], ['id' => 5]], new \RuntimeException);
+
+        $result = $accumulator->toResult(FlushStrategy::COLLECT);
+
+        self::assertSame(2, $result->failureCount());
+        self::assertSame(5, $result->failedRecordCount());
+    }
+
+    /**
      * Test that retain merges retained records per table and that failedRecords
      * exposes them for retry.
      *

--- a/tests/Unit/Repositories/Concerns/WritePoolTest.php
+++ b/tests/Unit/Repositories/Concerns/WritePoolTest.php
@@ -804,6 +804,35 @@ final class WritePoolTest extends TestCase
     }
 
     /**
+     * Test that a transactional throw rollback retains the failing table and
+     * the tables after it, but not a table that already committed before it, so
+     * the retained buffer excludes rows that are already persisted.
+     *
+     * @return void
+     */
+    public function testTransactionalThrowRetainsUnprocessedTablesButNotCommittedOnes(): void
+    {
+        $pool = new WritePool(chunkSize: 1, poolLimit: 10000, strategy: FlushStrategy::THROW, transactional: true);
+
+        $pool->add('test_records', ['name' => 'foo', 'value' => 'bar']);
+        $pool->add('test_unique', ['name' => 'alpha']);
+        $pool->add('test_unique', ['name' => 'alpha']);
+        $pool->add('test_other', ['label' => 'baz']);
+
+        try {
+            $pool->flush();
+            self::fail('Expected WritePoolFlushException was not thrown');
+        } catch (WritePoolFlushException $exception) {
+            self::assertSame(3, $exception->flushResult()->retainedRecordCount());
+        }
+
+        self::assertSame(1, DB::table('test_records')->count());
+        self::assertSame(0, DB::table('test_unique')->count());
+        self::assertSame(0, DB::table('test_other')->count());
+        self::assertSame(3, $pool->count());
+    }
+
+    /**
      * Test that the collect strategy reports record-level counts for a
      * partially failing flush.
      *

--- a/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
+++ b/tests/Unit/Repositories/Criteria/ApiCriteriaTest.php
@@ -1036,6 +1036,44 @@ final class ApiCriteriaTest extends TestCase
     }
 
     /**
+     * Test that a resolved resource that is not an ApiResource subclass yields
+     * an empty query surface rather than being compiled as a schema.
+     *
+     * @return void
+     */
+    public function testBuildQuerySurfaceYieldsEmptySurfaceForNonApiResource(): void
+    {
+        $this->criteria->usingResource(\stdClass::class);
+
+        $method  = new \ReflectionMethod($this->criteria, 'buildQuerySurface');
+        $surface = $method->invoke($this->criteria, new User);
+
+        self::assertInstanceOf(QuerySurface::class, $surface);
+
+        $property = new \ReflectionProperty($surface, 'filterableColumns');
+
+        self::assertSame([], $property->getValue($surface));
+    }
+
+    /**
+     * Test that when the reject-undeclared flag is entirely absent from config
+     * the query surface defaults to fail-closed.
+     *
+     * @return void
+     */
+    public function testAbsentRejectUndeclaredConfigDefaultsToFailClosed(): void
+    {
+        Config::set('api-toolkit.repositories', []);
+
+        $method  = new \ReflectionMethod($this->criteria, 'buildQuerySurface');
+        $surface = $method->invoke($this->criteria, new User);
+
+        $property = new \ReflectionProperty($surface, 'rejectUndeclared');
+
+        self::assertTrue($property->getValue($surface));
+    }
+
+    /**
      * Resolve the API query parser and parse the given request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/ColumnProjectionApplierTest.php
@@ -359,6 +359,98 @@ final class ColumnProjectionApplierTest extends TestCase
     }
 
     /**
+     * Test that when the narrow-columns flag is entirely absent from config the
+     * applier defaults to disabled, leaving the query unnarrowed.
+     *
+     * @return void
+     */
+    public function testAbsentNarrowFlagDefaultsToDisabled(): void
+    {
+        Config::set('api-toolkit.resources', []);
+
+        $this->parseRequest(new Request);
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(self::USER_DEFAULT_FIELDS);
+        $provider->method('eagerLoadMapFor')->willReturn([]);
+
+        $query  = (new User)->newQuery();
+        $result = $this->makeApplier()->apply($query, $provider, UserResource::class, ['name' => 'asc']);
+
+        self::assertNull($result->getQuery()->columns);
+    }
+
+    /**
+     * Test that a non-string relation path preceding a valid list-keyed
+     * relation is skipped without halting the loop, so the later relation's
+     * parent key is still retained.
+     *
+     * @return void
+     */
+    public function testProcessesListKeyedRelationAfterNonStringPath(): void
+    {
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $this->parseRequest(new Request);
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(self::USER_DEFAULT_FIELDS);
+        // A non-string path (nested array under an int key) precedes a valid
+        // list-keyed relation entry.
+        $provider->method('eagerLoadMapFor')->willReturn([['nested', 'array'], 'author']);
+
+        $author = self::createStub(Relation::class);
+
+        $introspector = self::createStub(SchemaIntrospectionProvider::class);
+        $introspector->method('getColumns')->willReturn([...self::USER_COLUMNS, 'author_id']);
+        $introspector->method('getDeletedAtColumn')->willReturn(null);
+        $introspector->method('resolveRelation')->willReturnCallback(
+            static fn (string $key): ?Relation => $key === 'author' ? $author : null,
+        );
+        $introspector->method('parentKeysFor')->willReturn(['author_id']);
+
+        $applier = new ColumnProjectionApplier(new SafetySetDeriver($introspector));
+
+        $columns = $applier->apply((new User)->newQuery(), $provider, UserResource::class, [])->getQuery()->columns;
+
+        self::assertNotNull($columns);
+        self::assertContains('author_id', $columns);
+    }
+
+    /**
+     * Test that the random-ordering keyword is excluded from the order-derived
+     * safety columns, so a real column that happens to share its name is not
+     * force-retained by a random-order request.
+     *
+     * @return void
+     */
+    public function testExcludesRandomOrderKeywordFromRetainedColumns(): void
+    {
+        Config::set('api-toolkit.resources.narrow_columns', true);
+
+        $this->parseRequest(new Request);
+
+        $provider = self::createStub(ResourceMetadataProvider::class);
+        $provider->method('getResourceType')->willReturn('users');
+        $provider->method('resolveFields')->willReturn(self::USER_DEFAULT_FIELDS);
+        $provider->method('eagerLoadMapFor')->willReturn([]);
+
+        $introspector = self::createStub(SchemaIntrospectionProvider::class);
+        $introspector->method('getColumns')->willReturn([...self::USER_COLUMNS, 'random']);
+        $introspector->method('getDeletedAtColumn')->willReturn(null);
+        $introspector->method('resolveRelation')->willReturn(null);
+
+        $applier = new ColumnProjectionApplier(new SafetySetDeriver($introspector));
+
+        $columns = $applier->apply((new User)->newQuery(), $provider, UserResource::class, ['random' => 'asc'])->getQuery()->columns;
+
+        self::assertNotNull($columns);
+        self::assertNotContains('random', $columns);
+    }
+
+    /**
      * Build a column projection applier over a stubbed introspection provider
      * reporting the fixture user columns.
      *

--- a/tests/Unit/Repositories/Criteria/Concerns/OrderApplierTest.php
+++ b/tests/Unit/Repositories/Criteria/Concerns/OrderApplierTest.php
@@ -159,6 +159,24 @@ final class OrderApplierTest extends TestCase
     }
 
     /**
+     * Test that a column failing the sort guard is skipped without halting the
+     * loop, so a valid column declared after it is still applied.
+     *
+     * @return void
+     */
+    public function testAppliesValidColumnAfterSkippingAnInvalidOne(): void
+    {
+        $query  = (new User)->newQuery();
+        $result = $this->applier->apply($query, ['nonexistent' => 'asc', 'name' => 'asc'], $this->surface());
+
+        $orders = $result->getQuery()->orders ?? [];
+
+        self::assertCount(1, $orders);
+        self::assertSame('name', $orders[0]['column']);
+        self::assertSame('asc', $orders[0]['direction']);
+    }
+
+    /**
      * Test that the ORDER_BY_RANDOM constant equals 'random'.
      *
      * @return void

--- a/tests/Unit/Repositories/Criteria/Operators/ContainsOperatorTest.php
+++ b/tests/Unit/Repositories/Criteria/Operators/ContainsOperatorTest.php
@@ -255,6 +255,51 @@ final class ContainsOperatorTest extends TestCase
     }
 
     /**
+     * Test that a non-string, non-empty scalar is routed to the defensive
+     * containment path and recorded verbatim rather than fed to JSON
+     * validation, which would reject a non-string argument.
+     *
+     * @return void
+     */
+    public function testApplyWithIntegerValueUsesWhereJsonContains(): void
+    {
+        $query = (new User)->newQuery();
+
+        $this->operator->apply($query, 'tags', 123, FilterContext::root());
+
+        $wheres = $query->getQuery()->wheres;
+
+        self::assertCount(1, $wheres);
+        self::assertSame(self::TYPE_JSON_CONTAINS, $wheres[0]['type']);
+        self::assertSame('tags', $wheres[0]['column']);
+        self::assertSame(123, $wheres[0]['value']);
+    }
+
+    /**
+     * Test that an array value takes the trusted direct containment path, so a
+     * grammar rejection surfaces as an exception rather than being swallowed by
+     * the defensive fall-back reserved for untrusted scalars.
+     *
+     * @return void
+     */
+    public function testApplyWithArrayThatTheGrammarRejectsPropagatesTheException(): void
+    {
+        Log::spy();
+
+        $base = \Mockery::mock(QueryBuilder::class);
+        $base->shouldReceive('whereJsonContains')
+            ->andThrow(new \RuntimeException('grammar rejects json-contains'));
+
+        $query = \Mockery::mock(Builder::class);
+        $query->shouldReceive('getQuery')->andReturn($base);
+        $query->shouldReceive('getModel')->andReturn(new User);
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->operator->apply($query, 'tags', ['Alice'], FilterContext::root());
+    }
+
+    /**
      * Test that the comma-split conditions are grouped inside a single nested
      * where on the parent query.
      *

--- a/tests/Unit/Schema/Introspection/SchemaIntrospectorTest.php
+++ b/tests/Unit/Schema/Introspection/SchemaIntrospectorTest.php
@@ -853,9 +853,11 @@ final class SchemaIntrospectorTest extends TestCase
             // phpcs:enable Squiz.Commenting.FunctionComment.InvalidNoReturn
         };
 
+        $expectedMessage = 'Failed to resolve relation \'broken\' on ' . $model::class . ': Test logic failure';
+
         Log::shouldReceive('warning')
             ->once()
-            ->withArgs(fn (string $message) => str_contains($message, 'broken') && str_contains($message, 'Test logic failure'));
+            ->with($expectedMessage);
 
         $introspector = $this->makeIntrospector();
 
@@ -1121,6 +1123,129 @@ final class SchemaIntrospectorTest extends TestCase
         $expectedKey = CacheKeys::MODEL_RELATIONS->resolveKey([User::class, 'posts']);
 
         self::assertContains($expectedKey, $registry->keys());
+    }
+
+    /**
+     * Test that a fresh introspector serves the full multi-column listing from
+     * the memo cache populated by an earlier instance.
+     *
+     * @return void
+     */
+    public function testGetColumnsServesFullColumnListFromMemoCacheOnFreshInstance(): void
+    {
+        $model = new User;
+
+        $first = ($this->makeIntrospector())->getColumns($model);
+
+        self::assertGreaterThan(1, count($first));
+
+        $second = ($this->makeIntrospector())->getColumns($model);
+
+        self::assertSame($first, $second);
+    }
+
+    /**
+     * Test that a cached searchable set is served from the instance cache
+     * and is not recomputed when the exclusion configuration changes
+     * afterwards.
+     *
+     * @return void
+     */
+    public function testGetSearchableColumnsServesInstanceCacheAfterConfigChange(): void
+    {
+        Config::set('api-toolkit.repositories.searchable_exclusions', ['password']);
+
+        $introspector = $this->makeIntrospector();
+        $model        = new User;
+
+        $first = $introspector->getSearchableColumns($model);
+
+        self::assertNotContains('password', $first);
+
+        Config::set('api-toolkit.repositories.searchable_exclusions', []);
+
+        $second = $introspector->getSearchableColumns($model);
+
+        self::assertSame($first, $second);
+        self::assertNotContains('password', $second);
+    }
+
+    /**
+     * Test that getColumnDefinitions lower-cases a driver-reported type name
+     * that arrives in mixed case.
+     *
+     * @return void
+     */
+    public function testGetColumnDefinitionsLowerCasesDriverReportedTypeName(): void
+    {
+        Cache::memo()->flush(); // @phpstan-ignore method.notFound
+
+        Schema::shouldReceive('getColumns')
+            ->once()
+            ->andReturn([
+                ['name' => 'id', 'type_name' => 'INTEGER', 'nullable' => false],
+            ]);
+
+        $model = new class extends Model {
+            /** @var string|null */
+            protected $table = 'widgets';
+        };
+
+        $definitions = ($this->makeIntrospector())->getColumnDefinitions($model);
+
+        self::assertSame('integer', $definitions['id']->typeName);
+    }
+
+    /**
+     * Test that parentKeysFor returns the parent local key for a
+     * MorphOneOrMany relation.
+     *
+     * @return void
+     */
+    public function testParentKeysForMorphOneOrManyReturnsLocalKey(): void
+    {
+        $morphMany = self::createStub(MorphMany::class);
+
+        $morphMany->method('getLocalKeyName')->willReturn('taggable_local_id');
+
+        $introspector = $this->makeIntrospector();
+
+        self::assertSame(['taggable_local_id'], $introspector->parentKeysFor($morphMany));
+    }
+
+    /**
+     * Test that parentKeysFor drops empty key names and reindexes the survivors
+     * into a contiguous list.
+     *
+     * @return void
+     */
+    public function testParentKeysForFiltersEmptyKeyNamesAndReindexes(): void
+    {
+        $morphTo = self::createStub(MorphTo::class);
+
+        $morphTo->method('getForeignKeyName')->willReturn('');
+        $morphTo->method('getMorphType')->willReturn('taggable_type');
+
+        $introspector = $this->makeIntrospector();
+
+        self::assertSame(['taggable_type'], $introspector->parentKeysFor($morphTo));
+    }
+
+    /**
+     * Test that parentKeysFor de-duplicates repeated key names.
+     *
+     * @return void
+     */
+    public function testParentKeysForDeduplicatesRepeatedKeyNames(): void
+    {
+        $morphTo = self::createStub(MorphTo::class);
+
+        $morphTo->method('getForeignKeyName')->willReturn('shared_key');
+        $morphTo->method('getMorphType')->willReturn('shared_key');
+
+        $introspector = $this->makeIntrospector();
+
+        self::assertSame(['shared_key'], $introspector->parentKeysFor($morphTo));
     }
 
     /**

--- a/tests/Unit/Schema/Validation/Rules/ValidateAccessorsTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidateAccessorsTest.php
@@ -187,6 +187,29 @@ final class ValidateAccessorsTest extends TestCase
     }
 
     /**
+     * Test that a valid non-empty string accessor does not halt iteration, so a
+     * later field's empty accessor is still reported.
+     *
+     * @return void
+     */
+    public function testContinuesPastValidStringAccessorFields(): void
+    {
+        $schema = new CompiledSchema(
+            fields: [
+                'clean' => $this->makeField('name'),
+                'bad'   => $this->makeField(''),
+            ],
+            counts: [],
+        );
+
+        $rule   = new ValidateAccessors;
+        $errors = $rule->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('bad', $errors[0]->fieldKey);
+    }
+
+    /**
      * Test that every empty accessor is reported.
      *
      * @return void

--- a/tests/Unit/Schema/Validation/Rules/ValidateGuardsTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidateGuardsTest.php
@@ -152,6 +152,48 @@ final class ValidateGuardsTest extends TestCase
     }
 
     /**
+     * Test that field guard errors and count definition guard errors are both
+     * accumulated rather than the count loop discarding earlier errors.
+     *
+     * @return void
+     */
+    public function testAccumulatesFieldAndCountGuardErrors(): void
+    {
+        $field = new CompiledFieldDefinition(
+            accessor: 'name',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: ['not_a_function'],
+            transformers: [],
+        );
+
+        $count = new CompiledCountDefinition(
+            presentKey: 'comments_count',
+            relation: 'comments',
+            constraint: null,
+            isDefault: false,
+            guards: ['not_a_function'],
+        );
+
+        $schema = new CompiledSchema(
+            fields: ['name' => $field],
+            counts: ['comments_count' => $count],
+        );
+
+        $rule   = new ValidateGuards;
+        $errors = $rule->validate('App\Http\Resources\PostResource', null, $schema);
+
+        self::assertCount(2, $errors);
+        self::assertSame('name', $errors[0]->fieldKey);
+        self::assertSame('comments_count', $errors[1]->fieldKey);
+    }
+
+    /**
      * Test no errors for schema with no guards.
      *
      * @return void

--- a/tests/Unit/Schema/Validation/Rules/ValidateRelationClassesTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidateRelationClassesTest.php
@@ -144,6 +144,29 @@ final class ValidateRelationClassesTest extends TestCase
     }
 
     /**
+     * Test that a field whose relation class exists does not halt iteration, so
+     * a later field's missing class is still reported.
+     *
+     * @return void
+     */
+    public function testContinuesPastExistingRelationClass(): void
+    {
+        $schema = new CompiledSchema(
+            fields: [
+                'clean' => $this->makeField(OrganizationResource::class),
+                'bad'   => $this->makeField('App\NonExistent\Resource'),
+            ],
+            counts: [],
+        );
+
+        $rule   = new ValidateRelationClasses;
+        $errors = $rule->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('bad', $errors[0]->fieldKey);
+    }
+
+    /**
      * Test that every non-existent relation class is reported.
      *
      * @return void

--- a/tests/Unit/Schema/Validation/Rules/ValidateRelationInterfacesTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidateRelationInterfacesTest.php
@@ -171,6 +171,29 @@ final class ValidateRelationInterfacesTest extends TestCase
     }
 
     /**
+     * Test that a relation class implementing the interface does not halt
+     * iteration, so a later non-conforming class is still reported.
+     *
+     * @return void
+     */
+    public function testContinuesPastConformingRelationClass(): void
+    {
+        $schema = new CompiledSchema(
+            fields: [
+                'good' => $this->makeField(OrganizationResource::class),
+                'bad'  => $this->makeField(\stdClass::class),
+            ],
+            counts: [],
+        );
+
+        $rule   = new ValidateRelationInterfaces;
+        $errors = $rule->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('bad', $errors[0]->fieldKey);
+    }
+
+    /**
      * Test that every non-conforming relation class is reported.
      *
      * @return void

--- a/tests/Unit/Schema/Validation/Rules/ValidateRelationMethodsTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidateRelationMethodsTest.php
@@ -252,6 +252,86 @@ final class ValidateRelationMethodsTest extends TestCase
     }
 
     /**
+     * Test that a field whose relation method is valid does not halt iteration,
+     * so a later field's defect is still reported.
+     *
+     * @return void
+     */
+    public function testContinuesPastFieldWithValidRelation(): void
+    {
+        $schema = new CompiledSchema(
+            fields: [
+                'organization' => new CompiledFieldDefinition(
+                    accessor: 'organization',
+                    compute: null,
+                    relation: 'organization',
+                    resource: OrganizationResource::class,
+                    fields: null,
+                    constraint: null,
+                    extras: [],
+                    needs: [],
+                    guards: [],
+                    transformers: [],
+                ),
+                'bad' => new CompiledFieldDefinition(
+                    accessor: 'bad',
+                    compute: null,
+                    relation: 'missing_relation',
+                    resource: OrganizationResource::class,
+                    fields: null,
+                    constraint: null,
+                    extras: [],
+                    needs: [],
+                    guards: [],
+                    transformers: [],
+                ),
+            ],
+            counts: [],
+        );
+
+        $rule   = new ValidateRelationMethods;
+        $errors = $rule->validate(UserResource::class, User::class, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('bad', $errors[0]->fieldKey);
+    }
+
+    /**
+     * Test that a count definition whose relation method is valid does not halt
+     * iteration, so a later count definition's defect is still reported.
+     *
+     * @return void
+     */
+    public function testContinuesPastCountDefinitionWithValidRelation(): void
+    {
+        $schema = new CompiledSchema(
+            fields: [],
+            counts: [
+                'posts_count' => new CompiledCountDefinition(
+                    presentKey: 'posts_count',
+                    relation: 'posts',
+                    constraint: null,
+                    isDefault: false,
+                    guards: [],
+                ),
+                'bad_count' => new CompiledCountDefinition(
+                    presentKey: 'bad_count',
+                    relation: 'missing_relation',
+                    constraint: null,
+                    isDefault: false,
+                    guards: [],
+                ),
+            ],
+        );
+
+        $rule   = new ValidateRelationMethods;
+        $errors = $rule->validate(UserResource::class, User::class, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('bad_count', $errors[0]->fieldKey);
+    }
+
+    /**
      * Test that a count definition whose relation method is valid produces no
      * error, so the loop advances past it.
      *

--- a/tests/Unit/Schema/Validation/Rules/ValidatesCallableListsTest.php
+++ b/tests/Unit/Schema/Validation/Rules/ValidatesCallableListsTest.php
@@ -96,6 +96,114 @@ final class ValidatesCallableListsTest extends TestCase
     }
 
     /**
+     * Test that a null field definition does not halt iteration, so a later
+     * field's non-callable entry is still reported.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public function testContinuesPastNullFieldDefinition(): void
+    {
+        $bad = new CompiledFieldDefinition(
+            accessor: 'name',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: ['not_a_function'],
+            transformers: [],
+        );
+
+        $reflection = new \ReflectionClass(CompiledSchema::class);
+        $schema     = $reflection->newInstanceWithoutConstructor();
+
+        $reflection->getProperty('fields')->setValue($schema, ['ghost' => null, 'name' => $bad]);
+        $reflection->getProperty('counts')->setValue($schema, []);
+
+        $errors = $this->makeRule()->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('name', $errors[0]->fieldKey);
+    }
+
+    /**
+     * Test that errors from every field are accumulated rather than only the
+     * final field's errors surviving.
+     *
+     * @return void
+     */
+    public function testAccumulatesErrorsAcrossFields(): void
+    {
+        $first = new CompiledFieldDefinition(
+            accessor: 'first',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: ['not_a_function'],
+            transformers: [],
+        );
+
+        $second = new CompiledFieldDefinition(
+            accessor: 'second',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: ['also_not_a_function'],
+            transformers: [],
+        );
+
+        $schema = new CompiledSchema(fields: ['first' => $first, 'second' => $second], counts: []);
+
+        $errors = $this->makeRule()->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(2, $errors);
+        self::assertSame('first', $errors[0]->fieldKey);
+        self::assertSame('second', $errors[1]->fieldKey);
+    }
+
+    /**
+     * Test that a callable entry does not halt the list scan, so a following
+     * non-callable entry is still reported at its true index.
+     *
+     * @return void
+     */
+    public function testContinuesPastCallableEntryInList(): void
+    {
+        $field = new CompiledFieldDefinition(
+            accessor: 'name',
+            compute: null,
+            relation: null,
+            resource: null,
+            fields: null,
+            constraint: null,
+            extras: [],
+            needs: [],
+            guards: [fn ($value, $model) => true, 'not_a_function'],
+            transformers: [],
+        );
+
+        $schema = new CompiledSchema(fields: ['name' => $field], counts: []);
+
+        $errors = $this->makeRule()->validate('App\Http\Resources\UserResource', null, $schema);
+
+        self::assertCount(1, $errors);
+        self::assertSame('name', $errors[0]->fieldKey);
+        self::assertSame('Item at index 1 is not callable', $errors[0]->defect);
+    }
+
+    /**
      * Build a concrete rule that validates each field's guard list.
      *
      * @return \SineMacula\ApiToolkit\Schema\Validation\Rules\ValidatesCallableLists

--- a/tests/Unit/Services/Input/ArrayInputTest.php
+++ b/tests/Unit/Services/Input/ArrayInputTest.php
@@ -55,6 +55,21 @@ final class ArrayInputTest extends TestCase
     }
 
     /**
+     * Test that non-scalar values coerce to the zero value of the target type.
+     *
+     * @return void
+     */
+    public function testNonScalarValuesCoerceToZeroValues(): void
+    {
+        $input = new ArrayInput([
+            'list' => ['a', 'b'],
+        ]);
+
+        self::assertSame('', $input->string('list'));
+        self::assertSame(0, $input->integer('list'));
+    }
+
+    /**
      * Test that get() returns the supplied default for a missing key.
      *
      * @return void

--- a/tests/Unit/Services/Input/InputDataTest.php
+++ b/tests/Unit/Services/Input/InputDataTest.php
@@ -279,9 +279,94 @@ final class InputDataTest extends TestCase
         /** @var \Tests\Fixtures\Input\SampleInput $input */
         $input = $reflection->newInstanceWithoutConstructor();
 
+        // Initialise the first and last properties, leaving the middle one
+        // uninitialised, so the loop must skip the gap and keep the later
+        // value.
         $reflection->getProperty('city')->setValue($input, 'OnlyCity');
+        $reflection->getProperty('status')->setValue($input, StubStatusEnum::ACTIVE);
 
-        self::assertSame(['city' => 'OnlyCity'], $input->toArray());
+        self::assertSame(
+            ['city' => 'OnlyCity', 'status' => StubStatusEnum::ACTIVE],
+            $input->toArray(),
+        );
+    }
+
+    /**
+     * Test that a value for a parameter without a named type is left unchanged.
+     *
+     * The enum cast only applies when the parameter declares a single named
+     * type, so a union-typed parameter must receive its value verbatim.
+     *
+     * @return void
+     */
+    public function testCastValueLeavesNonNamedTypeValueUnchanged(): void
+    {
+        $definition = new class (data: '') extends InputData {
+            /**
+             * Create a new instance with a union-typed promoted property.
+             *
+             * @param  int|string  $data
+             */
+            public function __construct(
+
+                /** A union-typed value that must not be cast. */
+                public readonly int|string $data = '',
+            ) {}
+
+            /**
+             * Require the union-typed field.
+             *
+             * @return array<string, mixed>
+             */
+            #[\Override]
+            public static function rules(): array
+            {
+                return ['data' => ['required']];
+            }
+        };
+
+        $result = $definition::from(['data' => 'hello']);
+
+        self::assertSame('hello', $result->data);
+    }
+
+    /**
+     * Test that a non-string value for an enum parameter is passed through.
+     *
+     * The enum cast only applies to string values, so an already-constructed
+     * enum instance must be returned unchanged rather than re-cast.
+     *
+     * @return void
+     */
+    public function testCastValueLeavesNonStringEnumValueUnchanged(): void
+    {
+        $definition = new class (status: StubStatusEnum::ACTIVE) extends InputData {
+            /**
+             * Create a new instance with an enum-typed promoted property.
+             *
+             * @param  \Tests\Fixtures\Services\Input\Enums\StubStatusEnum|null  $status
+             */
+            public function __construct(
+
+                /** An enum value given as an instance, not a string. */
+                public readonly ?StubStatusEnum $status = null,
+            ) {}
+
+            /**
+             * Accept the status field without transforming it.
+             *
+             * @return array<string, mixed>
+             */
+            #[\Override]
+            public static function rules(): array
+            {
+                return ['status' => []];
+            }
+        };
+
+        $result = $definition::from(['status' => StubStatusEnum::ACTIVE]);
+
+        self::assertSame(StubStatusEnum::ACTIVE, $result->status);
     }
 
     /**

--- a/tests/Unit/Services/ServiceRunnerTest.php
+++ b/tests/Unit/Services/ServiceRunnerTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Tests\Unit\Services;
 
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Exceptions\LockOperationException;
 use SineMacula\ApiToolkit\Services\Actors\AnonymousActor;
@@ -530,5 +531,177 @@ final class ServiceRunnerTest extends TestCase
         (new ServiceRunner)->run($service, ServiceContext::for(new AnonymousActor));
 
         self::assertSame(['A:before', 'B:before', 'B:after', 'A:after'], iterator_to_array($callOrder));
+    }
+
+    /**
+     * Test that an afterCommit throw is logged with the throwing exception in
+     * the log context.
+     *
+     * @return void
+     */
+    public function testAfterCommitThrowIsLoggedWithException(): void
+    {
+        Log::shouldReceive('error')
+            ->once()
+            ->with(
+                'Service afterCommit threw an exception.',
+                \Mockery::on(static fn (array $context): bool => ($context['exception'] ?? null) instanceof \RuntimeException),
+            );
+
+        $service = new class (new ArrayInput([])) extends Service {
+            /**
+             * Return a concrete output value.
+             *
+             * @return string
+             */
+            #[\Override]
+            protected function handle(): mixed
+            {
+                return 'output';
+            }
+
+            /**
+             * Throw a side-effect exception.
+             *
+             * @param  mixed  $output
+             * @return void
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function afterCommit(mixed $output): void
+            {
+                throw new \RuntimeException('after-commit-error');
+            }
+        };
+
+        $result = (new ServiceRunner)->run($service, ServiceContext::for(new AnonymousActor));
+
+        self::assertTrue($result->succeeded());
+        self::assertCount(1, $result->sideEffectErrors());
+    }
+
+    /**
+     * Test that an onFailure throw is logged with the throwing exception in the
+     * log context.
+     *
+     * @return void
+     */
+    public function testOnFailureThrowIsLoggedWithException(): void
+    {
+        Log::shouldReceive('error')
+            ->once()
+            ->with(
+                'Service onFailure threw an exception.',
+                \Mockery::on(static fn (array $context): bool => ($context['exception'] ?? null) instanceof \RuntimeException),
+            );
+
+        $service = new class (new ArrayInput([])) extends Service {
+            /**
+             * Always throw a domain exception.
+             *
+             * @return never
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function handle(): never
+            {
+                throw new \RuntimeException('domain error');
+            }
+
+            /**
+             * Throw a secondary exception from the failure hook.
+             *
+             * @param  \Throwable  $exception
+             * @return void
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function onFailure(\Throwable $exception): void
+            {
+                throw new \RuntimeException('on-failure-error');
+            }
+        };
+
+        $result = (new ServiceRunner)->run($service, ServiceContext::for(new AnonymousActor));
+
+        self::assertTrue($result->failed());
+    }
+
+    /**
+     * Test that the dispatched event carries the elapsed execution duration
+     * rather than a corrupted time value.
+     *
+     * @return void
+     */
+    public function testDispatchedEventCarriesElapsedDuration(): void
+    {
+        Event::fake();
+
+        $service = new OutputService(new ArrayInput(['message' => 'x']));
+
+        (new ServiceRunner)->run($service, ServiceContext::for(new AnonymousActor));
+
+        Event::assertDispatched(
+            ServiceCompleted::class,
+            static fn (ServiceCompleted $event): bool => $event->duration >= 0.0 && $event->duration < 3600.0,
+        );
+    }
+
+    /**
+     * Test that the observability event is still dispatched when the
+     * failure-handling path itself throws, proving the dispatch is guaranteed
+     * by the finally rather than merely reached on the ordinary catch path.
+     *
+     * @return void
+     */
+    public function testEventDispatchedEvenWhenFailureHandlingThrows(): void
+    {
+        Event::fake();
+        Log::shouldReceive('error')->andThrow(new \RuntimeException('log-error'));
+
+        $service = new class (new ArrayInput([])) extends Service {
+            /**
+             * Always throw a domain exception.
+             *
+             * @return never
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function handle(): never
+            {
+                throw new \RuntimeException('domain error');
+            }
+
+            /**
+             * Throw a secondary exception from the failure hook.
+             *
+             * @param  \Throwable  $exception
+             * @return void
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function onFailure(\Throwable $exception): void
+            {
+                throw new \RuntimeException('on-failure-error');
+            }
+        };
+
+        $caught = null;
+
+        try {
+            (new ServiceRunner)->run($service, ServiceContext::for(new AnonymousActor));
+        } catch (\RuntimeException $exception) {
+            $caught = $exception;
+        }
+
+        self::assertInstanceOf(\RuntimeException::class, $caught);
+        self::assertSame('log-error', $caught->getMessage());
+
+        Event::assertDispatched(ServiceFailed::class);
     }
 }

--- a/tests/Unit/Services/ServiceTest.php
+++ b/tests/Unit/Services/ServiceTest.php
@@ -4,12 +4,17 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\Services;
 
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SineMacula\ApiToolkit\Contracts\LockKeyProvider;
 use SineMacula\ApiToolkit\Services\Actors\AnonymousActor;
 use SineMacula\ApiToolkit\Services\Contracts\Actor;
 use SineMacula\ApiToolkit\Services\Contracts\ServiceInput;
+use SineMacula\ApiToolkit\Services\Enums\ServiceSource;
+use SineMacula\ApiToolkit\Services\Events\ServiceCompleted;
 use SineMacula\ApiToolkit\Services\Input\ArrayInput;
+use SineMacula\ApiToolkit\Services\Jobs\ServiceJob;
 use SineMacula\ApiToolkit\Services\Service;
 use SineMacula\ApiToolkit\Services\ServiceContext;
 use SineMacula\ApiToolkit\Services\ServiceResult;
@@ -303,5 +308,166 @@ final class ServiceTest extends TestCase
         $service = new OutputService(new ArrayInput([]));
 
         self::assertInstanceOf(Actor::class, $service->actor());
+    }
+
+    /**
+     * Test that run() reuses the context supplied via withContext() rather than
+     * building a fresh one.
+     *
+     * @return void
+     */
+    public function testRunReusesContextSuppliedByWithContext(): void
+    {
+        Event::fake();
+
+        $context = ServiceContext::for(new StubActor, ServiceSource::HTTP, [], 'fixed-correlation');
+        $service = new OutputService(new ArrayInput(['message' => 'hello']));
+
+        $service->withContext($context)->run();
+
+        Event::assertDispatched(
+            ServiceCompleted::class,
+            static fn (ServiceCompleted $event): bool => $event->correlationId === 'fixed-correlation',
+        );
+    }
+
+    /**
+     * Test that dispatch() reuses the context supplied via withContext() rather
+     * than building a fresh one.
+     *
+     * @return void
+     */
+    public function testDispatchReusesContextSuppliedByWithContext(): void
+    {
+        Queue::fake();
+
+        $context = ServiceContext::for(new StubActor, ServiceSource::HTTP, [], 'fixed-correlation');
+        $service = new OutputService(new ArrayInput([]));
+
+        $service->withContext($context)->dispatch();
+
+        Queue::assertPushed(
+            ServiceJob::class,
+            static fn (ServiceJob $job): bool => $job->context->correlationId === 'fixed-correlation'
+                && $job->context->source                                      === ServiceSource::HTTP,
+        );
+    }
+
+    /**
+     * Test that serviceHooks wires prepare() so it is invoked during a run.
+     *
+     * @return void
+     */
+    public function testServiceHooksInvokePrepareDuringRun(): void
+    {
+        $service = new class (new ArrayInput([])) extends Service {
+            /** @var bool */
+            public bool $prepareCalled = false;
+
+            /**
+             * Record the prepare call.
+             *
+             * @return void
+             */
+            #[\Override]
+            protected function prepare(): void
+            {
+                $this->prepareCalled = true;
+            }
+
+            /**
+             * Return null output.
+             *
+             * @return mixed
+             */
+            #[\Override]
+            protected function handle(): mixed
+            {
+                return null;
+            }
+        };
+
+        $service->run();
+
+        self::assertTrue($service->prepareCalled);
+    }
+
+    /**
+     * Test that serviceHooks wires onFailure() so it is invoked when the run
+     * fails.
+     *
+     * @return void
+     */
+    public function testServiceHooksInvokeOnFailureDuringRun(): void
+    {
+        $service = new class (new ArrayInput([])) extends Service {
+            /** @var bool */
+            public bool $onFailureCalled = false;
+
+            /**
+             * Always throw a domain exception.
+             *
+             * @return never
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function handle(): never
+            {
+                throw new \RuntimeException('domain failure');
+            }
+
+            /**
+             * Record the onFailure call.
+             *
+             * @param  \Throwable  $exception
+             * @return void
+             */
+            #[\Override]
+            protected function onFailure(\Throwable $exception): void
+            {
+                $this->onFailureCalled = true;
+            }
+        };
+
+        $service->run();
+
+        self::assertTrue($service->onFailureCalled);
+    }
+
+    /**
+     * Test that every overridable lifecycle hook remains protected so concrete
+     * services can override it.
+     *
+     * @return void
+     */
+    public function testLifecycleHooksRemainProtectedForOverriding(): void
+    {
+        // Exercise the non-overridden base hook bodies so they are covered.
+        (new OutputService(new ArrayInput([])))->run();
+
+        $failing = new class (new ArrayInput([])) extends Service {
+            /**
+             * Always throw so the base onFailure() hook is exercised.
+             *
+             * @return never
+             *
+             * @throws \RuntimeException
+             */
+            #[\Override]
+            protected function handle(): never
+            {
+                throw new \RuntimeException('domain failure');
+            }
+        };
+
+        $failing->run();
+
+        foreach (['authorize', 'validate', 'prepare', 'onFailure', 'concerns', 'lockId'] as $hook) {
+            self::assertTrue(
+                (new \ReflectionMethod(Service::class, $hook))->isProtected(),
+                $hook . '() must remain protected so subclasses can override it',
+            );
+        }
     }
 }

--- a/tests/Unit/Traits/OrdersFieldsTest.php
+++ b/tests/Unit/Traits/OrdersFieldsTest.php
@@ -90,6 +90,16 @@ final class OrdersFieldsTest extends TestCase
             ],
             ['_type', 'id', 'age', 'name', 'created_at', 'updated_at'],
         ];
+
+        yield 'id keeps priority when a field name collides on its weight' => [
+            [
+                ''      => 'x',
+                'id'    => 1,
+                '_type' => 'users',
+                'name'  => 'Alice',
+            ],
+            ['_type', 'id', '', 'name'],
+        ];
     }
 
     /**
@@ -153,6 +163,16 @@ final class OrdersFieldsTest extends TestCase
                 'name' => 'Alice',
             ],
             ['name', 'id'],
+        ];
+
+        yield 'absent field mid-list keeps later requested fields in order' => [
+            ['name', 'missing', 'email'],
+            [
+                'id'    => 1,
+                'email' => self::TEST_EMAIL,
+                'name'  => 'Alice',
+            ],
+            ['name', 'email', 'id'],
         ];
     }
 


### PR DESCRIPTION
## What

A comprehensive coverage pass over the whole test suite ahead of the v2 publish. Two layers:

1. **e2e/feature coverage** - drive every feature through a real HTTP request (or Artisan command) end to end, closing the gaps where a behaviour was only proven below the HTTP layer.
2. **Mutation hardening** - `src/` was already at **100% line coverage**, so a full Infection run was used to find code that executes but is not asserted tightly enough. Genuine escaped mutants are now killed with targeted assertions in the name-mapped test classes.

No `src/` changes - this PR is tests only.

## Numbers

| | Before | After |
|------------------------|-------:|------:|
| Tests                  | 2027   | 2208  |
| `src/` line coverage   | ~      | 100%  |
| Full mutation MSI      | 93%    | 98%   |
| Escaped mutants        | 198    | 48    |

- **+181 tests.** 94 new e2e/feature tests, then ~87 assertions/tests added to kill mutants.
- **151 genuine mutants killed**; the remaining **48 are equivalent mutants** (no input produces an observable difference - e.g. a fallback normalised by a following guard, an `isset()`-based visited check, `[] + \$data === \$data`). These were each proven equivalent rather than chased.

## e2e/feature coverage added

Across all 14 areas: filter operator matrix (`\$neq`/`\$lt`/`\$ge`/`\$le`/`\$between`/`\$null`/`\$notNull`), `\$or`/`\$and` grouping, AND composition, custom operators, malformed-JSON 422; sparse fieldsets, column narrowing over HTTP, `:all`, computed/accessor fields, `withoutFields`; offset + cursor pagination edges, multi-column sort; relation aggregates (undeclared omission, default vs non-default, values, filter composition); blocklist posture, nested relation filters, `\$has`/`\$hasnt`, fail-quiet drop, nested-rejection 422, multi-hop traversal; per-row + auth-user guards, single polymorphic envelope; repository caching (zero-query hits, per-filter fingerprinting, invalidation round trip, `withoutCache`, reference mode); deferred writes (auto-flush, throw/log/collect, transactional rollback, console boundary); service envelopes (validation/lock/authorize/handle-failure); middleware (per-caller throttle keying, rate-limit headers, pretty print, capabilities); exception render strategies + the 405/401/400/410/413/423/503 taxonomy; guarded exports; OpenAPI/schema-validation CLI failure paths; and Octane cross-request isolation + boundary flush.

## Mutation hardening touched every subsystem

OpenAPI builders/resolution/metadata, schema introspection + validation rules, the service layer + input coercion, the container/lifecycle registrars, resource field/guard/eager-load/tabular resolution, resource discovery, the repository write pool + criteria, the exception taxonomy, and query parsing/ordering. Four name-mapped unit tests that did not previously exist were added (FieldColumnMapper, ToolkitCollection, ToolkitResource, PerItemGuardedFieldException).

## Notes

- The `\$contains` (JSON containment) tests skip on the default SQLite driver, whose grammar rejects `whereJsonContains`; they run under MySQL/Postgres (`DB_DRIVER=mysql`).
- Verified locally: full suite green (2208, 3 SQLite skips), coverage gate clean (no invalid `@Covers`, no warnings), `qlty check` clean, full mutation MSI 98%.