### PR TITLE
feat(openapi): document exceptions from configured extra namespaces

### DIFF
--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -235,6 +235,16 @@ return [
             'namespaces' => DocumentableRouteFilter::DEFAULT_NAMESPACES,
         ],
 
+        // Additional PSR-4 namespace prefixes to scan for documentable
+        // ApiException subclasses, on top of the application and its modules
+        // (which are always scanned). The application scan deliberately skips
+        // vendor, so an installed ecosystem package's exceptions are not
+        // catalogued by default; list its root namespace here (e.g.
+        // 'SineMacula\Authentication\') to include its error codes. Every
+        // registered PSR-4 root at or below a listed prefix is scanned, and
+        // only ApiException subclasses declaring a CODE are documented.
+        'exception_namespaces' => [],
+
     ],
 
     /*

--- a/src/OpenApi/Metadata/ApiExceptionDiscoverer.php
+++ b/src/OpenApi/Metadata/ApiExceptionDiscoverer.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace SineMacula\ApiToolkit\OpenApi\Metadata;
 
+use Illuminate\Support\Facades\Config;
 use SineMacula\ApiToolkit\Exceptions\ApiException;
 
 /**
@@ -15,7 +16,10 @@ use SineMacula\ApiToolkit\Exceptions\ApiException;
  * is injected so the source can be driven from the registered Composer
  * autoloader in production and pointed at a controlled directory under test.
  * The shared root map excludes vendor and non-existent roots, restricting the
- * scan to the application, its modules, and any local path packages.
+ * scan to the application, its modules, and any local path packages. A caller
+ * may list extra namespace prefixes to scan in addition, matched against the
+ * full prefix map so an installed package's exceptions can be catalogued on
+ * request even though they resolve under vendor.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -26,12 +30,16 @@ final readonly class ApiExceptionDiscoverer
      * Create a new discoverer for the given PSR-4 roots.
      *
      * @param  array<string, array<int, string>>  $prefixes
+     * @param  array<int, string>  $extraNamespaces
      * @return void
      */
     public function __construct(
 
         /** PSR-4 namespace prefix to source directories to scan. */
         private array $prefixes,
+
+        /** Extra namespace prefixes to scan even when resolved under vendor. */
+        private array $extraNamespaces = [],
     ) {}
 
     /**
@@ -39,13 +47,17 @@ final readonly class ApiExceptionDiscoverer
      *
      * Locates the ClassLoader among the registered SPL autoloaders and reads
      * its public PSR-4 prefix map. Vendor directories are filtered at scan
-     * time, so the full prefix map is handed over untouched.
+     * time, so the full prefix map is handed over untouched, alongside the
+     * configured extra namespaces to also scan under vendor.
      *
      * @return self
      */
     public static function fromComposer(): self
     {
-        return new self(Psr4RootMap::fromComposer()->all());
+        $configured = Config::get('api-toolkit.openapi.exception_namespaces', []);
+        $namespaces = is_array($configured) ? array_filter($configured, 'is_string') : [];
+
+        return new self(Psr4RootMap::fromComposer()->all(), $namespaces);
     }
 
     /**
@@ -57,15 +69,70 @@ final readonly class ApiExceptionDiscoverer
     {
         $classes = [];
 
-        foreach ((new Psr4RootMap($this->prefixes))->roots() as $prefix => $dirs) {
-            foreach ($dirs as $dir) {
-                foreach ($this->scan($prefix, $dir) as $class) {
-                    $classes[] = $class;
-                }
+        foreach ($this->scanTargets() as [$prefix, $dir]) {
+            foreach ($this->scan($prefix, $dir) as $class) {
+                $classes[] = $class;
             }
         }
 
-        return $classes;
+        return array_values(array_unique($classes));
+    }
+
+    /**
+     * Resolve the prefix and directory pairs to scan: the non-vendor roots plus
+     * the directories of any configured extra namespace, which are included
+     * even when they resolve under vendor.
+     *
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function scanTargets(): array
+    {
+        $targets = [];
+
+        foreach ((new Psr4RootMap($this->prefixes))->roots() as $prefix => $dirs) {
+            foreach ($dirs as $dir) {
+                $targets[] = [$prefix, $dir];
+            }
+        }
+
+        foreach ($this->extraNamespaceTargets() as $target) {
+            $targets[] = $target;
+        }
+
+        return $targets;
+    }
+
+    /**
+     * Resolve the prefix and real-directory pairs for the configured extra
+     * namespaces, each looked up as a registered PSR-4 root in the full prefix
+     * map so a package installed under vendor is scanned when its root
+     * namespace is listed. The lookup key is normalised to a single trailing
+     * separator so a listed namespace matches with or without one. A class also
+     * reached by a non-vendor root is de-duplicated by discover().
+     *
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function extraNamespaceTargets(): array
+    {
+        $targets = [];
+
+        foreach ($this->extraNamespaces as $namespace) {
+
+            $prefix = rtrim($namespace, '\\') . '\\';
+
+            foreach ($this->prefixes[$prefix] ?? [] as $dir) {
+
+                $real = realpath($dir);
+
+                if ($real === false) {
+                    continue;
+                }
+
+                $targets[] = [$prefix, $real];
+            }
+        }
+
+        return $targets;
     }
 
     /**

--- a/tests/Unit/OpenApi/Metadata/ApiExceptionDiscovererTest.php
+++ b/tests/Unit/OpenApi/Metadata/ApiExceptionDiscovererTest.php
@@ -154,6 +154,94 @@ final class ApiExceptionDiscovererTest extends TestCase
     }
 
     /**
+     * Test that a namespace listed as extra is scanned even when it resolves
+     * under vendor, so an installed package's exceptions can be catalogued.
+     *
+     * @return void
+     */
+    public function testExtraNamespaceIncludesAVendorRoot(): void
+    {
+        $base   = sys_get_temp_dir() . '/api-toolkit-extra-' . uniqid('', true);
+        $vendor = $base . '/vendor/pkg';
+
+        mkdir($vendor, 0777, true);
+
+        // The stub derives the real, already-autoloadable exception FQCN, so
+        // only the vendor exclusion decides whether it is discovered.
+        file_put_contents($vendor . '/WidgetFailureException.php', "<?php\n");
+
+        $prefixes = ['Tests\Fixtures\Exceptions\\' => [$vendor]];
+
+        try {
+
+            self::assertNotContains(
+                WidgetFailureException::class,
+                (new ApiExceptionDiscoverer($prefixes))->discover(),
+            );
+
+            self::assertContains(
+                WidgetFailureException::class,
+                (new ApiExceptionDiscoverer($prefixes, ['Tests\Fixtures\Exceptions\\']))->discover(),
+            );
+
+        } finally {
+            unlink($vendor . '/WidgetFailureException.php');
+            rmdir($vendor);
+            rmdir($base . '/vendor');
+            rmdir($base);
+        }
+    }
+
+    /**
+     * Test that a class reached by both a non-vendor root and a matching extra
+     * namespace is reported once, not duplicated.
+     *
+     * @return void
+     */
+    public function testExtraNamespaceDoesNotDuplicateANonVendorRoot(): void
+    {
+        $prefixes = ['Tests\Fixtures\Exceptions\\' => [$this->fixtureExceptionsDirectory()]];
+
+        $discovered = (new ApiExceptionDiscoverer($prefixes, ['Tests\Fixtures\Exceptions\\']))->discover();
+
+        self::assertCount(1, array_keys($discovered, WidgetFailureException::class, true));
+    }
+
+    /**
+     * Test that fromComposer reads the configured extra namespaces, filters out
+     * non-string entries, and tolerates a non-array configuration value.
+     *
+     * @return void
+     */
+    public function testFromComposerReadsConfiguredExtraNamespaces(): void
+    {
+        // A mixed list: the non-string entry is filtered out rather than fatal.
+        config()->set('api-toolkit.openapi.exception_namespaces', ['SineMacula\ApiToolkit\\', 123]);
+
+        self::assertContains(NotFoundException::class, ApiExceptionDiscoverer::fromComposer()->discover());
+
+        // A non-array configuration is tolerated as no extra namespaces.
+        config()->set('api-toolkit.openapi.exception_namespaces', 'not-an-array');
+
+        self::assertContains(NotFoundException::class, ApiExceptionDiscoverer::fromComposer()->discover());
+    }
+
+    /**
+     * Test that an extra namespace that matches no registered PSR-4 root scans
+     * nothing extra, leaving the baseline discovery unaffected.
+     *
+     * @return void
+     */
+    public function testUnregisteredExtraNamespaceIsIgnored(): void
+    {
+        $prefixes = ['Tests\Fixtures\Exceptions\\' => [$this->fixtureExceptionsDirectory()]];
+
+        $discovered = (new ApiExceptionDiscoverer($prefixes, ['Unregistered\Package\\']))->discover();
+
+        self::assertContains(WidgetFailureException::class, $discovered);
+    }
+
+    /**
      * Resolve the directory holding the fixture exceptions.
      *
      * @return string


### PR DESCRIPTION
The first slice of the deferred "contributor seam": let the error catalogue include an ecosystem package's `ApiException`s.

## Why

The exporter's exception scan covers the application and its modules but deliberately skips `vendor/`, so `ApiException`s shipped by an installed package (e.g. an auth/IAM package) never appear in the catalogue. Their error codes were therefore undocumentable without the app redeclaring them.

## What

- New config `openapi.exception_namespaces` (default `[]`): a list of PSR-4 namespace prefixes to additionally scan for `ApiException` subclasses.
- Each listed namespace is looked up as a registered PSR-4 root in the Composer prefix map and scanned **even under vendor**; only subclasses declaring a `CODE` are documented. The key is normalised so a namespace matches with or without a trailing separator; non-string entries and a non-array config value are tolerated.
- Empty by default, so **no behaviour change** out of the box - the application and its modules are always scanned regardless.

## Verification

Full suite green (2708); `qlty check` clean; mutation MSI 91% (>= 90) on the diff.

Scoped deliberately: this is the exceptions half of the contributor seam. The security-scheme and doc-section contribution points remain deferred until a real consumer needs them.