### PR TITLE
style: reflow docblock prose to the greedy 80-char comment wrap

### DIFF
--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -88,9 +88,9 @@ return [
         'detail' => 'The service is temporarily unavailable, please try again a little later',
     ],
 
-    // No title is defined for the generic HTTP error; the handler derives
-    // it from the runtime HTTP status so the response reflects the original
-    // status phrase (e.g. "Conflict" for an abort(409))
+    // No title is defined for the generic HTTP error; the handler derives it
+    // from the runtime HTTP status so the response reflects the original status
+    // phrase (e.g. "Conflict" for an abort(409))
     ErrorCode::HTTP_ERROR->getCode() => [
         'detail' => 'The request could not be completed',
     ],

--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -120,8 +120,8 @@ final class ApiServiceProvider extends ServiceProvider
      *
      * The merge is skipped while the config cache is being built: baking
      * discovered bindings into the cached config would make them
-     * indistinguishable from explicit entries and mask later discovery
-     * changes. Runtime boots always merge fresh discoveries on top.
+     * indistinguishable from explicit entries and mask later discovery changes.
+     * Runtime boots always merge fresh discoveries on top.
      *
      * @return void
      */

--- a/src/Attributes/ForModel.php
+++ b/src/Attributes/ForModel.php
@@ -11,8 +11,8 @@ namespace SineMacula\ApiToolkit\Attributes;
  * resource paths and compiled into the model to resource map, so the binding
  * lives on the resource itself rather than in a hand-maintained config entry.
  * The attribute may be repeated to bind one resource to several models. An
- * explicit `resource_map` entry for the same model always wins, acting as
- * the canonical-resource tiebreak when a model has more than one resource.
+ * explicit `resource_map` entry for the same model always wins, acting as the
+ * canonical-resource tiebreak when a model has more than one resource.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Exceptions/ApiExceptionHandler.php
+++ b/src/Exceptions/ApiExceptionHandler.php
@@ -80,8 +80,8 @@ final class ApiExceptionHandler
             return null;
         }
 
-        // In auto mode, defer to Laravel's default rendering when the
-        // request does not expect JSON and debug mode is enabled
+        // In auto mode, defer to Laravel's default rendering when the request
+        // does not expect JSON and debug mode is enabled
         if ($strategy === 'auto' && !$request->expectsJson() && (bool) Config::get('app.debug')) {
             return null;
         }
@@ -187,9 +187,9 @@ final class ApiExceptionHandler
      */
     private static function mapGenericHttpException(SymfonyHttpExceptionInterface $exception, ?array $meta, array $headers): ApiException
     {
-        // Laravel's handler converts session token mismatches to a generic
-        // 419 HttpException before render callbacks run; 419 has no
-        // HttpStatus case, so map it back to the dedicated exception
+        // Laravel's handler converts session token mismatches to a generic 419
+        // HttpException before render callbacks run; 419 has no HttpStatus
+        // case, so map it back to the dedicated exception
         if ($exception->getStatusCode() === 419) {
             return new TokenMismatchException($meta, $headers, $exception);
         }

--- a/src/Http/Middleware/Concerns/ThrottleRequestsTrait.php
+++ b/src/Http/Middleware/Concerns/ThrottleRequestsTrait.php
@@ -27,8 +27,8 @@ trait ThrottleRequestsTrait
     protected function resolveRequestSignature(#[\SensitiveParameter] $request): string
     {
         // phpcs:enable
-        // Invoke the route resolver directly, as route() is documented as
-        // never returning null when called without arguments
+        // Invoke the route resolver directly, as route() is documented as never
+        // returning null when called without arguments
         $route = ($request->getRouteResolver())();
 
         if ($route === null) {

--- a/src/Http/Resources/Concerns/DerivedTabularSchema.php
+++ b/src/Http/Resources/Concerns/DerivedTabularSchema.php
@@ -8,12 +8,11 @@ use Illuminate\Http\Request;
 use SineMacula\Exporter\Schema\TabularSchema;
 
 /**
- * Concrete TabularSchema implementation backing the DerivesTabularSchema
- * trait.
+ * Concrete TabularSchema implementation backing the DerivesTabularSchema trait.
  *
  * Holds the ordered list of Column instances produced from the resource's
- * compiled field definitions and returns them to the export engine. This
- * class is an implementation detail of the trait and is not intended to be
+ * compiled field definitions and returns them to the export engine. This class
+ * is an implementation detail of the trait and is not intended to be
  * instantiated or extended outside it.
  *
  * @internal

--- a/src/Http/Resources/Concerns/DerivesTabularSchema.php
+++ b/src/Http/Resources/Concerns/DerivesTabularSchema.php
@@ -104,10 +104,10 @@ trait DerivesTabularSchema
     /**
      * Build the value-resolving column for the field, before guards.
      *
-     * Fields with a compute, a callable accessor, or transformers resolve
-     * their value through a fresh resource so the JSON value, transformers
-     * included, is mirrored in the cell. Plain scalar and string-accessor
-     * fields without transformers keep the exporter's raw attribute read.
+     * Fields with a compute, a callable accessor, or transformers resolve their
+     * value through a fresh resource so the JSON value, transformers included,
+     * is mirrored in the cell. Plain scalar and string-accessor fields without
+     * transformers keep the exporter's raw attribute read.
      *
      * @param  string  $key
      * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition
@@ -167,9 +167,9 @@ trait DerivesTabularSchema
     /**
      * Apply the field's guards to the column.
      *
-     * A field with no guards is returned untouched. A guard that inspects
-     * the row cannot gate a flat column, so the field is refused. Guards
-     * that depend only on the request map to the column-visibility gate.
+     * A field with no guards is returned untouched. A guard that inspects the
+     * row cannot gate a flat column, so the field is refused. Guards that
+     * depend only on the request map to the column-visibility gate.
      *
      * @param  string  $key
      * @param  \SineMacula\ApiToolkit\Schema\CompiledFieldDefinition  $definition

--- a/src/Http/Resources/Concerns/EagerLoadPlanner.php
+++ b/src/Http/Resources/Concerns/EagerLoadPlanner.php
@@ -225,9 +225,9 @@ final class EagerLoadPlanner
                 continue;
             }
 
-            // Alias the aggregate to the full attribute name the resolver
-            // reads back ({presentKey}_{metric}_{column}); Laravel uses the
-            // "as" alias verbatim as the result column, so it must match.
+            // Alias the aggregate to the full attribute name the resolver reads
+            // back ({presentKey}_{metric}_{column}); Laravel uses the "as"
+            // alias verbatim as the result column, so it must match.
             $aliased    = $definition->relation . ' as ' . $definition->presentKey . '_' . $metric . '_' . $definition->column;
             $constraint = $definition->constraint;
 

--- a/src/Http/Resources/ResourceDiscovery.php
+++ b/src/Http/Resources/ResourceDiscovery.php
@@ -15,20 +15,20 @@ use SineMacula\ApiToolkit\Enums\CacheKeys;
  * Boot-time discovery of attribute-bound API resources.
  *
  * Scans the configured resource paths for classes carrying the ForModel
- * attribute and compiles them into a model to resource map. The compiled map
- * is memoised through the metadata cache under a key fingerprinted by the
- * scanned file list and modification times, so the expensive tokenise and
- * reflect pass runs only when a scanned file actually changes, while adding,
- * editing, or removing a resource rotates the key and triggers a rescan on
- * the next boot. When schema validation is enabled the cache is bypassed
- * entirely so every diagnostic fires on every boot.
+ * attribute and compiles them into a model to resource map. The compiled map is
+ * memoised through the metadata cache under a key fingerprinted by the scanned
+ * file list and modification times, so the expensive tokenise and reflect pass
+ * runs only when a scanned file actually changes, while adding, editing, or
+ * removing a resource rotates the key and triggers a rescan on the next boot.
+ * When schema validation is enabled the cache is bypassed entirely so every
+ * diagnostic fires on every boot.
  *
- * Files are visited in a deterministic (sorted) order; when two resources
- * claim the same model the first discovered binding wins and a warning is
- * logged, or the scan fails hard when schema validation is enabled - unless
- * the model is explicitly declared in the resource map, which resolves the
- * ambiguity. A binding whose class is not an instantiable API resource, or
- * whose model does not exist, is skipped with a warning.
+ * Files are visited in a deterministic (sorted) order; when two resources claim
+ * the same model the first discovered binding wins and a warning is logged, or
+ * the scan fails hard when schema validation is enabled - unless the model is
+ * explicitly declared in the resource map, which resolves the ambiguity. A
+ * binding whose class is not an instantiable API resource, or whose model does
+ * not exist, is skipped with a warning.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -111,9 +111,9 @@ final readonly class ResourceDiscovery
      * Merge the bindings declared by the given class into the map.
      *
      * A class that is not autoloadable is skipped silently (the scan derives
-     * names from file contents, so a stray file is not an error). A model
-     * that is already bound is never rebound - the first discovered binding
-     * wins - and the duplicate claim is reported.
+     * names from file contents, so a stray file is not an error). A model that
+     * is already bound is never rebound - the first discovered binding wins -
+     * and the duplicate claim is reported.
      *
      * @param  array<class-string, class-string>  $map
      * @param  string  $class
@@ -174,8 +174,8 @@ final readonly class ResourceDiscovery
     }
 
     /**
-     * Determine whether the discovered binding is valid, logging a warning
-     * when it is not.
+     * Determine whether the discovered binding is valid, logging a warning when
+     * it is not.
      *
      * @param  class-string  $class
      * @param  string  $model
@@ -195,8 +195,8 @@ final readonly class ResourceDiscovery
     }
 
     /**
-     * Diagnose the discovered binding, returning null when it is valid, or
-     * the rejection message otherwise.
+     * Diagnose the discovered binding, returning null when it is valid, or the
+     * rejection message otherwise.
      *
      * @param  class-string  $class
      * @param  string  $model
@@ -270,9 +270,9 @@ final readonly class ResourceDiscovery
     }
 
     /**
-     * Read a file's contents, tolerating a file removed between enumeration
-     * and read (a hot deploy swapping resources mid-scan, or a concurrent
-     * test) by returning null rather than aborting discovery.
+     * Read a file's contents, tolerating a file removed between enumeration and
+     * read (a hot deploy swapping resources mid-scan, or a concurrent test) by
+     * returning null rather than aborting discovery.
      *
      * @param  string  $file
      * @return string|null
@@ -295,8 +295,8 @@ final readonly class ResourceDiscovery
     /**
      * Resolve the fully qualified class names declared in the given file.
      *
-     * Tokenising avoids loading the file, so a scanned file that is not a
-     * class (or is not autoloadable) has no side effects on the process. A
+     * Tokenising avoids loading the file, so a scanned file that is not a class
+     * (or is not autoloadable) has no side effects on the process. A
      * class keyword preceded by a double colon (a ::class constant) or by
      * new (an anonymous class) is not a declaration and is skipped.
      *

--- a/src/Repositories/Criteria/QuerySurface.php
+++ b/src/Repositories/Criteria/QuerySurface.php
@@ -32,8 +32,8 @@ use SineMacula\ApiToolkit\Schema\SchemaCompiler;
  * root relation against the declared traversable set, and each onward relation
  * against the related resource's declared traversable set, failing closed when
  * the related model has no mapped resource. Traversal depth is therefore
- * bounded by declarations rather than a fixed limit - a chain ends at the
- * first undeclared or unmapped hop.
+ * bounded by declarations rather than a fixed limit - a chain ends at the first
+ * undeclared or unmapped hop.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Services/Events/ServiceEvent.php
+++ b/src/Services/Events/ServiceEvent.php
@@ -14,9 +14,9 @@ use SineMacula\ApiToolkit\Services\ServiceResult;
  * metadata. Concrete subclasses (ServiceCompleted, ServiceFailed) distinguish
  * the success and failure cases so consumers can subscribe to each.
  *
- * The inputSummary is produced by the input's toArray() and flows verbatim
- * to every listener (audit, telemetry); it is not redacted here. Override
- * the input's toArray() to scrub sensitive keys before they reach listeners.
+ * The inputSummary is produced by the input's toArray() and flows verbatim to
+ * every listener (audit, telemetry); it is not redacted here. Override the
+ * input's toArray() to scrub sensitive keys before they reach listeners.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -20,9 +20,9 @@ use Tests\TestCase;
  * Feature tests for the authorized controller guard through the HTTP kernel.
  *
  * Dispatches real requests to an authorized controller backed by a policy: an
- * action outside the guard exclusions is gated by its ability and, when
- * denied, renders the toolkit forbidden envelope, while an excluded action
- * bypasses the guard entirely.
+ * action outside the guard exclusions is gated by its ability and, when denied,
+ * renders the toolkit forbidden envelope, while an excluded action bypasses the
+ * guard entirely.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Feature/CombinedRequestTest.php
+++ b/tests/Feature/CombinedRequestTest.php
@@ -22,10 +22,10 @@ use Tests\TestCase;
  *
  * Under the default allowlist posture a real request narrows the fieldset,
  * applies a declared filter, orders by a declared sortable column, and
- * truncates with a page limit. The four modifiers are proven to apply
- * together: the fieldset drops undeclared keys, the filtered total excludes
- * non-matching rows, the ordering fixes row positions, and the limit caps the
- * page while the meta still reports the filtered total.
+ * truncates with a page limit. The four modifiers are proven to apply together:
+ * the fieldset drops undeclared keys, the filtered total excludes non-matching
+ * rows, the ordering fixes row positions, and the limit caps the page while the
+ * meta still reports the filtered total.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Feature/DeepTraversalHttpTest.php
+++ b/tests/Feature/DeepTraversalHttpTest.php
@@ -24,9 +24,9 @@ use Tests\TestCase;
  *
  * When the related resource declares an onward traversable relation the chain
  * users -> posts -> user is permitted at every hop and compiles to nested
- * whereHas constraints. A real request proves the per-hop gating and the
- * nested existence constraint survive the HTTP layer: only the user owning a
- * post whose onward user matches the nested predicate is returned.
+ * whereHas constraints. A real request proves the per-hop gating and the nested
+ * existence constraint survive the HTTP layer: only the user owning a post
+ * whose onward user matches the nested predicate is returned.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -59,8 +59,8 @@ final class MaintenanceModeTest extends TestCase
     }
 
     /**
-     * Test that a guarded route renders the service-unavailable envelope
-     * while maintenance mode is active.
+     * Test that a guarded route renders the service-unavailable envelope while
+     * maintenance mode is active.
      *
      * @return void
      */

--- a/tests/Feature/OffsetPaginationTest.php
+++ b/tests/Feature/OffsetPaginationTest.php
@@ -21,11 +21,11 @@ use Tests\TestCase;
 /**
  * Feature tests for offset-paginated collections through the kernel.
  *
- * Driving `page=` over the length-aware paginator returns the requested
- * slice of rows alongside the full meta block (total, count, continue), the
- * self, first, prev, next, and last links, and the total-count response
- * header. The terminal page reports no further pages and a null next link,
- * and the configured default limit applies when the client supplies none.
+ * Driving `page=` over the length-aware paginator returns the requested slice
+ * of rows alongside the full meta block (total, count, continue), the self,
+ * first, prev, next, and last links, and the total-count response header. The
+ * terminal page reports no further pages and a null next link, and the
+ * configured default limit applies when the client supplies none.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Discovery/Invalid/AbstractAttributedResource.php
+++ b/tests/Fixtures/Discovery/Invalid/AbstractAttributedResource.php
@@ -9,8 +9,8 @@ use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use Tests\Fixtures\Models\User;
 
 /**
- * Fixture abstract resource with a model binding; discovery must skip it with
- * a warning because it is not instantiable.
+ * Fixture abstract resource with a model binding; discovery must skip it with a
+ * warning because it is not instantiable.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Discovery/Invalid/MissingModelResource.php
+++ b/tests/Fixtures/Discovery/Invalid/MissingModelResource.php
@@ -9,8 +9,8 @@ use SineMacula\ApiToolkit\Http\Resources\ApiResource;
 use SineMacula\ApiToolkit\Schema\Field;
 
 /**
- * Fixture resource whose declared model does not exist; discovery must skip
- * it with a warning.
+ * Fixture resource whose declared model does not exist; discovery must skip it
+ * with a warning.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Overrides/functions.php
+++ b/tests/Fixtures/Overrides/functions.php
@@ -128,9 +128,9 @@ use Tests\Fixtures\Support\FunctionOverrides;
 /**
  * Override class_exists() within the Providers\Registrars namespace.
  *
- * Lets tests simulate the presence or absence of optional integration
- * packages (Octane, notifications) so the class_exists guards on both branches
- * are observable without changing the installed dependency set.
+ * Lets tests simulate the presence or absence of optional integration packages
+ * (Octane, notifications) so the class_exists guards on both branches are
+ * observable without changing the installed dependency set.
  *
  * @SuppressWarnings("php:S100")
  * @SuppressWarnings("php:S4144")

--- a/tests/Fixtures/Repositories/ReferenceCacheUserRepository.php
+++ b/tests/Fixtures/Repositories/ReferenceCacheUserRepository.php
@@ -12,8 +12,8 @@ use Tests\Fixtures\Models\User;
  * Fixture cacheable user repository operating in whole-table reference mode.
  *
  * Opts into the whole-table reference cache so a repeat read serves the
- * snapshot with zero queries, while a criteria-composed read falls through
- * to the database.
+ * snapshot with zero queries, while a criteria-composed read falls through to
+ * the database.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Resources/AuthUserGuardedUserResource.php
+++ b/tests/Fixtures/Resources/AuthUserGuardedUserResource.php
@@ -10,9 +10,9 @@ use SineMacula\ApiToolkit\Schema\Field;
 /**
  * Fixture user resource whose email field is guarded on the authenticated user.
  *
- * The email guard reads the request's authenticated user and reveals the
- * field only when that user is an admin. The is_admin accessor on the User
- * and ActorUser fixtures resolves to true when the authenticated user's email
+ * The email guard reads the request's authenticated user and reveals the field
+ * only when that user is an admin. The is_admin accessor on the User and
+ * ActorUser fixtures resolves to true when the authenticated user's email
  * begins with "admin@", so the field is absent for a guest and present only
  * under actingAs() of an admin user.
  *

--- a/tests/Fixtures/Resources/ConstrainedUserResource.php
+++ b/tests/Fixtures/Resources/ConstrainedUserResource.php
@@ -12,8 +12,8 @@ use SineMacula\ApiToolkit\Schema\Relation;
 /**
  * Fixture user resource whose posts relation is eager-load constrained.
  *
- * The posts relation carries a constraint closure that limits the eager load
- * to published posts, so the whole collection resolves through one constrained
+ * The posts relation carries a constraint closure that limits the eager load to
+ * published posts, so the whole collection resolves through one constrained
  * sub-query rather than a per-row filtered load.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/tests/Fixtures/Resources/ExportableUserResource.php
+++ b/tests/Fixtures/Resources/ExportableUserResource.php
@@ -16,9 +16,9 @@ use Tests\Fixtures\Models\User;
  *
  * Used by the export-negotiator integration suite to prove that the
  * DerivesTabularSchema trait maps scalar, callable-accessor, and
- * callable-compute fields to the correct Column implementations without
- * manual column declarations. The relation field is present to confirm it is
- * skipped by the trait.
+ * callable-compute fields to the correct Column implementations without manual
+ * column declarations. The relation field is present to confirm it is skipped
+ * by the trait.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Fixtures/Resources/PerItemGuardedUserResource.php
+++ b/tests/Fixtures/Resources/PerItemGuardedUserResource.php
@@ -12,10 +12,10 @@ use Tests\Fixtures\Models\User;
 /**
  * Fixture user resource whose email field is guarded per row.
  *
- * The email guard reads the row being rendered and reveals the field only
- * when that user's status is active. Driven as a plain JSON collection, a
- * two-row set (one active, one inactive) therefore carries email on the
- * active row and omits it on the inactive row within the same body.
+ * The email guard reads the row being rendered and reveals the field only when
+ * that user's status is active. Driven as a plain JSON collection, a two-row
+ * set (one active, one inactive) therefore carries email on the active row and
+ * omits it on the inactive row within the same body.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/ApiServiceProviderTest.php
+++ b/tests/Integration/ApiServiceProviderTest.php
@@ -355,9 +355,9 @@ final class ApiServiceProviderTest extends TestCase
     }
 
     /**
-     * Test that the discovery merge is skipped while the config cache is
-     * being built, so discovered bindings are never baked into the cached
-     * config as pseudo-explicit entries.
+     * Test that the discovery merge is skipped while the config cache is being
+     * built, so discovered bindings are never baked into the cached config as
+     * pseudo-explicit entries.
      *
      * @return void
      */
@@ -677,9 +677,9 @@ final class ApiServiceProviderTest extends TestCase
 
         // The WritePoolFlushSubscriber also listens to JobProcessed, so we
         // check that QueueFlushSubscriber specifically was not subscribed by
-        // verifying only the write pool subscriber listeners exist.
-        // Since both subscribers listen to the same events, we verify the
-        // disabled branch by confirming boot completes without error.
+        // verifying only the write pool subscriber listeners exist. Since both
+        // subscribers listen to the same events, we verify the disabled branch
+        // by confirming boot completes without error.
         self::assertFalse((bool) $this->getConfig()->get('api-toolkit.lifecycle.queue'));
     }
 

--- a/tests/Integration/CacheableDeferrableInvalidationTest.php
+++ b/tests/Integration/CacheableDeferrableInvalidationTest.php
@@ -78,9 +78,9 @@ final class CacheableDeferrableInvalidationTest extends TestCase
     }
 
     /**
-     * Test that a deferred write flushed at the request boundary
-     * invalidates the combined repository's own per-query cache, so the
-     * next read re-queries and reflects the freshly persisted row.
+     * Test that a deferred write flushed at the request boundary invalidates
+     * the combined repository's own per-query cache, so the next read
+     * re-queries and reflects the freshly persisted row.
      *
      * @return void
      */
@@ -129,8 +129,8 @@ final class CacheableDeferrableInvalidationTest extends TestCase
         $result = $this->freshRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
 
         // Invalidation was disabled, so the warmed collection is served
-        // straight from cache without a database round trip and stays
-        // stale until its TTL expires.
+        // straight from cache without a database round trip and stays stale
+        // until its TTL expires.
         self::assertCount(0, DB::getQueryLog());
         self::assertCount(2, $result);
 

--- a/tests/Integration/CollectionEagerLoadRegressionTest.php
+++ b/tests/Integration/CollectionEagerLoadRegressionTest.php
@@ -24,8 +24,8 @@ use Tests\TestCase;
  * Regression guard for N+1 queries when serialising a relation-bearing
  * collection.
  *
- * Drives the eager-load planner through the criteria chain, then serialises
- * the resulting collection under a query log. The query count must be constant
+ * Drives the eager-load planner through the criteria chain, then serialises the
+ * resulting collection under a query log. The query count must be constant
  * regardless of how many rows the collection holds: a regression that made a
  * nested relation resolve per-row would inflate the count in lockstep with the
  * row count. The serialised relations are asserted to prove the constant count

--- a/tests/Integration/DeepNestingQueryBoundTest.php
+++ b/tests/Integration/DeepNestingQueryBoundTest.php
@@ -28,8 +28,8 @@ use Tests\TestCase;
  * Drives the eager-load planner across users -> posts -> tags, then serialises
  * the collection under a query log. The count must be a small constant (one
  * query per level, batched) and identical for a small and a large row count:
- * were the third level loaded per row, the count would scale with the rows.
- * The tags are asserted to have hydrated so a constant count cannot mean the
+ * were the third level loaded per row, the count would scale with the rows. The
+ * tags are asserted to have hydrated so a constant count cannot mean the
  * deepest level simply never loaded.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/tests/Integration/DeferredWriteRequestBoundaryTest.php
+++ b/tests/Integration/DeferredWriteRequestBoundaryTest.php
@@ -78,8 +78,8 @@ final class DeferredWriteRequestBoundaryTest extends TestCase
 
         $response->assertStatus(202);
 
-        // The route handler observed an empty table: deferred records
-        // must not be persisted while the request is still in flight.
+        // The route handler observed an empty table: deferred records must not
+        // be persisted while the request is still in flight.
         $response->assertJsonPath('persisted_during_request', 0);
 
         self::assertSame(2, DB::table('users')->count());

--- a/tests/Integration/ExportEagerLoadRegressionTest.php
+++ b/tests/Integration/ExportEagerLoadRegressionTest.php
@@ -26,12 +26,11 @@ use Tests\TestCase;
  * were already eager-loaded before the export began.
  *
  * ResourceCollectionSource and ResourceItemSource do not implement
- * DerivesAggregates, so the engine's withCount/withSum plan is never applied
- * to them. DerivesTabularSchema.tabular() also produces a schema whose
- * with() is empty (relation fields are skipped entirely), so loadMissing()
- * is not called on the pre-loaded collection. The tests confirm both
- * invariants empirically by counting the queries issued exclusively during
- * the streaming phase.
+ * DerivesAggregates, so the engine's withCount/withSum plan is never applied to
+ * them. DerivesTabularSchema.tabular() also produces a schema whose with() is
+ * empty (relation fields are skipped entirely), so loadMissing() is not called
+ * on the pre-loaded collection. The tests confirm both invariants empirically
+ * by counting the queries issued exclusively during the streaming phase.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -78,16 +77,16 @@ final class ExportEagerLoadRegressionTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * Test that a collection CSV export issues zero queries when the
-     * underlying models have their relations already eager-loaded.
+     * Test that a collection CSV export issues zero queries when the underlying
+     * models have their relations already eager-loaded.
      *
      * ResourceCollectionSource.rows() only calls loadMissing() when
-     * withRelations() received a non-empty list. DerivesTabularSchema skips
-     * all Relation fields, so the engine derives an empty with() list and
-     * the load is never triggered. The export also issues no withCount or
-     * withSum queries because ResourceCollectionSource does not implement
-     * DerivesAggregates. Pre-loaded models therefore reach the CSV writer
-     * with zero additional queries.
+     * withRelations() received a non-empty list. DerivesTabularSchema skips all
+     * Relation fields, so the engine derives an empty with() list and the load
+     * is never triggered. The export also issues no withCount or withSum
+     * queries because ResourceCollectionSource does not implement
+     * DerivesAggregates. Pre-loaded models therefore reach the CSV writer with
+     * zero additional queries.
      *
      * @return void
      */
@@ -214,11 +213,11 @@ final class ExportEagerLoadRegressionTest extends TestCase
      * Register the HTTP routes used by the eager-load regression scenarios.
      *
      * Both routes explicitly eager-load the organisation relation before
-     * returning the resource, mirroring what a real repository or service
-     * layer would do. The organisation column is a Relation field in
+     * returning the resource, mirroring what a real repository or service layer
+     * would do. The organisation column is a Relation field in
      * ExportableUserResource and is therefore excluded from the tabular
-     * schema - confirming that the export neither re-loads it nor uses it
-     * to derive aggregates.
+     * schema - confirming that the export neither re-loads it nor uses it to
+     * derive aggregates.
      *
      * @return void
      */

--- a/tests/Integration/ExportNegotiatorIntegrationTest.php
+++ b/tests/Integration/ExportNegotiatorIntegrationTest.php
@@ -23,9 +23,9 @@ use Tests\TestCase;
  * ExportNegotiator.
  *
  * Exercises ToolkitResource and ToolkitCollection delegation to the
- * ExportNegotiator when the exporter package is bound, verifying JSON
- * envelope fallback, tabular streaming (CSV/TSV), hierarchical streaming
- * (XML/NDJSON), and 406 rejection for resources without a tabular schema.
+ * ExportNegotiator when the exporter package is bound, verifying JSON envelope
+ * fallback, tabular streaming (CSV/TSV), hierarchical streaming (XML/NDJSON),
+ * and 406 rejection for resources without a tabular schema.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -157,8 +157,8 @@ final class ExportNegotiatorIntegrationTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * Test that a collection streams XML when the client sends
-     * Accept: application/xml (no tabular schema required).
+     * Test that a collection streams XML when the client sends Accept:
+     * application/xml (no tabular schema required).
      *
      * @return void
      */
@@ -181,8 +181,8 @@ final class ExportNegotiatorIntegrationTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * Test that a collection streams NDJSON when the client sends
-     * Accept: application/x-ndjson (no tabular schema required).
+     * Test that a collection streams NDJSON when the client sends Accept:
+     * application/x-ndjson (no tabular schema required).
      *
      * @return void
      */
@@ -243,8 +243,8 @@ final class ExportNegotiatorIntegrationTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * Test that a single item streams CSV when the client sends
-     * Accept: text/csv for a resource that implements ProvidesTabularExport.
+     * Test that a single item streams CSV when the client sends Accept:
+     * text/csv for a resource that implements ProvidesTabularExport.
      *
      * @return void
      */
@@ -301,8 +301,8 @@ final class ExportNegotiatorIntegrationTest extends TestCase
     }
 
     /**
-     * Test that the derived tabular schema resolves the timestamp accessor
-     * as an ISO 8601 string in the export.
+     * Test that the derived tabular schema resolves the timestamp accessor as
+     * an ISO 8601 string in the export.
      *
      * @return void
      */

--- a/tests/Integration/Repositories/DeferredWriteCacheInvalidationTest.php
+++ b/tests/Integration/Repositories/DeferredWriteCacheInvalidationTest.php
@@ -103,8 +103,8 @@ final class DeferredWriteCacheInvalidationTest extends TestCase
 
         $result = $this->freshTagRepository()->get(); // @phpstan-ignore staticMethod.dynamicCall
 
-        // The cache was not invalidated: the stale two-row collection is
-        // served straight from cache without touching the database.
+        // The cache was not invalidated: the stale two-row collection is served
+        // straight from cache without touching the database.
         self::assertCount(0, DB::getQueryLog());
         self::assertCount(2, $result);
 

--- a/tests/Integration/ResourceDiscoveryIntegrationTest.php
+++ b/tests/Integration/ResourceDiscoveryIntegrationTest.php
@@ -35,9 +35,9 @@ use Tests\TestCase;
 final class ResourceDiscoveryIntegrationTest extends TestCase
 {
     /**
-     * Test that discovered bindings merge beneath the configured resource
-     * map: an explicit entry wins for its model while discovered bindings
-     * fill the rest.
+     * Test that discovered bindings merge beneath the configured resource map:
+     * an explicit entry wins for its model while discovered bindings fill the
+     * rest.
      *
      * @return void
      */

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -358,8 +358,8 @@ final class ApiExceptionTest extends TestCase
     }
 
     /**
-     * Test that getCustomTitle returns the code-keyed title translation
-     * when one is registered, over the status-derived default title.
+     * Test that getCustomTitle returns the code-keyed title translation when
+     * one is registered, over the status-derived default title.
      *
      * @return void
      */
@@ -412,8 +412,8 @@ final class ApiExceptionTest extends TestCase
     }
 
     /**
-     * Test that a published per-status translation localises the derived
-     * title for the generic HTTP error path.
+     * Test that a published per-status translation localises the derived title
+     * for the generic HTTP error path.
      *
      * @return void
      */

--- a/tests/Unit/Http/Middleware/JsonPrettyPrintTest.php
+++ b/tests/Unit/Http/Middleware/JsonPrettyPrintTest.php
@@ -221,9 +221,9 @@ final class JsonPrettyPrintTest extends TestCase
     }
 
     /**
-     * Test that a non-streamed response whose content is not a string (its
-     * body is served from a file) is left untouched even when it declares a
-     * JSON content type.
+     * Test that a non-streamed response whose content is not a string (its body
+     * is served from a file) is left untouched even when it declares a JSON
+     * content type.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/ApiResourceCollectionTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceCollectionTest.php
@@ -280,13 +280,13 @@ final class ApiResourceCollectionTest extends TestCase
     {
         $user = User::create(['name' => 'Raw', 'email' => 'raw@example.com']);
 
-        // Construct with an empty collection to avoid wrapping overhead,
-        // then inject the raw model item directly.
+        // Construct with an empty collection to avoid wrapping overhead, then
+        // inject the raw model item directly.
         $collection = new ApiResourceCollection(collect([]), UserResource::class);
 
         // $this->collection is set to $this->resource->values() in the
-        // ResourceCollection constructor; inject the raw User directly so
-        // the false-branch of `instanceof ApiResource` in toArray() fires.
+        // ResourceCollection constructor; inject the raw User directly so the
+        // false-branch of `instanceof ApiResource` in toArray() fires.
         $reflection = new \ReflectionProperty($collection, 'collection');
         $reflection->setValue($collection, collect([$user])); // NOSONAR
 

--- a/tests/Unit/Http/Resources/ApiResourceTest.php
+++ b/tests/Unit/Http/Resources/ApiResourceTest.php
@@ -1931,8 +1931,8 @@ final class ApiResourceTest extends TestCase
         $outerClass::$childClassName = $childClassName;
 
         // No fields set for 'no_defaults_child' in the query — defaults are
-        // empty — so resolveChildFields falls through to getAllFields
-        // (line 837).
+        // empty — so resolveChildFields falls through to getAllFields (line
+        // 837).
         $map = $outerClass::eagerLoadMapFor(['rel']);
 
         self::assertContains('rel', $map);
@@ -1949,8 +1949,8 @@ final class ApiResourceTest extends TestCase
     {
         $this->clearSchemaCache();
 
-        // Request 'posts' on a resource whose schema does NOT include it as
-        // a relation. resolveSimpleProperty() is then called for 'posts'.
+        // Request 'posts' on a resource whose schema does NOT include it as a
+        // relation. resolveSimpleProperty() is then called for 'posts'.
         // User.posts() exists (method_exists = true) → reflection runs → the
         // return type is HasMany, not Attribute → line 388 condition is false.
         $resourceClass = new class (null) extends ApiResource {
@@ -1986,9 +1986,9 @@ final class ApiResourceTest extends TestCase
         $result = $resource->resolve();
 
         // 'posts' resolves via Eloquent's __isset/__get (relation lazy-loaded),
-        // so the key is present in the result. The main goal is to exercise
-        // the ReflectionMethod path (lines 385-386, 388) before falling through
-        // to the __isset check.
+        // so the key is present in the result. The main goal is to exercise the
+        // ReflectionMethod path (lines 385-386, 388) before falling through to
+        // the __isset check.
         self::assertArrayHasKey('_type', $result);
     }
 

--- a/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
+++ b/tests/Unit/Http/Resources/Concerns/DerivesTabularSchemaTest.php
@@ -317,9 +317,9 @@ final class DerivesTabularSchemaTest extends TestCase
     }
 
     /**
-     * Test that a non-callable guard preceding a request-scoped guard
-     * that hides the field is skipped rather than ending the check early,
-     * so the hiding guard still drops the column.
+     * Test that a non-callable guard preceding a request-scoped guard that
+     * hides the field is skipped rather than ending the check early, so the
+     * hiding guard still drops the column.
      *
      * @return void
      */

--- a/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
+++ b/tests/Unit/Http/Resources/ResourceDiscoveryTest.php
@@ -124,12 +124,12 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
-     * Test that files are visited in sorted order across the configured
-     * paths, so the first-discovered-wins conflict rule is deterministic
-     * regardless of path order.
+     * Test that files are visited in sorted order across the configured paths,
+     * so the first-discovered-wins conflict rule is deterministic regardless of
+     * path order.
      *
-     * The Conflict directory sorts before Primary, so its resource must win
-     * the User binding even though Primary is configured first.
+     * The Conflict directory sorts before Primary, so its resource must win the
+     * User binding even though Primary is configured first.
      *
      * @return void
      */
@@ -149,8 +149,7 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
-     * Test that a configured path that does not exist is skipped without
-     * error.
+     * Test that a configured path that does not exist is skipped without error.
      *
      * @return void
      */
@@ -182,8 +181,8 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
-     * Test that the compiled map is memoised through the metadata cache: a
-     * warm cache entry for the scanned file fingerprint is returned without
+     * Test that the compiled map is memoised through the metadata cache: a warm
+     * cache entry for the scanned file fingerprint is returned without
      * rescanning the filesystem.
      *
      * @return void
@@ -319,8 +318,8 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
-     * Test that changing a scanned file rotates the cache key, so the next
-     * boot rescans instead of serving the stale map.
+     * Test that changing a scanned file rotates the cache key, so the next boot
+     * rescans instead of serving the stale map.
      *
      * @return void
      */
@@ -424,10 +423,9 @@ final class ResourceDiscoveryTest extends TestCase
     }
 
     /**
-     * Test that every declared class in a multi-class, multi-namespace file
-     * is considered: both attributed resources bind, and a trailing
-     * unloadable class is skipped without disturbing the bindings already
-     * made.
+     * Test that every declared class in a multi-class, multi-namespace file is
+     * considered: both attributed resources bind, and a trailing unloadable
+     * class is skipped without disturbing the bindings already made.
      *
      * @return void
      */
@@ -566,8 +564,8 @@ final class ResourceDiscoveryTest extends TestCase
 
     /**
      * Test that the namespace name is read from the token that abuts the
-     * keyword: a non-name token sitting immediately after namespace resolves
-     * to no name rather than skipping ahead to a later identifier.
+     * keyword: a non-name token sitting immediately after namespace resolves to
+     * no name rather than skipping ahead to a later identifier.
      *
      * @return void
      */
@@ -576,9 +574,9 @@ final class ResourceDiscoveryTest extends TestCase
         $tokens = \PhpToken::tokenize('<?php namespace(Foo)');
         $method = new \ReflectionMethod(ResourceDiscovery::class, 'namespaceFromTokens');
 
-        // The keyword sits at index 1; the token at index 2 abuts it and is
-        // not a name token, so no namespace resolves. Beginning the scan a
-        // token later would wrongly read the identifier at index 3.
+        // The keyword sits at index 1; the token at index 2 abuts it and is not
+        // a name token, so no namespace resolves. Beginning the scan a token
+        // later would wrongly read the identifier at index 3.
         self::assertNull($method->invoke($this->discovery(), $tokens, 1));
     }
 
@@ -594,9 +592,9 @@ final class ResourceDiscoveryTest extends TestCase
         $tokens = \PhpToken::tokenize('<?php class(Foo)');
         $method = new \ReflectionMethod(ResourceDiscovery::class, 'declaredNameFromTokens');
 
-        // The keyword sits at index 1; the token at index 2 abuts it and is
-        // not a name token, so no declaration resolves. Beginning the scan a
-        // token later would wrongly read the identifier at index 3.
+        // The keyword sits at index 1; the token at index 2 abuts it and is not
+        // a name token, so no declaration resolves. Beginning the scan a token
+        // later would wrongly read the identifier at index 3.
         self::assertNull($method->invoke($this->discovery(), $tokens, 1, null));
     }
 

--- a/tests/Unit/OpenApi/Builder/ResourceSchemaBuilderTest.php
+++ b/tests/Unit/OpenApi/Builder/ResourceSchemaBuilderTest.php
@@ -73,8 +73,8 @@ final class ResourceSchemaBuilderTest extends TestCase
     }
 
     /**
-     * Test that a null field definition only skips its own key: later
-     * field keys in the same compiled schema are still emitted as properties.
+     * Test that a null field definition only skips its own key: later field
+     * keys in the same compiled schema are still emitted as properties.
      *
      * @return void
      */

--- a/tests/Unit/OpenApi/Metadata/ErrorCatalogueReaderTest.php
+++ b/tests/Unit/OpenApi/Metadata/ErrorCatalogueReaderTest.php
@@ -183,8 +183,8 @@ final class ErrorCatalogueReaderTest extends TestCase
     }
 
     /**
-     * Test that the exception map is memoised so a second read does not
-     * re-scan the filesystem.
+     * Test that the exception map is memoised so a second read does not re-scan
+     * the filesystem.
      *
      * @return void
      */
@@ -223,9 +223,9 @@ final class ErrorCatalogueReaderTest extends TestCase
     }
 
     /**
-     * Test that a discovered subclass declaring no CODE constant does not
-     * abort the scan: a later file is still processed and mapped, proving the
-     * CODE guard skips the offending file rather than stopping the loop.
+     * Test that a discovered subclass declaring no CODE constant does not abort
+     * the scan: a later file is still processed and mapped, proving the CODE
+     * guard skips the offending file rather than stopping the loop.
      *
      * @return void
      */

--- a/tests/Unit/Schema/Introspection/SchemaIntrospectorTest.php
+++ b/tests/Unit/Schema/Introspection/SchemaIntrospectorTest.php
@@ -1145,9 +1145,8 @@ final class SchemaIntrospectorTest extends TestCase
     }
 
     /**
-     * Test that a cached searchable set is served from the instance cache
-     * and is not recomputed when the exclusion configuration changes
-     * afterwards.
+     * Test that a cached searchable set is served from the instance cache and
+     * is not recomputed when the exclusion configuration changes afterwards.
      *
      * @return void
      */
@@ -1197,8 +1196,8 @@ final class SchemaIntrospectorTest extends TestCase
     }
 
     /**
-     * Test that parentKeysFor returns the parent local key for a
-     * MorphOneOrMany relation.
+     * Test that parentKeysFor returns the parent local key for a MorphOneOrMany
+     * relation.
      *
      * @return void
      */


### PR DESCRIPTION
Brings the codebase into conformance with coding-standards **v1.16.0**, whose `CommentLineLength` sniff enforces greedy 80-character wrapping of doc comments (fill each line to 80 before breaking).

Auto-fixed with phpcbf against the v1.16.0 standard: **96 comment lines across 42 files**, all genuine early-wraps. Comment-only changes - no behaviour change.

`ServiceRunner`'s `@phpstan-type ServiceHooks` block is intentionally left untouched: the earlier v1.15.0 rule reflowed it into invalid PHPDoc (a `phpDoc.parseError` that cascaded to `mixed` fallbacks), and v1.16.0 now correctly exempts structured type-annotation tags, so it no longer flags.

### Verification
- phpcs clean on all 42 files (and ServiceRunner) under v1.16.0
- phpstan unchanged from the clean-master baseline (zero reflow-induced errors, no parse errors)
- Full suite green (2208 tests), smells pass