### PR TITLE
ci: run the Feature suite against MySQL and Postgres

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
                     files: clover.xml
 
     # ==========================================================================
-    # JOB: INTEGRATION TESTS (MySQL + PostgreSQL)
+    # JOB: DATABASE-BACKED TESTS (Integration + Feature on MySQL + PostgreSQL)
     # ==========================================================================
     integration:
         name: Integration / ${{ matrix.database }}
@@ -132,7 +132,7 @@ jobs:
                     php-version: 8.3
                     extensions: pdo_mysql, pdo_pgsql
 
-            -   name: Run integration tests
+            -   name: Run database-backed tests (Integration + Feature)
                 env:
                     DB_DRIVER: ${{ matrix.db_driver }}
                     DB_HOST: 127.0.0.1
@@ -140,4 +140,4 @@ jobs:
                     DB_DATABASE: api_toolkit_test
                     DB_USERNAME: ${{ matrix.db_username }}
                     DB_PASSWORD: ${{ matrix.db_password }}
-                run: vendor/bin/phpunit --testsuite Integration
+                run: vendor/bin/phpunit --testsuite Integration,Feature


### PR DESCRIPTION
## What

The database matrix (`integration` job) only ran the **Integration** test suite, so the Feature/e2e tests were only ever exercised on the default in-memory **SQLite**. Anything genuinely engine-dependent never ran against a real engine in CI - most notably the `$contains` JSON-containment tests, which `markTestSkipped` on SQLite because its grammar rejects `whereJsonContains`.

This changes the matrix job to run `--testsuite Integration,Feature` so the full HTTP surface is validated on both MySQL and PostgreSQL. (Unit tests are engine-agnostic and stay in the main SQLite job.)

## Verification

Ran `vendor/bin/phpunit --testsuite Integration,Feature` locally against a real engine (MariaDB): **339 tests pass, zero skips** - the `$contains` tests execute there rather than skipping, which is exactly the gap this closes.

Only touches `.github/workflows/tests.yml` (3 lines).